### PR TITLE
Add support for viewing backends available on IBM Cloud

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -13,7 +13,7 @@
 """Client for accessing IBM Quantum runtime service."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from qiskit_ibm_runtime.credentials import Credentials
 from qiskit_ibm_runtime.api.session import RetrySession
@@ -278,3 +278,60 @@ class RuntimeClient:
     def logout(self) -> None:
         """Clear authorization cache."""
         self.api.logout()
+
+    # IBM Cloud only functions
+
+    def list_backends(self, timeout: Optional[float] = None) -> List[Dict[str, Any]]:
+        """Return IBM Cloud backends available for this service instance.
+
+        Args:
+            timeout: Number of seconds to wait for the request.
+
+        Returns:
+            IBM Cloud backends available for this service instance.
+        """
+        return self.api.backends(timeout=timeout)
+
+    def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
+        """Return the configuration of the IBM Cloud backend.
+
+        Args:
+            backend_name: The name of the IBM Cloud backend.
+
+        Returns:
+            Backend configuration.
+        """
+        return self.api.backend(backend_name).configuration()
+
+    def backend_status(self, backend_name: str) -> Dict[str, Any]:
+        """Return the status of the IBM Cloud backend.
+
+        Args:
+            backend_name: The name of the IBM Cloud backend.
+
+        Returns:
+            Backend status.
+        """
+        return self.api.backend(backend_name).status()
+
+    def backend_properties(self, backend_name: str) -> Dict[str, Any]:
+        """Return the properties of the IBM Cloud backend.
+
+        Args:
+            backend_name: The name of the IBM Cloud backend.
+
+        Returns:
+            Backend properties.
+        """
+        return self.api.backend(backend_name).properties()
+
+    def backend_pulse_defaults(self, backend_name: str) -> Dict:
+        """Return the pulse defaults of the IBM Cloud backend.
+
+        Args:
+            backend_name: The name of the IBM Cloud backend.
+
+        Returns:
+            Backend pulse defaults.
+        """
+        return self.api.backend(backend_name).pulse_defaults()

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -281,13 +281,13 @@ class RuntimeClient:
 
     # IBM Cloud only functions
 
-    def list_backends(self) -> List[Dict[str, Any]]:
+    def list_backends(self) -> List[str]:
         """Return IBM Cloud backends available for this service instance.
 
         Returns:
             IBM Cloud backends available for this service instance.
         """
-        return self.api.backends()
+        return self.api.backends()["devices"]
 
     def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
         """Return the configuration of the IBM Cloud backend.

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -281,16 +281,13 @@ class RuntimeClient:
 
     # IBM Cloud only functions
 
-    def list_backends(self, timeout: Optional[float] = None) -> List[Dict[str, Any]]:
+    def list_backends(self) -> List[Dict[str, Any]]:
         """Return IBM Cloud backends available for this service instance.
-
-        Args:
-            timeout: Number of seconds to wait for the request.
 
         Returns:
             IBM Cloud backends available for this service instance.
         """
-        return self.api.backends(timeout=timeout)
+        return self.api.backends()
 
     def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
         """Return the configuration of the IBM Cloud backend.

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -204,7 +204,7 @@ class Runtime(RestAdapterBase):
         """
         return CloudBackend(self.session, backend_name)
 
-    def backends(self, timeout: Optional[float] = None) -> List[Dict[str, Any]]:
+    def backends(self, timeout: Optional[float] = None) -> Dict[str, List[str]]:
         """Return a list of IBM Cloud backends.
 
         Args:

--- a/qiskit_ibm_runtime/hub_group_project.py
+++ b/qiskit_ibm_runtime/hub_group_project.py
@@ -120,7 +120,7 @@ class HubGroupProject:
                     configuration=config,
                     service=self._service,
                     credentials=self.credentials,
-                    api_client=self._api_client,
+                    account_client=self._api_client,
                 )
             except Exception:  # pylint: disable=broad-except
                 logger.warning(

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -69,7 +69,8 @@ class IBMBackend(Backend):
         configuration: Union[QasmBackendConfiguration, PulseBackendConfiguration],
         service: "ibm_runtime_service.IBMRuntimeService",
         credentials: Credentials,
-        api_client: Union[AccountClient, RuntimeClient],
+        account_client: Optional[AccountClient] = None,
+        runtime_client: Optional[RuntimeClient] = None,
     ) -> None:
         """IBMBackend constructor.
 
