### PR TITLE
Allow users to set a logging level when running a program

### DIFF
--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -202,6 +202,7 @@ Classes
    RuntimeEncoder
    RuntimeDecoder
    ParameterNamespace
+   RuntimeOptions
 """
 # """
 # ===================================================
@@ -284,6 +285,7 @@ from .program.user_messenger import UserMessenger
 from .program.program_backend import ProgramBackend
 from .program.result_decoder import ResultDecoder
 from .utils.json import RuntimeEncoder, RuntimeDecoder
+from .runtime_options import RuntimeOptions
 
 # Setup the logger for the IBM Quantum Provider package.
 logger = logging.getLogger(__name__)

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -118,8 +118,9 @@ class RuntimeClient(BaseBackendClient):
         program_id: str,
         backend_name: str,
         params: Dict,
-        image: str,
+        image: Optional[str],
         hgp: Optional[str],
+        log_level: Optional[str],
     ) -> Dict:
         """Run the specified program.
 
@@ -129,6 +130,7 @@ class RuntimeClient(BaseBackendClient):
             params: Parameters to use.
             image: The runtime image to use.
             hgp: Hub/group/project to use.
+            log_level: Log level to use.
 
         Returns:
             JSON response.
@@ -142,6 +144,7 @@ class RuntimeClient(BaseBackendClient):
             backend_name=backend_name,
             params=params,
             image=image,
+            log_level=log_level,
             **hgp_dict
         )
 

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -115,10 +115,11 @@ class Runtime(RestAdapterBase):
         program_id: str,
         backend_name: str,
         params: Dict,
-        image: str,
+        image: Optional[str] = None,
         hub: Optional[str] = None,
         group: Optional[str] = None,
         project: Optional[str] = None,
+        log_level: Optional[str] = None,
     ) -> Dict:
         """Execute the program.
 
@@ -130,6 +131,7 @@ class Runtime(RestAdapterBase):
             hub: Hub to be used.
             group: Group to be used.
             project: Project to be used.
+            log_level: Log level to use.
 
         Returns:
             JSON response.
@@ -139,8 +141,11 @@ class Runtime(RestAdapterBase):
             "program_id": program_id,
             "backend": backend_name,
             "params": params,
-            "runtime": image,
         }
+        if image:
+            payload["runtime"] = image
+        if log_level:
+            payload["log_level"] = log_level
         if all([hub, group, project]):
             payload["hub"] = hub
             payload["group"] = group

--- a/qiskit_ibm_runtime/runtime_options.py
+++ b/qiskit_ibm_runtime/runtime_options.py
@@ -30,7 +30,7 @@ class RuntimeOptions:
             the form of ``image_name:tag``. Not all accounts are
             authorized to select a different image.
         log_level: logging level to set in the execution environment. The default
-            level is WARNING.
+            level is ``WARNING``.
     """
 
     backend_name: Optional[str] = None

--- a/qiskit_ibm_runtime/runtime_options.py
+++ b/qiskit_ibm_runtime/runtime_options.py
@@ -29,8 +29,9 @@ class RuntimeOptions:
         image: the runtime image used to execute the program, specified in
             the form of ``image_name:tag``. Not all accounts are
             authorized to select a different image.
-        log_level: logging level to set in the execution environment. The default
-            level is ``WARNING``.
+        log_level: logging level to set in the execution environment. The valid
+            log levels are: ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, and ``CRITICAL``.
+            The default level is ``WARNING``.
     """
 
     backend_name: Optional[str] = None

