### PR TITLE
Ignore errors during session cleanup

### DIFF
--- a/qiskit_ibm_runtime/api/session.py
+++ b/qiskit_ibm_runtime/api/session.py
@@ -170,7 +170,11 @@ class RetrySession(Session):
 
     def __del__(self) -> None:
         """RetrySession destructor. Closes the session."""
-        self.close()
+        try:
+            self.close()
+        except Exception:  # pylint: disable=broad-except
+            # ignore errors that may happen during cleanup
+            pass
 
     def _initialize_retry(
         self, retries_total: int, retries_connect: int, backoff_factor: float


### PR DESCRIPTION
### Summary
See https://github.com/Qiskit/qiskit-ibm-runtime/issues/74#issuecomment-1014537885 for background information on the proposed solution.


### Details and comments
https://github.com/Qiskit/qiskit-ibm-runtime/issues/74, i.e. avoids `TypeErrors` when scripts finish or interactive python sessions are aborted.