@@ -81,7 +82,8 @@ class IBMBackend(Backend):
         """
         super().__init__(provider=service, configuration=configuration)
 
-        self._api_client = api_client
+        self._account_client = account_client
+        self._runtime_client = runtime_client
         self._credentials = credentials
         self.hub = credentials.hub
         self.group = credentials.group
@@ -150,9 +152,12 @@ class IBMBackend(Backend):
             datetime = local_to_utc(datetime)
 
         if datetime or refresh or self._properties is None:
-            api_properties = self._api_client.backend_properties(
-                self.name(), datetime=datetime  # type: ignore
-            )
+            if self._account_client:
+                api_properties = self._account_client.backend_properties(
+                    self.name(), datetime=datetime
+                )
+            elif self._runtime_client:
+                api_properties = self._runtime_client.backend_properties(self.name())
             if not api_properties:
                 return None
             decode_backend_properties(api_properties)
@@ -177,7 +182,10 @@ class IBMBackend(Backend):
         Raises:
             IBMBackendApiProtocolError: If the status for the backend cannot be formatted properly.
         """
-        api_status = self._api_client.backend_status(self.name())
+        if self._account_client:
+            api_status = self._account_client.backend_status(self.name())
+        elif self._runtime_client:
+            api_status = self._runtime_client.backend_status(self.name())
 
         try:
             return BackendStatus.from_dict(api_status)
@@ -202,7 +210,10 @@ class IBMBackend(Backend):
             The backend pulse defaults or ``None`` if the backend does not support pulse.
         """
         if refresh or self._defaults is None:
-            api_defaults = self._api_client.backend_pulse_defaults(self.name())
+            if self._account_client:
+                api_defaults = self._api_client.backend_pulse_defaults(self.name())
+            elif self._runtime_client:
+                api_defaults = self._runtime_client.backend_pulse_defaults(self.name())
             if api_defaults:
                 decode_pulse_defaults(api_defaults)
                 self._defaults = PulseDefaults.from_dict(api_defaults)
@@ -233,7 +244,7 @@ class IBMBackend(Backend):
         """
         start_datetime = local_to_utc(start_datetime) if start_datetime else None
         end_datetime = local_to_utc(end_datetime) if end_datetime else None
-        raw_response = self._api_client.backend_reservations(  # type: ignore
+        raw_response = self._account_client.backend_reservations(
             self.name(), start_datetime, end_datetime
         )
         return convert_reservation_data(raw_response, self.name())

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -31,7 +31,7 @@ from qiskit.providers.models import QasmBackendConfiguration, PulseBackendConfig
 # pylint: disable=unused-import, cyclic-import
 from qiskit_ibm_runtime import ibm_runtime_service
 
-from .api.clients import AccountClient
+from .api.clients import AccountClient, RuntimeClient
 from .backendreservation import BackendReservation
 from .credentials import Credentials
 from .exceptions import IBMBackendApiProtocolError
@@ -69,7 +69,7 @@ class IBMBackend(Backend):
         configuration: Union[QasmBackendConfiguration, PulseBackendConfiguration],
         service: "ibm_runtime_service.IBMRuntimeService",
         credentials: Credentials,
-        api_client: AccountClient,
+        api_client: Union[AccountClient, RuntimeClient],
     ) -> None:
         """IBMBackend constructor.
 
@@ -151,7 +151,7 @@ class IBMBackend(Backend):
 
         if datetime or refresh or self._properties is None:
             api_properties = self._api_client.backend_properties(
-                self.name(), datetime=datetime
+                self.name(), datetime=datetime  # type: ignore
             )
             if not api_properties:
                 return None
@@ -233,7 +233,7 @@ class IBMBackend(Backend):
         """
         start_datetime = local_to_utc(start_datetime) if start_datetime else None
         end_datetime = local_to_utc(end_datetime) if end_datetime else None
