### PR TITLE
Improve account management error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Qiskit IBM Runtime
-
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-ibm-runtime.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)[![Push-Test](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/main.yml/badge.svg)](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/main.yml)[![](https://img.shields.io/github/release/Qiskit/qiskit-ibm-runtime.svg?style=popout-square)](https://github.com/Qiskit/qiskit-ibm-runtime/releases)[![](https://img.shields.io/pypi/dm/qiskit-ibm-runtime.svg?style=popout-square)](https://pypi.org/project/qiskit-ibm-runtime/)[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 

--- a/qiskit_ibm_runtime/accounts/__init__.py
+++ b/qiskit_ibm_runtime/accounts/__init__.py
@@ -16,3 +16,8 @@ Account management functionality related to the IBM Runtime Services.
 
 from .account import Account, AccountType
 from .management import AccountManager
+from .exceptions import (
+    AccountNotFoundError,
+    AccountAlreadyExistsError,
+    InvalidAccountError,
+)

--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -18,9 +18,11 @@ from urllib.parse import urlparse
 
 from requests.auth import AuthBase
 from typing_extensions import Literal
+
+from .exceptions import InvalidAccountError
+from ..api.auth import LegacyAuth, CloudAuth
 from ..proxies import ProxyConfiguration
 from ..utils.hgp import from_instance_format
-from ..api.auth import LegacyAuth, CloudAuth
 
 AccountType = Optional[Literal["cloud", "legacy"]]
 
@@ -104,7 +106,7 @@ class Account:
         """Validates the account instance.
 
         Raises:
-            ValueError: if the account is invalid
+            InvalidAccountError: if the account is invalid
 
         Returns:
             This Account instance.
@@ -121,7 +123,7 @@ class Account:
     def _assert_valid_auth(auth: AccountType) -> None:
         """Assert that the auth parameter is valid."""
         if not (auth in ["cloud", "legacy"]):
-            raise ValueError(
+            raise InvalidAccountError(
                 f"Invalid `auth` value. Expected one of ['cloud', 'legacy'], got '{auth}'."
             )
 
@@ -129,7 +131,7 @@ class Account:
     def _assert_valid_token(token: str) -> None:
         """Assert that the token is valid."""
         if not (isinstance(token, str) and len(token) > 0):
-            raise ValueError(
+            raise InvalidAccountError(
                 f"Invalid `token` value. Expected a non-empty string, got '{token}'."
             )
 
@@ -139,7 +141,9 @@ class Account:
         try:
             urlparse(url)
         except:
-            raise ValueError(f"Invalid `url` value. Failed to parse '{url}' as URL.")
+            raise InvalidAccountError(
+                f"Invalid `url` value. Failed to parse '{url}' as URL."
+            )
 
     @staticmethod
     def _assert_valid_proxies(config: ProxyConfiguration) -> None:
@@ -152,7 +156,7 @@ class Account:
         """Assert that the instance name is valid for the given account type."""
         if auth == "cloud":
             if not (isinstance(instance, str) and len(instance) > 0):
-                raise ValueError(
+                raise InvalidAccountError(
                     f"Invalid `instance` value. Expected a non-empty string, got '{instance}'."
                 )
         if auth == "legacy":
@@ -160,6 +164,6 @@ class Account:
                 try:
                     from_instance_format(instance)
                 except:
-                    raise ValueError(
+                    raise InvalidAccountError(
                         f"Invalid `instance` value. Expected hub/group/project format, got {instance}"
                     )

--- a/qiskit_ibm_runtime/accounts/exceptions.py
+++ b/qiskit_ibm_runtime/accounts/exceptions.py
@@ -17,3 +17,15 @@ from ..exceptions import IBMError
 
 class AccountsError(IBMError):
     """Base class for errors raised during account management."""
+
+
+class InvalidAccountError(AccountsError):
+    """Errors raised when the account is invalid."""
+
+
+class AccountNotFoundError(AccountsError):
+    """Errors raised when the account is not found."""
+
+
+class AccountAlreadyExistsError(AccountsError):
+    """Errors raised when the account already exists."""

--- a/qiskit_ibm_runtime/accounts/storage.py
+++ b/qiskit_ibm_runtime/accounts/storage.py
@@ -16,21 +16,24 @@ import json
 import logging
 import os
 from typing import Optional, Dict
+from .exceptions import AccountAlreadyExistsError
 
 logger = logging.getLogger(__name__)
 
 
-def save_config(
-    filename: str,
-    name: str,
-    config: dict,
-) -> None:
+def save_config(filename: str, name: str, config: dict, overwrite: bool) -> None:
     """Save configuration data in a JSON file under the given name."""
     logger.debug("Save configuration data for '%s' in '%s'", name, filename)
     _ensure_file_exists(filename)
 
     with open(filename, mode="r") as json_in:
         data = json.load(json_in)
+
+    if data.get(name) and not overwrite:
+        raise AccountAlreadyExistsError(
+            f"Named account ({name}) already exists. "
+            f"Set overwrite=True to overwrite."
+        )
 
     with open(filename, mode="w") as json_out:
         data[name] = config

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -25,7 +25,6 @@ from qiskit.providers.providerutils import filter_backends
 
 from qiskit_ibm_runtime import ibm_backend
 from .accounts import AccountManager, Account, AccountType
-from .accounts.exceptions import AccountsError
 from .proxies import ProxyConfiguration
 from .api.clients import AuthClient, VersionClient
 from .api.clients.runtime import RuntimeClient
@@ -250,8 +249,6 @@ class IBMRuntimeService:
 
         if account is None:
             account = AccountManager.get()
-            if account is None:
-                raise AccountsError("Unable to find account.")
 
         if instance:
             account.instance = instance
@@ -548,6 +545,7 @@ class IBMRuntimeService:
         name: Optional[str] = None,
         proxies: Optional[dict] = None,
         verify: Optional[bool] = None,
+        overwrite: Optional[bool] = False,
     ) -> None:
         """Save the account to disk for future use.
 
@@ -565,6 +563,7 @@ class IBMRuntimeService:
                 ``username_ntlm``, ``password_ntlm`` (username and password to enable NTLM user
                 authentication)
             verify: Verify the server's TLS certificate.
+            overwrite: ``True`` if the existing account is to be overwritten.
         """
 
         AccountManager.save(
@@ -575,6 +574,7 @@ class IBMRuntimeService:
             name=name,
             proxies=ProxyConfiguration(**proxies) if proxies else None,
             verify=verify,
+            overwrite=overwrite,
         )
 
     @staticmethod


### PR DESCRIPTION
### Summary
- avoid that an existing account is overwritten unless explicitly specified (raise `AccountAlreadyExistsError` otherwise)
- raise dedicated error classes in other account management related failure cases, i.e.
  - `InvalidAccountError` instead of `ValueError`
  - `AccountNotFoundError` instead of `ValueError`

### Details and comments
Fixes https://github.com/Qiskit/qiskit-ibm-runtime/issues/117 and implements related improvements.

### Follow-Up
- [X] let Beccy now so she can update the docs accordingly 
   - reached out to Beccy and @rathishcholarajan 