### PR TITLE
Do no longer fail when `IBMRuntimeService.run` is invoked without providing options

### DIFF
--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -810,8 +810,11 @@ class IBMRuntimeService:
             inputs.validate()
             inputs = vars(inputs)
 
+        if options is None:
+            options = RuntimeOptions()
         if isinstance(options, dict):
             options = RuntimeOptions(**options)
+
         options.validate(self.auth)
 
         backend = None


### PR DESCRIPTION
### Summary
See https://github.com/Qiskit/qiskit-ibm-runtime/issues/115 for details.


### Details and comments
Fixes https://github.com/Qiskit/qiskit-ibm-runtime/issues/115