-        raw_response = self._api_client.backend_reservations(
+        raw_response = self._api_client.backend_reservations(  # type: ignore
             self.name(), start_datetime, end_datetime
         )
         return convert_reservation_data(raw_response, self.name())

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -26,6 +26,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.providers.backend import BackendV1 as Backend
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
+from qiskit.providers.models import PulseBackendConfiguration, QasmBackendConfiguration
 from qiskit.transpiler import Layout
 from typing_extensions import Literal
 
@@ -61,7 +62,7 @@ from .runner_result import RunnerResult
 from .runtime_job import RuntimeJob
 from .runtime_program import RuntimeProgram, ParameterNamespace
 from .utils import RuntimeDecoder, to_base64_string, to_python_identifier
-from .utils.backend import convert_reservation_data
+from .utils.backend import convert_reservation_data, decode_backend_configuration
 
 logger = logging.getLogger(__name__)
 
@@ -158,34 +159,32 @@ class IBMRuntimeService:
             IBMProviderCredentialsInvalidToken: If the `token` is not a valid IBM Quantum token.
         """
         super().__init__()
-
-        account_credentials, account_preferences = self._resolve_credentials(
+        self.account_credentials, account_preferences = self._resolve_credentials(
             token=token, locator=locator, **kwargs
         )
-
-        if auth == "cloud":
-            self._api_client = RuntimeClient(credentials=account_credentials)
-            self._programs: Dict[str, RuntimeProgram] = {}
-            return
-
-        self._initialize_hgps(
-            credentials=account_credentials, preferences=account_preferences
-        )
+        self._programs: Dict[str, RuntimeProgram] = {}
         self._backends: Dict[str, "ibm_backend.IBMBackend"] = {}
-        self._api_client = None
-        hgps = self._get_hgps()
-        for hgp in hgps:
-            for name, backend in hgp.backends.items():
-                if name not in self._backends:
-                    self._backends[name] = backend
-            if not self._api_client and hgp.has_service("runtime"):
-                self._default_hgp = hgp
-                self._api_client = RuntimeClient(self._default_hgp.credentials)
-                self._access_token = self._default_hgp.credentials.access_token
-                self._ws_url = self._default_hgp.credentials.runtime_url.replace(
-                    "https", "wss"
-                )
-                self._programs = {}
+        if auth == "cloud":
+            self._api_client = RuntimeClient(credentials=self.account_credentials)
+            self._backends = self._discover_remote_backends()
+        else:
+            self._initialize_hgps(
+                credentials=self.account_credentials, preferences=account_preferences
+            )
+            self._api_client = None
+            hgps = self._get_hgps()
+            for hgp in hgps:
+                for name, backend in hgp.backends.items():
+                    if name not in self._backends:
+                        self._backends[name] = backend
+                if not self._api_client and hgp.has_service("runtime"):
+                    self._default_hgp = hgp
+                    self._api_client = RuntimeClient(self._default_hgp.credentials)
+                    self._access_token = self._default_hgp.credentials.access_token
+                    self._ws_url = self._default_hgp.credentials.runtime_url.replace(
+                        "https", "wss"
+                    )
+                    self._programs = {}
         self._discover_backends()
 
     def _resolve_credentials(
@@ -248,6 +247,58 @@ class IBMRuntimeService:
                 )
             account_credentials = credentials_list[0]
         return account_credentials, preferences
+
+    def _discover_remote_backends(
+        self, timeout: Optional[float] = None
+    ) -> Dict[str, "ibm_backend.IBMBackend"]:
+        """Return the remote backends available for this service instance.
+
+        Args:
+            timeout: Maximum number of seconds to wait for the discovery of
+                remote backends.
+
+        Returns:
+            A dict of the remote backend instances, keyed by backend name.
+        """
+        ret = OrderedDict()  # type: ignore[var-annotated]
+        backends_list = self._api_client.list_backends(timeout=timeout)
+        for backend_name in backends_list:
+            raw_config = self._api_client.backend_configuration(
+                backend_name=backend_name
+            )
+            # Make sure the raw_config is of proper type
+            if not isinstance(raw_config, dict):
+                logger.warning(
+                    "An error occurred when retrieving backend "
+                    "information. Some backends might not be available."
+                )
+                continue
+            try:
+                decode_backend_configuration(raw_config)
+                try:
+                    config = PulseBackendConfiguration.from_dict(raw_config)
+                except (KeyError, TypeError):
+                    config = QasmBackendConfiguration.from_dict(raw_config)
+                backend_cls = (
+                    ibm_backend.IBMSimulator
+                    if config.simulator
+                    else ibm_backend.IBMBackend
+                )
+                ret[config.backend_name] = backend_cls(
+                    configuration=config,
+                    service=self,
+                    credentials=self.account_credentials,
+                    api_client=self._api_client,
+                )
+            except Exception:  # pylint: disable=broad-except
+                logger.warning(
+                    'Remote backend "%s" for service instance %s could not be instantiated due to an '
+                    "invalid config: %s",
+                    raw_config.get("backend_name", raw_config.get("name", "unknown")),
+                    repr(self),
+                    traceback.format_exc(),
+                )
+        return ret
 
     def _initialize_hgps(
         self, credentials: Credentials, preferences: Optional[Dict] = None

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -248,20 +248,14 @@ class IBMRuntimeService:
             account_credentials = credentials_list[0]
         return account_credentials, preferences
 
-    def _discover_remote_backends(
-        self, timeout: Optional[float] = None
-    ) -> Dict[str, "ibm_backend.IBMBackend"]:
+    def _discover_remote_backends(self) -> Dict[str, "ibm_backend.IBMBackend"]:
         """Return the remote backends available for this service instance.
-
-        Args:
-            timeout: Maximum number of seconds to wait for the discovery of
-                remote backends.
 
         Returns:
             A dict of the remote backend instances, keyed by backend name.
         """
         ret = OrderedDict()  # type: ignore[var-annotated]
-        backends_list = self._api_client.list_backends(timeout=timeout)
+        backends_list = self._api_client.list_backends()
         for backend_name in backends_list:
             raw_config = self._api_client.backend_configuration(
                 backend_name=backend_name
@@ -288,7 +282,7 @@ class IBMRuntimeService:
                     configuration=config,
                     service=self,
                     credentials=self.account_credentials,
-                    api_client=self._api_client,
+                    runtime_client=self._api_client,
                 )
             except Exception:  # pylint: disable=broad-except
                 logger.warning(


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR builds upon https://github.com/Qiskit/qiskit-ibm-runtime/pull/55 (will rebase this once #55 is merged) to make the following functionality available to IBM Cloud users. (Currently works only with staging env)

- backends()
- get_backend()
- backend.status()
- backend.properties()
- backend.defaults()
- backend.configuration()

Example:
```python
from qiskit_ibm_runtime import IBMRuntimeService
service = IBMRuntimeService(auth="cloud", token="<staging_api_key>", locator="<staging_locator>")

# List backends
service.backends()

# Get a backend by name
simulator = service.get_backend("ibmq_qasm_simulator")

# Get a backend's status
simulator.status()

# Get a backend's properties
simulator.properties()

# Get a backend's configuration
simulator.configuration()

# Get a backend's pulse defaults
simulator.defaults()
```

### Details and comments
Fixes #

