### PR TITLE
/jobs API returns 400 when program is not found

### DIFF
--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -836,7 +836,7 @@ class IBMRuntimeService:
                 log_level=options.log_level,
             )
         except RequestsApiError as ex:
-            if ex.status_code == 404:
+            if ex.status_code == 400 and "could not get program" in ex.message:
                 raise RuntimeProgramNotFound(
                     f"Program not found: {ex.message}"
                 ) from None


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
/jobs API returns 400 when program is not found and not 404. 400 is returned for other bad requests as well and hence checking the message as well.


### Details and comments
Fixes #