--- a/qiskit_ibm_runtime/runtime_options.py
+++ b/qiskit_ibm_runtime/runtime_options.py
@@ -1,0 +1,66 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Runtime options that control the execution environment."""
+
+import re
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from .exceptions import IBMInputValueError
+
+
+@dataclass
+class RuntimeOptions:
+    """Class for representing runtime execution options.
+
+    Args:
+        backend_name: target backend to run on. This is required for legacy runtime.
+        image: the runtime image used to execute the program, specified in
+            the form of ``image_name:tag``. Not all accounts are
+            authorized to select a different image.
+        log_level: logging level to set in the execution environment. The default
+            level is WARNING.
+    """
+
+    backend_name: Optional[str] = None
+    image: Optional[str] = None
+    log_level: Optional[str] = None
+
+    def validate(self, auth: str) -> None:
+        """Validate options.
+
+        Args:
+            auth: authentication type.
+
+        Raises:
+            IBMInputValueError: If one or more option is invalid.
+        """
+        if self.image and not re.match(
+            "[a-zA-Z0-9]+([/.\\-_][a-zA-Z0-9]+)*:[a-zA-Z0-9]+([.\\-_][a-zA-Z0-9]+)*$",
+            self.image,
+        ):
+            raise IBMInputValueError('"image" needs to be in form of image_name:tag')
+
+        if auth == "legacy" and not self.backend_name:
+            raise IBMInputValueError(
+                '"backend_name" is required field in "options" for legacy runtime.'
+            )
+
+        if self.log_level and not isinstance(
+            logging.getLevelName(self.log_level.upper()), int
+        ):
+            raise IBMInputValueError(
+                f"{self.log_level} is not a valid log level. The valid log levels are: `DEBUG`, "
+                f"`INFO`, `WARNING`, `ERROR`, and `CRITICAL`."
+            )

--- a/test/ibm_test_case.py
+++ b/test/ibm_test_case.py
@@ -174,6 +174,7 @@ class IBMIntegrationJobTestCase(IBMIntegrationTestCase):
         final_result=None,
         callback=None,
         backend=None,
+        log_level=None,
     ):
         """Run a program."""
         self.log.debug("Running program on %s", service.auth)
@@ -188,7 +189,7 @@ class IBMIntegrationJobTestCase(IBMIntegrationTestCase):
         )
         pid = program_id or self.program_ids[service.auth]
         backend_name = backend or self.sim_backends[service.auth]
-        options = {"backend_name": backend_name}
+        options = {"backend_name": backend_name, "log_level": log_level}
         job = service.run(
             program_id=pid, inputs=inputs, options=options, callback=callback
         )

--- a/test/mock/fake_runtime_client.py
+++ b/test/mock/fake_runtime_client.py
@@ -113,6 +113,7 @@ class BaseFakeRuntimeJob:
         final_status,
         params,
         image,
+        log_level=None,
     ):
         """Initialize a fake job."""
         self._job_id = job_id
@@ -125,6 +126,7 @@ class BaseFakeRuntimeJob:
         self._params = params
         self._image = image
         self._interim_results = json.dumps("foo")
+        self.log_level = log_level
         if final_status is None:
             self._future = self._executor.submit(self._auto_progress)
             self._result = None
@@ -345,6 +347,7 @@ class BaseFakeRuntimeClient:
         params: Dict,
         image: str,
         hgp: Optional[str],
+        log_level: Optional[str],
     ):
         """Run the specified program."""
         _ = self._get_program(program_id)
@@ -368,6 +371,7 @@ class BaseFakeRuntimeClient:
             params=params,
             final_status=self._final_status,
             image=image,
+            log_level=log_level,
             **self._job_kwargs,
         )
         self._jobs[job_id] = job

--- a/test/test_integration_job.py
+++ b/test/test_integration_job.py
@@ -57,6 +57,21 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
         self.assertEqual("foo", result)
 
     @run_cloud_legacy_real
+    def test_run_program_log_level(self, service):
+        """Test running with a custom log level."""
+        levels = ["INFO", "ERROR"]
+        for level in levels:
+            with self.subTest(level=level):
+                job = self._run_program(service, log_level=level)
+                job.wait_for_final_state()
+                expect_info_msg = level == "INFO"
+                self.assertEqual(
+                    "info log" in job.logs(),
+                    expect_info_msg,
+                    f"Job log is {job.logs()}",
+                )
+
+    @run_cloud_legacy_real
     def test_run_program_failed(self, service):
         """Test a failed program execution."""
         job = self._run_program(service, inputs={})

--- a/test/test_jobs.py
+++ b/test/test_jobs.py
@@ -145,6 +145,13 @@ class TestRuntimeJob(IBMTestCase):
         self.assertEqual(job.image, image)
 
     @run_legacy_and_cloud_fake
+    def test_run_program_with_custom_log_level(self, service):
+        """Test running program with a custom image."""
+        job = run_program(service=service, log_level="DEBUG")
+        job_raw = service._api_client._get_job(job.job_id)
+        self.assertEqual(job_raw.log_level, "DEBUG")
+
+    @run_legacy_and_cloud_fake
     def test_run_program_failed(self, service):
         """Test a failed program execution."""
         job = run_program(service=service, job_classes=FailedRuntimeJob)

--- a/test/utils/program.py
+++ b/test/utils/program.py
@@ -72,10 +72,11 @@ def run_program(
     image="",
     instance=None,
     backend_name=None,
+    log_level=None,
 ):
     """Run a program."""
     backend_name = backend_name if backend_name is not None else "common_backend"
-    options = {"backend_name": backend_name}
+    options = {"backend_name": backend_name, "image": image, "log_level": log_level}
     if final_status is not None:
         service._api_client.set_final_status(final_status)
     elif job_classes:
@@ -87,7 +88,6 @@ def run_program(
         options=options,
         inputs=inputs,
         result_decoder=decoder,
-        image=image,
         instance=instance,
     )
     return job

--- a/test/utils/templates.py
+++ b/test/utils/templates.py
@@ -16,9 +16,12 @@ RUNTIME_PROGRAM = """
 import random
 import time
 import warnings
+import logging
 
 from qiskit import transpile
 from qiskit.circuit.random import random_circuit
+
+logger = logging.getLogger("qiskit-test")
 
 def prepare_circuits(backend):
     circuit = random_circuit(num_qubits=5, depth=4, measure=True,
@@ -39,6 +42,7 @@ def main(backend, user_messenger, **kwargs):
     user_messenger.publish(final_result, final=True)
     print("this is a stdout message")
     warnings.warn("this is a stderr message")
+    logger.info("this is an info log")
     """
 
 RUNTIME_PROGRAM_METADATA = {


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Allow users to set a logging level when running a program.
@daka1510 Sorry for taking another one from you, but I need this to get some performance numbers. 

### Details and comments
Fixes #11

This PR adds a new `RuntimeOptions` class for the execution options, including `backend_name`, `image`, and now `log_level`. Since we already have `options` as a parameter to `run()`, it made more sense to me to have both `image` and `log_level` in it instead of creating more parameters, especially since they're both related to the execution environment. 