### PR TITLE
Don't use ibmq_berlin

### DIFF
--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -1125,7 +1125,7 @@ class IBMRuntimeService:
                 are included.
             program_id: Filter by Program ID.
             instance: The service instance to use. Currently only supported for legacy runtime,
-                and should be in the hub/group/project.
+                and should be in the hub/group/project format.
 
         Returns:
             A list of runtime jobs.
@@ -1265,6 +1265,22 @@ class IBMRuntimeService:
         **kwargs: Any,
     ) -> ibm_backend.IBMBackend:
         """Return the least busy available backend.
+
+        Args:
+            min_num_qubits: Minimum number of qubits the backend has to have.
+            instance: The service instance to use. For cloud runtime, this is the Cloud Resource
+                Name (CRN). For legacy runtime, this is the hub/group/project in that format.
+            filters: More complex filters, such as lambda functions.
+                For example::
+
+                    AccountProvider.backends(
+                        filters=lambda b: b.configuration().quantum_volume > 16)
+
+            kwargs: Simple filters that specify a ``True``/``False`` criteria in the
+                backend configuration, backends status, or provider credentials.
+                An example to get the operational backends with 5 qubits::
+
+                    IBMRuntimeService.least_busy(n_qubits=5, operational=True)
 
         Returns:
             The backend with the fewest number of pending jobs.

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -45,12 +45,14 @@ _TEST_CLOUD_ACCOUNT = Account(
     instance="crn:v1:bluemix:public:quantum-computing:us-east:a/...::",
 )
 
+
 # NamedTemporaryFiles not supported in Windows
 @skipIf(os.name == "nt", "Test not supported in Windows")
 class TestAccountManager(IBMTestCase):
     """Tests for AccountManager class."""
 
     @temporary_account_config_file(contents={})
+    @no_envs(["QISKIT_IBM_API_TOKEN"])
     def test_save_get(self):
         """Test save and get."""
 

--- a/test/test_integration_job.py
+++ b/test/test_integration_job.py
@@ -658,6 +658,8 @@ class TestIntegrationJob(IBMTestCase):
 
     def _get_real_device(self, service):
         try:
-            return service.least_busy(simulator=False).name()
+            # TODO: Remove filters when ibmq_berlin is removed
+            return service.least_busy(
+                simulator=False, filters=lambda b: b.name() != "ibmq_berlin").name()
         except QiskitBackendNotFoundError:
             raise unittest.SkipTest("No real device")  # cloud has no real device

--- a/test/test_integration_job.py
+++ b/test/test_integration_job.py
@@ -660,6 +660,7 @@ class TestIntegrationJob(IBMTestCase):
         try:
             # TODO: Remove filters when ibmq_berlin is removed
             return service.least_busy(
-                simulator=False, filters=lambda b: b.name() != "ibmq_berlin").name()
+                simulator=False, filters=lambda b: b.name() != "ibmq_berlin"
+            ).name()
         except QiskitBackendNotFoundError:
             raise unittest.SkipTest("No real device")  # cloud has no real device

--- a/test/test_proxies.py
+++ b/test/test_proxies.py
@@ -229,7 +229,6 @@ class TestProxies(IBMTestCase):
         test_urls = [
             "http://{}:{}".format(ADDRESS, PORT),
             "//{}:{}".format(ADDRESS, PORT),
-            "http:{}:{}".format(ADDRESS, PORT),
             "http://user:123@{}:{}".format(ADDRESS, PORT),
         ]
         for proxy_url in test_urls:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`ibmq_berlin` has been retired but continue to be reported by the server as a valid backend. This PR skips `ibmq_berlin`, so tests won't keep tripping over it until that's fixed. 


### Details and comments

Since I'm trying to get all tests to pass, this PR also
- closes https://github.com/Qiskit-Partners/qiskit-ibm/issues/226 ,  by deleting the malformed url from the test case. The `http:{}:{}` format was no longer supported in `requests` 2.26+, and I don't see why we need to support it especially since this is a new repo (sorry @daka1510, I know you were dying to fix this one lol)
-  fixes `test_save_get`
