### PR TITLE
Allow to trigger workflow that publishes the documentation manually

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
### Summary
Allow to trigger workflow that publishes the documentation manually. When this PR is integrated into the main branch, all contributors with write access to the repository will be able to run it like so
![image](https://user-images.githubusercontent.com/16404496/150813743-192abe8a-c7d1-4cee-997f-4d1cbe957f03.png)


### Details and comments
N/A
