### PR TITLE
Use consistently named environment variables

### DIFF
--- a/qiskit_ibm_runtime/accounts/management.py
+++ b/qiskit_ibm_runtime/accounts/management.py
@@ -172,8 +172,8 @@ class AccountManager:
     @classmethod
     def _from_env_variables(cls, auth: Optional[AccountType]) -> Optional[Account]:
         """Read account from environment variable."""
-        token = os.getenv("QISKIT_IBM_API_TOKEN")
-        url = os.getenv("QISKIT_IBM_API_URL")
+        token = os.getenv("QISKIT_IBM_TOKEN")
+        url = os.getenv("QISKIT_IBM_URL")
         if not (token and url):
             return None
         return Account(

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -138,7 +138,7 @@ class TestAccountManager(IBMTestCase):
     """Tests for AccountManager class."""
 
     @temporary_account_config_file(contents={})
-    @no_envs(["QISKIT_IBM_API_TOKEN"])
+    @no_envs(["QISKIT_IBM_TOKEN"])
     def test_save_get(self):
         """Test save and get."""
 
@@ -283,7 +283,7 @@ class TestEnableAccount(IBMTestCase):
     def test_enable_account_by_auth(self):
         """Test initializing account by auth."""
         for auth in ["cloud", "legacy"]:
-            with self.subTest(auth=auth), no_envs(["QISKIT_IBM_API_TOKEN"]):
+            with self.subTest(auth=auth), no_envs(["QISKIT_IBM_TOKEN"]):
                 token = uuid.uuid4().hex
                 with temporary_account_config_file(auth=auth, token=token):
                     service = FakeRuntimeService(auth=auth)
@@ -330,7 +330,7 @@ class TestEnableAccount(IBMTestCase):
         # Enable account will fail due to missing CRN.
         urls = [None, "some_url"]
         for url in urls:
-            with self.subTest(url=url), no_envs(["QISKIT_IBM_API_TOKEN"]):
+            with self.subTest(url=url), no_envs(["QISKIT_IBM_TOKEN"]):
                 token = uuid.uuid4().hex
                 with self.assertRaises(ValueError) as err:
                     _ = FakeRuntimeService(auth="cloud", token=token, url=url)
@@ -340,7 +340,7 @@ class TestEnableAccount(IBMTestCase):
         """Test initializing legacy account by auth, token, url."""
         urls = [(None, LEGACY_API_URL), ("some_url", "some_url")]
         for url, expected in urls:
-            with self.subTest(url=url), no_envs(["QISKIT_IBM_API_TOKEN"]):
+            with self.subTest(url=url), no_envs(["QISKIT_IBM_TOKEN"]):
                 token = uuid.uuid4().hex
                 service = FakeRuntimeService(auth="legacy", token=token, url=url)
                 self.assertTrue(service._account)
@@ -354,7 +354,7 @@ class TestEnableAccount(IBMTestCase):
             with self.subTest(auth=auth):
                 token = uuid.uuid4().hex
                 with temporary_account_config_file(auth=auth, token=token), no_envs(
-                    ["QISKIT_IBM_API_TOKEN"]
+                    ["QISKIT_IBM_TOKEN"]
                 ):
                     with self.assertLogs(
                         "qiskit_ibm_runtime", logging.WARNING
@@ -374,7 +374,7 @@ class TestEnableAccount(IBMTestCase):
             with self.subTest(auth=auth):
                 token = uuid.uuid4().hex
                 with temporary_account_config_file(auth=auth, token=token), no_envs(
-                    ["QISKIT_IBM_API_TOKEN"]
+                    ["QISKIT_IBM_TOKEN"]
                 ):
                     service = FakeRuntimeService()
                 self.assertTrue(service._account)
@@ -391,7 +391,7 @@ class TestEnableAccount(IBMTestCase):
             get_account_config_contents(auth="legacy", token=uuid.uuid4().hex)
         )
         with temporary_account_config_file(contents=contents), no_envs(
-            ["QISKIT_IBM_API_TOKEN"]
+            ["QISKIT_IBM_TOKEN"]
         ):
             service = FakeRuntimeService()
         self.assertTrue(service._account)
@@ -407,8 +407,8 @@ class TestEnableAccount(IBMTestCase):
                 token = uuid.uuid4().hex
                 url = uuid.uuid4().hex
                 envs = {
-                    "QISKIT_IBM_API_TOKEN": token,
-                    "QISKIT_IBM_API_URL": url,
+                    "QISKIT_IBM_TOKEN": token,
+                    "QISKIT_IBM_URL": url,
                     "QISKIT_IBM_INSTANCE": "h/g/p" if auth == "legacy" else "crn:123",
                 }
                 with custom_envs(envs):
@@ -425,8 +425,8 @@ class TestEnableAccount(IBMTestCase):
         token = uuid.uuid4().hex
         url = uuid.uuid4().hex
         envs = {
-            "QISKIT_IBM_API_TOKEN": token,
-            "QISKIT_IBM_API_URL": url,
+            "QISKIT_IBM_TOKEN": token,
+            "QISKIT_IBM_URL": url,
             "QISKIT_IBM_INSTANCE": "my_crn",
         }
         subtests = [{"token": token}, {"url": url}, {"token": token, "url": url}]
@@ -483,7 +483,7 @@ class TestEnableAccount(IBMTestCase):
                 ), temporary_account_config_file(
                     auth=auth, verify=True, proxies="some proxies"
                 ), no_envs(
-                    ["QISKIT_IBM_API_TOKEN"]
+                    ["QISKIT_IBM_TOKEN"]
                 ):
                     service = FakeRuntimeService(auth=auth, **extra)
                     self.assertTrue(service._account)
@@ -502,8 +502,8 @@ class TestEnableAccount(IBMTestCase):
                 token = uuid.uuid4().hex
                 url = uuid.uuid4().hex
                 envs = {
-                    "QISKIT_IBM_API_TOKEN": token,
-                    "QISKIT_IBM_API_URL": url,
+                    "QISKIT_IBM_TOKEN": token,
+                    "QISKIT_IBM_URL": url,
                     "QISKIT_IBM_INSTANCE": "my_crn",
                 }
                 with custom_envs(envs):
@@ -533,8 +533,8 @@ class TestEnableAccount(IBMTestCase):
         """Test initializing account by env and input instance."""
         instance = uuid.uuid4().hex
         envs = {
-            "QISKIT_IBM_API_TOKEN": "some_token",
-            "QISKIT_IBM_API_URL": "some_url",
+            "QISKIT_IBM_TOKEN": "some_token",
+            "QISKIT_IBM_URL": "some_url",
             "QISKIT_IBM_INSTANCE": "some_instance",
         }
         with custom_envs(envs):


### PR DESCRIPTION
### Summary
Make sure environment variables relied on by consumers of the library are consistently named. I.e. use (`QISKIT_IBM_TOKEN`, `QISKIT_IBM_URL`, `QISKIT_IBM_INSTANCE`) instead of (`QISKIT_IBM_API_TOKEN`, `QISKIT_IBM_API_URL`, `QISKIT_IBM_INSTANCE`.

### Related Future Work
- documentation will follow in a separate PR that @jyu00 is working on
- updating test cases will follow via [separate efforts](https://github.com/Qiskit/qiskit-ibm-runtime/issues/30) (the environment variables used for test cases are mostly implementation details)