### PR TITLE
Finalize account management functionality

### DIFF
--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -120,3 +120,17 @@ class Account:
             return CloudAuth(api_key=self.token, crn=self.instance)
 
         return LegacyAuth(access_token=self.token)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Account):
+            return False
+        return all(
+            [
+                self.auth == other.auth,
+                self.token == other.token,
+                self.url == other.url,
+                self.instance == other.instance,
+                self.proxies == other.proxies,
+                self.verify == other.verify,
+            ]
+        )

--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -68,7 +68,7 @@ class Account:
         self,
         auth: AccountType,
         token: str,
-        url: Optional[str],
+        url: Optional[str] = None,
         instance: Optional[str] = None,
         # TODO: add validation for proxies input format
         proxies: Optional[dict] = None,

--- a/qiskit_ibm_runtime/accounts/management.py
+++ b/qiskit_ibm_runtime/accounts/management.py
@@ -13,7 +13,7 @@
 """Account management related classes and functions."""
 
 import os
-from typing import Optional
+from typing import Optional, Dict
 
 from .account import Account, AccountType
 from .storage import save_config, read_config, delete_config
@@ -63,16 +63,16 @@ class AccountManager:
         default: Optional[bool] = None,
         auth: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> dict[str, Account]:
+    ) -> Dict[str, Account]:
         """List all accounts saved on disk."""
 
-        def _matching_name(account_name: str):
+        def _matching_name(account_name: str) -> bool:
             return name is None or name == account_name
 
-        def _matching_auth(account: Account):
+        def _matching_auth(account: Account) -> bool:
             return auth is None or account.auth == auth
 
