### PR TITLE
Load backend configuration individually

### DIFF
--- a/qiskit_ibm_runtime/api/clients/account.py
+++ b/qiskit_ibm_runtime/api/clients/account.py
@@ -47,13 +47,16 @@ class AccountClient(BaseBackendClient):
             project=project,
         )
 
-    def list_backends(self) -> List[Dict[str, Any]]:
-        """Return backends available.
+    def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
+        """Return the configuration of the backend.
+
+        Args:
+            backend_name: The name of the backend.
 
         Returns:
-            Backends available for this hub/group/project.
+            Backend configuration.
         """
-        return self.account_api.backends()
+        return self.account_api.backend(backend_name).configuration()
 
     def backend_status(self, backend_name: str) -> Dict[str, Any]:
         """Return the status of the backend.

--- a/qiskit_ibm_runtime/api/clients/auth.py
+++ b/qiskit_ibm_runtime/api/clients/auth.py
@@ -119,7 +119,7 @@ class AuthClient(BaseClient):
         response = self.auth_api.user_info()
         return response["urls"]
 
-    def user_hubs(self) -> List[Dict[str, str]]:
+    def user_hubs(self) -> List[Dict[str, Any]]:
         """Retrieve the hub/group/project sets available to the user.
 
         The first entry in the list will be the default set, as indicated by

--- a/qiskit_ibm_runtime/api/clients/auth.py
+++ b/qiskit_ibm_runtime/api/clients/auth.py
@@ -130,7 +130,6 @@ class AuthClient(BaseClient):
             ``hub``, ``group``, and ``project``, respectively.
         """
         response = self.base_api.hubs()
-
         hubs = []  # type: ignore[var-annotated]
         for hub in response:
             hub_name = hub["name"]
@@ -140,8 +139,11 @@ class AuthClient(BaseClient):
                         "hub": hub_name,
                         "group": group_name,
                         "project": project_name,
+                        "backend_names": [
+                            backend.get("name")
+                            for backend in project["devices"].values()
+                        ],
                     }
-
                     # Move to the top if it is the default h/g/p.
                     if project.get("isDefault"):
                         hubs.insert(0, entry)

--- a/qiskit_ibm_runtime/api/rest/account.py
+++ b/qiskit_ibm_runtime/api/rest/account.py
@@ -13,7 +13,6 @@
 """Account REST adapter."""
 
 import logging
-from typing import Dict, Optional, Any, List
 
 from .base import RestAdapterBase
 from .backend import Backend
@@ -24,8 +23,6 @@ logger = logging.getLogger(__name__)
 
 class Account(RestAdapterBase):
     """Rest adapter for hub/group/project related endpoints."""
-
-    URL_MAP = {"backends": "/devices/v/1"}
 
     TEMPLATE_IBM_HUBS = "/Network/{hub}/Groups/{group}/Projects/{project}"
     """str: Template for creating an IBM Quantum URL with
@@ -59,17 +56,3 @@ class Account(RestAdapterBase):
             The backend adapter.
         """
         return Backend(self.session, backend_name, self.url_prefix)
-
-    # Client functions.
-
-    def backends(self, timeout: Optional[float] = None) -> List[Dict[str, Any]]:
-        """Return a list of backends.
-
-        Args:
-            timeout: Number of seconds to wait for the request.
-
-        Returns:
-            JSON response.
-        """
-        url = self.get_url("backends")
-        return self.session.get(url, timeout=timeout).json()

