### PR TITLE
Exclude `jupyter` and `visualization` from public API documentation

### DIFF
--- a/docs/apidocs/ibm-runtime.rst
+++ b/docs/apidocs/ibm-runtime.rst
@@ -7,5 +7,3 @@ Qiskit IBM Runtime API Reference
 
    ibm_runtime
    ibm_program
-   ibm_visualization
-   ibm_jupyter

--- a/docs/apidocs/ibm_jupyter.rst
+++ b/docs/apidocs/ibm_jupyter.rst
@@ -1,6 +1,0 @@
-.. _qiskit_ibm_runtime-jupyter:
-
-.. automodule:: qiskit_ibm_runtime.jupyter
-   :no-members:
-   :no-inherited-members:
-   :no-special-members:

--- a/docs/apidocs/ibm_visualization.rst
+++ b/docs/apidocs/ibm_visualization.rst
@@ -1,6 +1,0 @@
-.. _qiskit_ibm_runtime-visualization:
-
-.. automodule:: qiskit_ibm_runtime.visualization
-   :no-members:
-   :no-inherited-members:
-   :no-special-members:


### PR DESCRIPTION
### Summary
Exclude `jupyter` and `visualization` from public API documentation.


### Details and comments
Fixes https://github.com/Qiskit/qiskit-ibm-runtime/issues/111 (via Option 2)