-        def _matching_default(account_name: str):
+        def _matching_default(account_name: str) -> bool:
             default_accounts = [
                 _DEFAULT_ACCOUNT_NAME,
                 _DEFAULT_ACCOUNT_NAME_LEGACY,
@@ -180,7 +180,7 @@ class AccountManager:
     @classmethod
     def _get_default_account_name(cls, auth: AccountType) -> str:
         return (
-            _DEFAULT_ACCOUNT_NAME_CLOUD
-            if auth == "cloud"
-            else _DEFAULT_ACCOUNT_NAME_LEGACY
+            _DEFAULT_ACCOUNT_NAME_LEGACY
+            if auth == "legacy"
+            else _DEFAULT_ACCOUNT_NAME_CLOUD
         )

--- a/qiskit_ibm_runtime/accounts/management.py
+++ b/qiskit_ibm_runtime/accounts/management.py
@@ -18,7 +18,7 @@ from typing import Optional, Dict
 from .account import Account, AccountType
 from .storage import save_config, read_config, delete_config
 
-_DEFAULT_ACCOUNG_CONFIG_JSON_FILE = os.path.join(
+_DEFAULT_ACCOUNT_CONFIG_JSON_FILE = os.path.join(
     os.path.expanduser("~"), ".qiskit", "qiskit-ibm.json"
 )
 _DEFAULT_ACCOUNT_NAME = "default"
@@ -46,7 +46,7 @@ class AccountManager:
 
         config_key = name or cls._get_default_account_name(auth)
         return save_config(
-            filename=_DEFAULT_ACCOUNG_CONFIG_JSON_FILE,
+            filename=_DEFAULT_ACCOUNT_CONFIG_JSON_FILE,
             name=config_key,
             config=Account(
                 token=token,
@@ -88,7 +88,7 @@ class AccountManager:
         # load all accounts
         all_accounts = map(
             lambda kv: (kv[0], Account.from_saved_format(kv[1])),
-            read_config(filename=_DEFAULT_ACCOUNG_CONFIG_JSON_FILE).items(),
+            read_config(filename=_DEFAULT_ACCOUNT_CONFIG_JSON_FILE).items(),
         )
 
         # filter based on input parameters
@@ -123,7 +123,7 @@ class AccountManager:
         """
         if name:
             saved_account = read_config(
-                filename=_DEFAULT_ACCOUNG_CONFIG_JSON_FILE, name=name
+                filename=_DEFAULT_ACCOUNT_CONFIG_JSON_FILE, name=name
             )
             if not saved_account:
                 raise ValueError(
@@ -138,14 +138,14 @@ class AccountManager:
 
         if auth:
             saved_account = read_config(
-                filename=_DEFAULT_ACCOUNG_CONFIG_JSON_FILE,
+                filename=_DEFAULT_ACCOUNT_CONFIG_JSON_FILE,
                 name=cls._get_default_account_name(auth),
             )
             if saved_account is None:
                 raise ValueError(f"No default {auth} account saved.")
             return Account.from_saved_format(saved_account)
 
-        all_config = read_config(filename=_DEFAULT_ACCOUNG_CONFIG_JSON_FILE)
+        all_config = read_config(filename=_DEFAULT_ACCOUNT_CONFIG_JSON_FILE)
         for account_type in _ACCOUNT_TYPES:
             account_name = cls._get_default_account_name(account_type)
             if account_name in all_config:
@@ -163,7 +163,7 @@ class AccountManager:
 
         config_key = name or cls._get_default_account_name(auth)
         return delete_config(
-            name=config_key, filename=_DEFAULT_ACCOUNG_CONFIG_JSON_FILE
+            name=config_key, filename=_DEFAULT_ACCOUNT_CONFIG_JSON_FILE
         )
 
     @classmethod

--- a/qiskit_ibm_runtime/accounts/storage.py
+++ b/qiskit_ibm_runtime/accounts/storage.py
@@ -13,8 +13,11 @@
 """Utility functions related to storing account configuration on disk."""
 
 import json
+import logging
 import os
 from typing import Optional, Dict
+
+logger = logging.getLogger(__name__)
 
 
 def save_config(
@@ -23,7 +26,7 @@ def save_config(
     config: dict,
 ) -> None:
     """Save configuration data in a JSON file under the given name."""
-
+    logger.debug(f"Save configuration data for '{name}' in '{filename}'")
     _ensure_file_exists(filename)
 
     with open(filename, mode="r") as json_in:
@@ -39,7 +42,7 @@ def read_config(
     name: Optional[str] = None,
 ) -> Optional[Dict]:
     """Save configuration data from a JSON file."""
-
+    logger.debug(f"Read configuration data for '{name}' from '{filename}'")
     _ensure_file_exists(filename)
 
     with open(filename) as json_file:
@@ -58,6 +61,8 @@ def delete_config(
 ) -> bool:
     """Delete configuration data from a JSON file."""
 
+    logger.debug(f"Delete configuration data for '{name}' from '{filename}'")
+
     _ensure_file_exists(filename)
     with open(filename, mode="r") as json_in:
         data = json.load(json_in)
@@ -73,6 +78,7 @@ def delete_config(
 
 def _ensure_file_exists(filename: str, initial_content: str = "{}") -> None:
     if not os.path.isfile(filename):
+        logger.debug(f"Create empty configuration file at {filename}")
 
         # create parent directories
         os.makedirs(os.path.dirname(filename), exist_ok=True)

--- a/qiskit_ibm_runtime/accounts/storage.py
+++ b/qiskit_ibm_runtime/accounts/storage.py
@@ -41,7 +41,7 @@ def read_config(
     filename: str,
     name: Optional[str] = None,
 ) -> Optional[Dict]:
-    """Save configuration data from a JSON file."""
+    """Read configuration data from a JSON file."""
     logger.debug("Read configuration data for '%s' from '%s'", name, filename)
     _ensure_file_exists(filename)
 

--- a/qiskit_ibm_runtime/accounts/storage.py
+++ b/qiskit_ibm_runtime/accounts/storage.py
@@ -26,7 +26,7 @@ def save_config(
     config: dict,
 ) -> None:
     """Save configuration data in a JSON file under the given name."""
-    logger.debug(f"Save configuration data for '{name}' in '{filename}'")
+    logger.debug("Save configuration data for '%s' in '%s'", name, filename)
     _ensure_file_exists(filename)
 
     with open(filename, mode="r") as json_in:
@@ -42,7 +42,7 @@ def read_config(
     name: Optional[str] = None,
 ) -> Optional[Dict]:
     """Save configuration data from a JSON file."""
-    logger.debug(f"Read configuration data for '{name}' from '{filename}'")
+    logger.debug("Read configuration data for '%s' from '%s'", name, filename)
     _ensure_file_exists(filename)
 
     with open(filename) as json_file:
@@ -61,7 +61,7 @@ def delete_config(
 ) -> bool:
     """Delete configuration data from a JSON file."""
 
-    logger.debug(f"Delete configuration data for '{name}' from '{filename}'")
+    logger.debug("Delete configuration data for '%s' from '%s'", name, filename)
 
     _ensure_file_exists(filename)
     with open(filename, mode="r") as json_in:
@@ -78,7 +78,7 @@ def delete_config(
 
 def _ensure_file_exists(filename: str, initial_content: str = "{}") -> None:
     if not os.path.isfile(filename):
-        logger.debug(f"Create empty configuration file at {filename}")
+        logger.debug("Create empty configuration file at %s", filename)
 
         # create parent directories
         os.makedirs(os.path.dirname(filename), exist_ok=True)

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -517,18 +517,19 @@ class IBMRuntimeService:
         return self._account.to_saved_format()
 
     @staticmethod
-    def delete_account(name: Optional[str]) -> bool:
+    def delete_account(name: Optional[str] = None, auth: Optional[str] = None) -> bool:
         """Delete a saved account from disk.
 
         Args:
-            name: Custom name of the saved account. Defaults to "default".
+            name: Name of the saved account to delete.
+            auth: Authentication type of the default account to delete. Ignored if account name is provided.
 
         Returns:
-            True if the account with the given name was deleted.
-            False if no account was found for the given name.
+            True if the account was deleted.
+            False if no account was found.
         """
 
-        return AccountManager.delete(name=name)
+        return AccountManager.delete(name=name, auth=auth)
 
     @staticmethod
     def save_account(
@@ -565,8 +566,17 @@ class IBMRuntimeService:
         )
 
     @staticmethod
-    def saved_accounts() -> dict:
+    def saved_accounts(
+        default: Optional[bool] = None,
+        auth: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> dict:
         """List the accounts saved on disk.
+
+        Args:
+            default: If set to True, only default accounts are returned.
+            auth: If set, only accounts with the given authentication type are returned.
+            name: If set, only accounts with the given name are returned.
 
         Returns:
             A dictionary with information about the accounts saved on disk.
@@ -575,7 +585,13 @@ class IBMRuntimeService:
             IBMProviderCredentialsInvalidUrl: If invalid IBM Quantum
                 credentials are found on disk.
         """
-        return AccountManager.list()
+
+        return dict(
+            map(
+                lambda kv: (kv[0], Account.to_saved_format(kv[1])),
+                AccountManager.list(default=default, auth=auth, name=name).items(),
+            ),
+        )
 
     def get_backend(
         self,

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -522,7 +522,8 @@ class IBMRuntimeService:
 
         Args:
             name: Name of the saved account to delete.
-            auth: Authentication type of the default account to delete. Ignored if account name is provided.
+            auth: Authentication type of the default account to delete.
+                Ignored if account name is provided.
 
         Returns:
             True if the account was deleted.

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -45,7 +45,8 @@ _TEST_CLOUD_ACCOUNT = Account(
     instance="crn:v1:bluemix:public:quantum-computing:us-east:a/...::",
 )
 
-
+# NamedTemporaryFiles not supported in Windows
+@skipIf(os.name == "nt", "Test not supported in Windows")
 class TestAccountManager(IBMTestCase):
     """Tests for AccountManager class."""
 
@@ -173,7 +174,7 @@ class TestAccountManager(IBMTestCase):
         self.assertTrue(len(AccountManager.list()) == 0)
 
 
-# NamedTemporaryFiles not support in Windows
+# NamedTemporaryFiles not supported in Windows
 @skipIf(os.name == "nt", "Test not supported in Windows")
 class TestEnableAccount(IBMTestCase):
     """Tests for IBMRuntimeService enable account."""

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -47,8 +47,11 @@ _TEST_CLOUD_ACCOUNT = Account(
 
 
 class TestAccountManager(IBMTestCase):
+    """Tests for AccountManager class."""
+
     @temporary_account_config_file(contents={})
     def test_save_get(self):
+        """Test save and get."""
 
         # Each tuple contains the
         # - account to save
@@ -92,6 +95,8 @@ class TestAccountManager(IBMTestCase):
         )
     )
     def test_list(self):
+        """Test list."""
+
         with temporary_account_config_file(
             contents={
                 "key1": _TEST_CLOUD_ACCOUNT.to_saved_format(),
@@ -153,6 +158,8 @@ class TestAccountManager(IBMTestCase):
         }
     )
     def test_delete(self):
+        """Test delete."""
+
         with self.subTest("delete named account"):
             self.assertTrue(AccountManager.delete(name="key1"))
             self.assertFalse(AccountManager.delete(name="key1"))
@@ -163,7 +170,7 @@ class TestAccountManager(IBMTestCase):
         with self.subTest("delete default cloud account"):
             self.assertTrue(AccountManager.delete())
 
-        self.assertEquals(len(AccountManager.list()), 0)
+        self.assertTrue(len(AccountManager.list()) == 0)
 
 
 # NamedTemporaryFiles not support in Windows

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -32,10 +32,10 @@ from .utils.account import (
 )
 
 _TEST_LEGACY_ACCOUNT = Account(
-    "legacy",
-    "token-x",
-    "https://auth.quantum-computing.ibm.com/api",
-    "ibm-q/open/main",
+    auth="legacy",
+    token="token-x",
+    url="https://auth.quantum-computing.ibm.com/api",
+    instance="ibm-q/open/main",
 )
 
 _TEST_CLOUD_ACCOUNT = Account(

--- a/test/utils/account.py
+++ b/test/utils/account.py
@@ -12,8 +12,8 @@
 
 """Context managers for using with IBM Provider unit tests."""
 
-import os
 import json
+import os
 import uuid
 from contextlib import ContextDecorator
 from tempfile import NamedTemporaryFile
@@ -22,7 +22,6 @@ from unittest.mock import patch
 from qiskit_ibm_runtime.accounts import management
 from qiskit_ibm_runtime.accounts.account import CLOUD_API_URL, LEGACY_API_URL
 from qiskit_ibm_runtime.credentials.environ import VARIABLES_MAP
-
 
 CREDENTIAL_ENV_VARS = VARIABLES_MAP.keys()
 
@@ -102,35 +101,34 @@ class no_file(ContextDecorator):
         return self.isfile_original(filename_)
 
 
-class custom_qiskitrc(ContextDecorator):
+class temporary_account_config_file(ContextDecorator):
     """Context manager that uses a temporary qiskitrc."""
 
     # pylint: disable=invalid-name
 
     def __init__(self, contents=None, **kwargs):
         # Create a temporary file with the contents.
-        contents = contents or get_qiskitrc_contents(**kwargs)
+        contents = (
+            contents if contents is not None else get_account_config_contents(**kwargs)
+        )
+
         self.tmp_file = NamedTemporaryFile(mode="w+")
         json.dump(contents, self.tmp_file)
         self.tmp_file.flush()
-        self.default_qiskitrc_file_original = (
-            management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE
-        )
+        self.account_config_json_backup = management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE
 
     def __enter__(self):
-        # Temporarily modify the default location of the qiskitrc file.
+        # Temporarily modify the default location of the configuration file.
         management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE = self.tmp_file.name
         return self
 
     def __exit__(self, *exc):
         # Delete the temporary file and restore the default location.
         self.tmp_file.close()
-        management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE = (
-            self.default_qiskitrc_file_original
-        )
+        management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE = self.account_config_json_backup
 
 
-def get_qiskitrc_contents(
+def get_account_config_contents(
     name=None,
     auth="cloud",
     token=None,

--- a/test/utils/account.py
+++ b/test/utils/account.py
@@ -115,17 +115,17 @@ class temporary_account_config_file(ContextDecorator):
         self.tmp_file = NamedTemporaryFile(mode="w+")
         json.dump(contents, self.tmp_file)
         self.tmp_file.flush()
-        self.account_config_json_backup = management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE
+        self.account_config_json_backup = management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE
 
     def __enter__(self):
         # Temporarily modify the default location of the configuration file.
-        management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE = self.tmp_file.name
+        management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE = self.tmp_file.name
         return self
 
     def __exit__(self, *exc):
         # Delete the temporary file and restore the default location.
         self.tmp_file.close()
-        management._DEFAULT_ACCOUNG_CONFIG_JSON_FILE = self.account_config_json_backup
+        management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE = self.account_config_json_backup
 
 
 def get_account_config_contents(


### PR DESCRIPTION
### Summary
This PR includes the following

**Mainline**
- [X] allow to filter accounts returned from `service.saved_accounts` (by name, default, auth)
- [X] added log statements to account storage module
- [X] updated default account name resolution based on `auth` type

**Tests**
- [X] renamed `custom_qiskitrc` to `temporary_account_config_file`
- [X] renamed `get_qiskitrc_contents` to `get_account_config_contents`
- [X] added dedicated unit tests for `AccountManager` class

### Details and comments
Finalizes account management functionality by filling gaps to meet the acceptance criteria proposed via https://github.com/Qiskit/qiskit-ibm-runtime/pull/58.