--- a/qiskit_ibm_runtime/api/rest/backend.py
+++ b/qiskit_ibm_runtime/api/rest/backend.py
@@ -25,6 +25,7 @@ class Backend(RestAdapterBase):
     """Rest adapter for backend related endpoints."""
 
     URL_MAP = {
+        "configuration": "/fullConfiguration",
         "properties": "/properties",
         "pulse_defaults": "/defaults",
         "status": "/queue/status",
@@ -44,6 +45,15 @@ class Backend(RestAdapterBase):
         """
         self.backend_name = backend_name
         super().__init__(session, "{}/devices/{}".format(url_prefix, backend_name))
+
+    def configuration(self) -> Dict[str, Any]:
+        """Return backend configuration.
+
+        Returns:
+            JSON response of backend configuration.
+        """
+        url = self.get_url("configuration")
+        return self.session.get(url).json()
 
     def properties(self, datetime: Optional[datetime] = None) -> Dict[str, Any]:
         """Return backend properties.

--- a/qiskit_ibm_runtime/hub_group_project.py
+++ b/qiskit_ibm_runtime/hub_group_project.py
@@ -14,7 +14,7 @@
 
 import logging
 from collections import OrderedDict
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from qiskit_ibm_runtime import (  # pylint: disable=unused-import
     ibm_backend,
@@ -35,6 +35,7 @@ class HubGroupProject:
         self,
         client_params: ClientParameters,
         instance: str,
+        backend_names: List[str],
     ) -> None:
         """HubGroupProject constructor
 
@@ -43,6 +44,7 @@ class HubGroupProject:
             instance: Hub/group/project.
         """
         self._api_client = AccountClient(client_params)
+        self._backend_names = backend_names
         # Initialize the internal list of backends.
         self._backends: Dict[str, "ibm_backend.IBMBackend"] = {}
         self._hub, self._group, self._project = from_instance_format(instance)
@@ -74,8 +76,10 @@ class HubGroupProject:
             A dict of the remote backend instances, keyed by backend name.
         """
         ret = OrderedDict()
-        configs_list = self._api_client.list_backends()
-        for raw_config in configs_list:
+        for backend_name in self._backend_names:
+            raw_config = self._api_client.backend_configuration(
+                backend_name=backend_name
+            )
             config = configuration_from_server_data(
                 raw_config=raw_config, instance=self.name
             )

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -380,13 +380,13 @@ class QiskitRuntimeService:
                 proxies=self._account.proxies,
                 verify=self._account.verify,
             )
-
+            backend_names = hub_info["backend_names"]
             # Build the hgp.
             try:
                 hgp = HubGroupProject(
                     client_params=hgp_params,
                     instance=hgp_params.instance,
-                    backend_names=hub_info["backend_names"],
+                    backend_names=backend_names,
                 )
                 hgps[hgp.name] = hgp
             except Exception:  # pylint: disable=broad-except

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -384,7 +384,9 @@ class QiskitRuntimeService:
             # Build the hgp.
             try:
                 hgp = HubGroupProject(
-                    client_params=hgp_params, instance=hgp_params.instance
+                    client_params=hgp_params,
+                    instance=hgp_params.instance,
+                    backend_names=hub_info["backend_names"],
                 )
                 hgps[hgp.name] = hgp
             except Exception:  # pylint: disable=broad-except

--- a/test/unit/mock/fake_account_client.py
+++ b/test/unit/mock/fake_account_client.py
@@ -74,7 +74,7 @@ class BaseFakeAccountClient:
     def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
         """Return the configuration of the backend."""
         for backend in self._backends:
-            if backend["name"] == backend_name:
+            if backend.name == backend_name:
                 return backend.configuration.copy()
         raise ValueError(f"Backend {backend_name} not found.")
 

--- a/test/unit/mock/fake_account_client.py
+++ b/test/unit/mock/fake_account_client.py
@@ -76,7 +76,6 @@ class BaseFakeAccountClient:
         for backend in self._backends:
             if backend.name == backend_name:
                 return backend.configuration.copy()
-        raise ValueError(f"Backend {backend_name} not found.")
 
     def backend_status(self, backend_name: str) -> Dict[str, Any]:
         """Return the status of the backend."""

--- a/test/unit/mock/fake_account_client.py
+++ b/test/unit/mock/fake_account_client.py
@@ -71,16 +71,18 @@ class BaseFakeAccountClient:
                 config["backend_name"] = f"backend{idx}"
             self._backends.append(FakeApiBackend(config, status))
 
-    def list_backends(self) -> List[Dict[str, Any]]:
-        """Return backends available for this provider."""
-        # pylint: disable=unused-argument
-        return [back.configuration.copy() for back in self._backends]
+    def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
+        """Return the configuration of the backend."""
+        for backend in self._backends:
+            if backend["name"] == backend_name:
+                return backend.configuration.copy()
+        raise ValueError(f"Backend {backend_name} not found.")
 
     def backend_status(self, backend_name: str) -> Dict[str, Any]:
         """Return the status of the backend."""
-        for back in self._backends:
-            if back.name == backend_name:
-                return back.status.copy()
+        for backend in self._backends:
+            if backend.name == backend_name:
+                return backend.status.copy()
         raise ValueError(f"Backend {backend_name} not found")
 
     def backend_properties(

--- a/test/unit/mock/fake_account_client.py
+++ b/test/unit/mock/fake_account_client.py
@@ -76,6 +76,7 @@ class BaseFakeAccountClient:
         for backend in self._backends:
             if backend.name == backend_name:
                 return backend.configuration.copy()
+        raise ValueError(f"Backend {backend_name} not found")
 
     def backend_status(self, backend_name: str) -> Dict[str, Any]:
         """Return the status of the backend."""

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -489,11 +489,10 @@ class BaseFakeRuntimeClient:
     @cloud_only
     def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
         """Return the configuration of the IBM Cloud backend."""
-        configs = self._backend_client.list_backends()
-        for conf in configs:
-            if conf["backend_name"] == backend_name:
-                return conf
-        raise ValueError(f"Backend {backend_name} not found.")
+        config = self._backend_client.backend_configuration(backend_name)
+        if not config:
+            raise ValueError(f"Backend {backend_name} not found.")
+        return config
 
     @cloud_only
     def backend_status(self, backend_name: str) -> Dict[str, Any]:

--- a/test/unit/mock/fake_runtime_service.py
+++ b/test/unit/mock/fake_runtime_service.py
@@ -78,17 +78,16 @@ class FakeRuntimeService(QiskitRuntimeService):
                 url="some_url",
                 instance=hgp_name,
             )
-            hgp = HubGroupProject(client_params=hgp_params, instance=hgp_name)
+            unique_backend = self.DEFAULT_UNIQUE_BACKEND_PREFIX + str(idx)
+            backend_names = [self.DEFAULT_COMMON_BACKEND, unique_backend]
+            hgp = HubGroupProject(
+                client_params=hgp_params, instance=hgp_name, backend_names=backend_names
+            )
             fake_account_client = self._fake_account_client
             if not fake_account_client:
                 specs = [
                     {"configuration": {"backend_name": self.DEFAULT_COMMON_BACKEND}},
-                    {
-                        "configuration": {
-                            "backend_name": self.DEFAULT_UNIQUE_BACKEND_PREFIX
-                            + str(idx)
-                        }
-                    },
+                    {"configuration": {"backend_name": unique_backend}},
                 ]
                 fake_account_client = BaseFakeAccountClient(specs=specs, hgp=hgp_name)
             hgp._api_client = fake_account_client

--- a/test/unit/mock/fake_runtime_service.py
+++ b/test/unit/mock/fake_runtime_service.py
@@ -79,11 +79,16 @@ class FakeRuntimeService(QiskitRuntimeService):
                 instance=hgp_name,
             )
             unique_backend = self.DEFAULT_UNIQUE_BACKEND_PREFIX + str(idx)
-            backend_names = [self.DEFAULT_COMMON_BACKEND, unique_backend]
+            fake_account_client = self._fake_account_client
+            if not fake_account_client:
+                backend_names = [self.DEFAULT_COMMON_BACKEND, unique_backend]
+            else:
+                backend_names = [
+                    backend.name for backend in fake_account_client._backends
+                ]
             hgp = HubGroupProject(
                 client_params=hgp_params, instance=hgp_name, backend_names=backend_names
             )
-            fake_account_client = self._fake_account_client
             if not fake_account_client:
                 specs = [
                     {"configuration": {"backend_name": self.DEFAULT_COMMON_BACKEND}},


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR improves performance by loading the backend configuration individually for each backend in a provider instead of getting the configuration for all backends in a provider at once.

(For BackendV2 we'd have to load configuration, properties and pulse defaults initially in order to create Target object. Performance might degrade even further and this would be a nice to have.)

There is a bug in fullConfiguration API where it returns null for simulators and I've opened issue with API team. We cannot merge this PR until then.

### Details and comments
Fixes #272

TODO:
- [x] Fix tests