### PR TITLE
Don't raise if cancel failed because job is done

### DIFF
--- a/test/test_integration_job.py
+++ b/test/test_integration_job.py
@@ -41,6 +41,7 @@ from .utils.serialization import (
     SerializableClassDecoder,
     SerializableClass,
 )
+from .utils.utils import cancel_job_safe
 from .mock.proxy_server import MockProxyServer, use_proxies
 
 
@@ -284,8 +285,8 @@ class TestIntegrationJob(IBMTestCase):
         _ = self._run_program(service, iterations=10, backend=real_device)
         job = self._run_program(service, iterations=2, backend=real_device)
         self._wait_for_status(job, JobStatus.QUEUED)
-        job.cancel()
-        self.assertEqual(job.status(), JobStatus.CANCELLED)
+        if not cancel_job_safe(job, self.log):
+            return
         time.sleep(10)  # Wait a bit for DB to update.
         rjob = service.job(job.job_id)
         self.assertEqual(rjob.status(), JobStatus.CANCELLED)
@@ -295,8 +296,8 @@ class TestIntegrationJob(IBMTestCase):
         """Test canceling a running job."""
         job = self._run_program(service, iterations=3)
         self._wait_for_status(job, JobStatus.RUNNING)
-        job.cancel()
-        self.assertEqual(job.status(), JobStatus.CANCELLED)
+        if not cancel_job_safe(job, self.log):
+            return
         time.sleep(10)  # Wait a bit for DB to update.
         rjob = service.job(job.job_id)
         self.assertEqual(rjob.status(), JobStatus.CANCELLED)
@@ -462,13 +463,8 @@ class TestIntegrationJob(IBMTestCase):
                     callback=result_callback,
                 )
                 self._wait_for_status(job, status)
-                try:
-                    job.cancel()
-                except RuntimeInvalidStateError:
-                    if job.status == JobStatus.DONE:
-                        self.log.warning("Unable to cancel job because it's already done.")
-                        return
-                    raise
+                if not cancel_job_safe(job, self.log):
+                    return
                 time.sleep(3)  # Wait for cleanup
                 self.assertIsNotNone(job._ws_client._server_close_code)
                 self.assertLess(final_it, iterations)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Test cases that cancel a running job can [fail](https://github.com/Qiskit/qiskit-ibm-runtime/runs/4739824168?check_suite_focus=true#step:5:2651) if the job has already finished. This PR adds a utility function that logs a warning and exits the test case if the cancel failed due to job already finished. 


### Details and comments
Fixes #

