### PR TITLE
Separating slow test terra main

### DIFF
--- a/.github/workflows/cron-slow-terra-main.yml
+++ b/.github/workflows/cron-slow-terra-main.yml
@@ -10,13 +10,13 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-name: Slow-test
+name: Slow-test-terra-main
 on:
   schedule:
     - cron: '0 7 * * *'
 jobs:
-  slow-test:
-    name: slow-test
+  terra-main:
+    name: terra-main
     runs-on: macOS-latest
     env:
       QISKIT_IBM_API_TOKEN: ${{ secrets.QISKIT_IBM_API_TOKEN }}
@@ -40,5 +40,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -c constraints.txt -e .
           pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -U git+https://github.com/Qiskit/qiskit-terra.git
       - name: Run Tests
         run: make test


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Slow test is usually more stable than slow test against terra main, having them both under same file gives impression that slow tests are always failing in the github UI, so separating them gives better visibility.

### Details and comments

