### PR TITLE
Fix missing program in test

### DIFF
--- a/test/test_integration_program.py
+++ b/test/test_integration_program.py
@@ -77,10 +77,16 @@ class TestIntegrationProgram(IBMIntegrationTestCase):
     @run_cloud_legacy_real
     def test_retrieve_unauthorized_program_data(self, service):
         """Test retrieving program data when user is not the program author"""
-        program = service.program("sample-program")
-        self._validate_program(program)
+        programs = service.programs()
+        not_mine = None
+        for prog in programs:
+            if prog.is_public:
+                not_mine = prog
+                break
+        if not_mine is None:
+            self.skipTest("Cannot find a program that's not mine!")
         with self.assertRaises(IBMNotAuthorizedError):
-            return program.data
+            return not_mine.data
 
     @run_cloud_legacy_real
     def test_upload_program(self, service):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`test_retrieve_unauthorized_program_data` uses a hard coded program id `sample-program`, which is no longer available on cloud runtime. This PR fixes that by selecting a public program. 

### Details and comments
Fixes #

