### PR TITLE
Remove test suites from Makefile to fix cron test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ test:
 	python -m unittest -v
 
 test1:
-	python -m unittest -v test/ibm/test_ibm_backend.py test/ibm/test_account_client.py test/ibm/test_ibm_job_states.py test/ibm/test_tutorials.py test/ibm/test_basic_server_paths.py test/ibm/test_proxies.py test/ibm/test_ibm_integration.py test/ibm/test_ibm_logger.py test/ibm/test_filter_backends.py test/ibm/test_registration.py
+	python -m unittest -v test/ibm/test_ibm_backend.py test/ibm/test_account_client.py test/ibm/test_tutorials.py test/ibm/test_basic_server_paths.py test/ibm/test_proxies.py test/ibm/test_ibm_logger.py test/ibm/test_filter_backends.py test/ibm/test_registration.py
 
 test2:
-	python -m unittest -v test/ibm/test_ibm_qasm_simulator.py test/ibm/test_serialization.py test/ibm/test_jupyter.py test/ibm/test_ibm_provider.py
+	python -m unittest -v test/ibm/test_serialization.py test/ibm/test_jupyter.py test/ibm/test_ibm_provider.py
 
 test3:
-	python -m unittest -v test/ibm/test_ibm_job_attributes.py test/ibm/test_ibm_job.py test/ibm/websocket/test_websocket.py test/ibm/websocket/test_websocket_integration.py
+	python -m unittest -v test/ibm/test_ibm_job_attributes.py test/ibm/test_ibm_job.py
 
 runtime_integration:
 	python -m unittest -v test/ibm/runtime/test_runtime_integration.py


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Some test suites were removed after porting from qiskit-ibm. In this PR they are removed from Makefile as well so that the Cron-test can run fine.


### Details and comments
Fixes #

