### PR TITLE
Fix JSON decoding of Parameters in Terra 0.19.1

### DIFF
--- a/releasenotes/notes/fix-qpy-v3-serialisation-20ddba46e7c6ba09.yaml
+++ b/releasenotes/notes/fix-qpy-v3-serialisation-20ddba46e7c6ba09.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue with JSON encoding and decoding when using
+    ``ParameterExpression``\ s in conjunction with Qiskit Terra 0.19.1 and
+    above.  Previously, the ``Parameter`` instances reconstructed from the JSON
+    output would have different unique identifiers, causing them to seem unequal
+    to the input.  They will now have the correct backing identities.


### PR DESCRIPTION
### Summary

Terra 0.19.1 included a new version of the QPY format, which affects how
`ParameterExpression` objects are read.  This requires us to detect the
version of Terra in use, and use the correct internal QPY reader for the
format version.

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #59 

