### PR TITLE
Enable test coverage reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,5 +88,5 @@ jobs:
       - name: Upload test coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: coverage_report
+          name: coverage_report-${{ matrix.python-version }}
           path: htmlcov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,4 +84,9 @@ jobs:
           pip install -c constraints.txt -e .
           pip install -U -c constraints.txt -r requirements-dev.txt
       - name: Run Tests
-        run: make test
+        run: make coverage
+      - name: Upload test coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage_report
+          path: htmlcov

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,12 @@ jobs:
           pip install -c constraints.txt -e .
           pip install -U -c constraints.txt -r requirements-dev.txt
       - name: Run Tests
-        run: make test
+        run: make coverage
+      - name: Upload test coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage_report
+          path: htmlcov
   lint:
     name: lint & mypy
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload test coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: coverage_report
+          name: coverage_report-${{ matrix.python-version }}
           path: htmlcov
   lint:
     name: lint & mypy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload test coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: coverage_report-${{ matrix.python-version }}
+          name: coverage_report-${{ matrix.python-version }}-${{ matrix.os }}
           path: htmlcov
   lint:
     name: lint & mypy

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 
 coverage:
 	coverage run -m unittest -v
-	coverage report html
+	coverage html
 
 test1:
 	python -m unittest -v test/test_integration_backend.py test/test_integration_program.py

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ style:
 test:
 	python -m unittest -v
 
+coverage:
+	coverage run -m unittest -v
+	coverage report html
+
 test1:
 	python -m unittest -v test/test_integration_backend.py test/test_integration_program.py
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,3 +24,4 @@ qiskit-aer
 websockets>=8
 scikit-quant;platform_system != 'Windows'
 black==21.11b1
+coverage>=6.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[coverage:run]
+source = qiskit_ibm_runtime
+
 [mypy]
 python_version = 3.7
 namespace_packages = True


### PR DESCRIPTION
### Summary
Create test coverage reports for unit and integration tests. HTML reports are uploaded as workflow artifacts when the `PR-Test` or `Push-Test` workflows run.

This makes it easy to review current coverage metrics. Let's add the "fancy stuff" (e.g. trends over time, central place to check, badge in README) via [follow-up efforts](https://github.com/Qiskit/qiskit-ibm-runtime/issues/22).

### Details and comments
Related to https://github.com/Qiskit/qiskit-ibm-runtime/issues/109

