### PR TITLE
Use only backends in specified instance

### DIFF
--- a/test/utils/decorators.py
+++ b/test/utils/decorators.py
@@ -170,13 +170,18 @@ def requires_cloud_legacy_devices(func):
 
     @wraps(func)
     def _wrapper(obj, *args, **kwargs):
-        legacy = _get_service("legacy")
-        cloud = _get_service("cloud")
-        legacy_backend = legacy.least_busy(simulator=False, min_num_qubits=5)
-        # TODO use real device when cloud supports it
-        cloud_backend = cloud.least_busy(min_num_qubits=5)
 
-        kwargs.update({"devices": [cloud_backend, legacy_backend]})
+        devices = []
+        token, url, instance = _get_token_url_instance("cloud")
+        service = IBMRuntimeService(auth="cloud", token=token, url=url, instance=instance)
+        # TODO use real device when cloud supports it
+        devices.append(service.least_busy(min_num_qubits=5))
+
+        token, url, instance = _get_token_url_instance("legacy")
+        service = IBMRuntimeService(auth="legacy", token=token, url=url, instance=instance)
+        devices.append(service.least_busy(simulator=False, min_num_qubits=5, instance=instance))
+
+        kwargs.update({"devices": devices})
         return func(obj, *args, **kwargs)
 
     return _wrapper

--- a/test/utils/decorators.py
+++ b/test/utils/decorators.py
@@ -173,13 +173,19 @@ def requires_cloud_legacy_devices(func):
 
         devices = []
         token, url, instance = _get_token_url_instance("cloud")
-        service = IBMRuntimeService(auth="cloud", token=token, url=url, instance=instance)
+        service = IBMRuntimeService(
+            auth="cloud", token=token, url=url, instance=instance
+        )
         # TODO use real device when cloud supports it
         devices.append(service.least_busy(min_num_qubits=5))
 
         token, url, instance = _get_token_url_instance("legacy")
-        service = IBMRuntimeService(auth="legacy", token=token, url=url, instance=instance)
-        devices.append(service.least_busy(simulator=False, min_num_qubits=5, instance=instance))
+        service = IBMRuntimeService(
+            auth="legacy", token=token, url=url, instance=instance
+        )
+        devices.append(
+            service.least_busy(simulator=False, min_num_qubits=5, instance=instance)
+        )
 
         kwargs.update({"devices": devices})
         return func(obj, *args, **kwargs)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`TestIBMBackend` has been failing because `ibmq_berlin` status could not be retrieved. While this appears to be a server-side issue, the tests probably should use only devices within the specified h/g/p. 

### Details and comments
Fixes #

