### PR TITLE
Enable disabled pylint rules pt. 2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -66,16 +66,16 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=arguments-renamed,              # unnecessary  
+disable=arguments-renamed,              # more readable and clear 
         bad-continuation, bad-whitespace, # differences of opinion with black
-        consider-using-f-string,        # unnecessary
+        consider-using-f-string,        # unnecesary to convert all str.format() to f strings
         consider-using-with,            # TODO: investigate / re-enable
-        docstring-first-line-empty,     # unnecessary
+        docstring-first-line-empty,     # docstrings are more readable
         duplicate-code,                 # too verbose
         fixme,                          # avoid that to do annotations show up as warnings
-        missing-param-doc,              # unnecessary
+        missing-param-doc,              # false positives when docs contain ":"
         no-else-return,                 # relax "elif" after a clause with a return
-        no-member,                      # unecessary
+        no-member,                      # false positives when variable from external function
         no-self-use,                    # too verbose
         protected-access,               # we don't strictly follow the public vs. private convention
         raise-missing-from,             # TODO: investigate / re-enable

--- a/.pylintrc
+++ b/.pylintrc
@@ -66,22 +66,19 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=arguments-renamed,              # TODO: investigate / re-enable
-        bad-mcs-classmethod-argument,   # TODO: investigate / re-enable
+disable=arguments-renamed,              # unnecessary  
         bad-continuation, bad-whitespace, # differences of opinion with black
-        consider-using-f-string,        # TODO: investigate / re-enable
+        consider-using-f-string,        # unnecessary
         consider-using-with,            # TODO: investigate / re-enable
-        docstring-first-line-empty,     # TODO: investigate / re-enable
+        docstring-first-line-empty,     # unnecessary
         duplicate-code,                 # too verbose
         fixme,                          # avoid that to do annotations show up as warnings
-        invalid-name,                   # TODO: investigate / re-enable
-        missing-param-doc,              # TODO: investigate / re-enable (issues with kwargs docs)
+        missing-param-doc,              # unnecessary
         no-else-return,                 # relax "elif" after a clause with a return
-        no-member,                      # TODO: investigate / re-enable
+        no-member,                      # unecessary
         no-self-use,                    # too verbose
         protected-access,               # we don't strictly follow the public vs. private convention
         raise-missing-from,             # TODO: investigate / re-enable
-        super-with-arguments,           # TODO: investigate / re-enable
         too-few-public-methods,         # too verbose
         too-many-ancestors,             # too verbose
         too-many-arguments,             # too verbose

--- a/qiskit_ibm_runtime/jupyter/dashboard/dashboard.py
+++ b/qiskit_ibm_runtime/jupyter/dashboard/dashboard.py
@@ -38,7 +38,7 @@ class AccordionWithThread(wid.Accordion):
             **kwargs: Additional keywords to be passed to ``ipywidgets.Accordion``.
         """
         children = children or []
-        super(AccordionWithThread, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
         self._thread = None
         # Devices VBox.
         self._device_list = None  # type: Optional[wid.VBox]

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -142,10 +142,10 @@ def _set_int_keys_flag(obj: Dict) -> Union[Dict, List]:
         obj with the '__int_keys__' flag set if dictionary uses integer key
     """
     if isinstance(obj, dict):
-        for k, v in list(obj.items()):
+        for k, val in list(obj.items()):
             if isinstance(k, int):
                 obj["__int_keys__"] = True
-            _set_int_keys_flag(v)
+            _set_int_keys_flag(val)
     return obj
 
 
@@ -160,13 +160,13 @@ def _cast_strings_keys_to_int(obj: Dict) -> Dict:
     """
     if isinstance(obj, dict):
         int_keys: List[int] = []
-        for k, v in list(obj.items()):
+        for k, val in list(obj.items()):
             if "__int_keys__" in obj:
                 try:
                     int_keys.append(int(k))
                 except ValueError:
                     pass
-            _cast_strings_keys_to_int(v)
+            _cast_strings_keys_to_int(val)
         while len(int_keys) > 0:
             key = int_keys.pop()
             obj[key] = obj[str(key)]

--- a/qiskit_ibm_runtime/version.py
+++ b/qiskit_ibm_runtime/version.py
@@ -28,9 +28,9 @@ def _minimal_ext_cmd(cmd: List[str]) -> bytes:
     # construct minimal environment
     env = {}
     for k in ["SYSTEMROOT", "PATH"]:
-        v = os.environ.get(k)
-        if v is not None:
-            env[k] = v
+        version = os.environ.get(k)
+        if version is not None:
+            env[k] = version
     # LANGUAGE is used on win32
     env["LANGUAGE"] = "C"
     env["LANG"] = "C"

--- a/test/test_data_serialization.py
+++ b/test/test_data_serialization.py
@@ -128,13 +128,13 @@ class TestDataSerialization(IBMTestCase):
 
     def test_coder_operators(self):
         """Test runtime encoder and decoder for operators."""
-        x = Parameter("x")
-        y = x + 1
-        qc = QuantumCircuit(1)
-        qc.h(0)
+        coeff_x = Parameter("x")
+        coeff_y = coeff_x + 1
+        quantum_circuit = QuantumCircuit(1)
+        quantum_circuit.h(0)
         coeffs = np.array([1, 2, 3, 4, 5, 6])
         table = PauliTable.from_labels(["III", "IXI", "IYY", "YIZ", "XYZ", "III"])
-        op = 2.0 * I ^ I
+        operator = 2.0 * I ^ I
         z2_symmetries = Z2Symmetries(
             [Pauli("IIZI"), Pauli("ZIII")],
             [Pauli("IIXI"), Pauli("XIII")],
@@ -146,19 +146,19 @@ class TestDataSerialization(IBMTestCase):
 
         subtests = (
             PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[2]), coeff=3),
-            PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[1]), coeff=y),
+            PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[1]), coeff=coeff_y),
             PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[1 + 2j]), coeff=3 - 2j),
             PauliSumOp.from_list(
                 [("II", -1.052373245772859), ("IZ", 0.39793742484318045)]
             ),
             PauliSumOp(SparsePauliOp(table, coeffs), coeff=10),
-            MatrixOp(primitive=np.array([[0, -1j], [1j, 0]]), coeff=x),
-            PauliOp(primitive=Pauli("Y"), coeff=x),
-            CircuitOp(qc, coeff=x),
-            EvolvedOp(op, coeff=x),
+            MatrixOp(primitive=np.array([[0, -1j], [1j, 0]]), coeff=coeff_x),
+            PauliOp(primitive=Pauli("Y"), coeff=coeff_x),
+            CircuitOp(quantum_circuit, coeff=coeff_x),
+            EvolvedOp(operator, coeff=coeff_x),
             TaperedPauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[2]), z2_symmetries),
-            StateFn(qc, coeff=x),
-            CircuitStateFn(qc, is_measurement=True),
+            StateFn(quantum_circuit, coeff=coeff_x),
+            CircuitStateFn(quantum_circuit, is_measurement=True),
             DictStateFn("1" * 3, is_measurement=True),
             VectorStateFn(np.ones(2 ** 3, dtype=complex)),
             OperatorStateFn(CircuitOp(QuantumCircuit(1))),
@@ -170,12 +170,12 @@ class TestDataSerialization(IBMTestCase):
             TensoredOp([(X ^ Y), (Z ^ I)]),
             (Z ^ Z) ^ (I ^ 2),
         )
-        for op in subtests:
-            with self.subTest(op=op):
-                encoded = json.dumps(op, cls=RuntimeEncoder)
+        for operator in subtests:
+            with self.subTest(operator=operator):
+                encoded = json.dumps(operator, cls=RuntimeEncoder)
                 self.assertIsInstance(encoded, str)
                 decoded = json.loads(encoded, cls=RuntimeDecoder)
-                self.assertEqual(op, decoded)
+                self.assertEqual(operator, decoded)
 
     @skipIf(os.name == "nt", "Test not supported on Windows")
     def test_coder_optimizers(self):
@@ -242,9 +242,9 @@ if __name__ == '__main__':
             DictStateFn("1" * 3, is_measurement=True),
             Statevector([1, 0]),
         )
-        for op in subtests:
-            with self.subTest(op=op):
-                encoded = json.dumps(op, cls=RuntimeEncoder)
+        for operator in subtests:
+            with self.subTest(operator=operator):
+                encoded = json.dumps(operator, cls=RuntimeEncoder)
                 self.assertIsInstance(encoded, str)
                 cmd = ["python", temp_fp.name, encoded]
                 proc = subprocess.run(
@@ -254,7 +254,7 @@ if __name__ == '__main__':
                     universal_newlines=True,
                     check=True,
                 )
-                self.assertIn(op.__class__.__name__, proc.stdout)
+                self.assertIn(operator.__class__.__name__, proc.stdout)
 
     def test_result_decoder(self):
         """Test result decoder."""

--- a/test/test_tutorials.py
+++ b/test/test_tutorials.py
@@ -32,7 +32,7 @@ TUTORIAL_PATH = "docs/tutorials/**/*.ipynb"
 class TutorialsTestCaseMeta(type):
     """Metaclass that dynamically appends a "test_TUTORIAL_NAME" method to the class."""
 
-    def __new__(mcs, name, bases, dict_):
+    def __new__(cls, name, bases, dict_):
         def create_test(filename):
             """Return a new test function."""
 
@@ -48,7 +48,7 @@ class TutorialsTestCaseMeta(type):
             test_name = "test_%s" % to_python_identifier(filename)
             dict_[test_name] = create_test(filename)
             dict_[test_name].__doc__ = 'Test tutorial "%s"' % filename
-        return type.__new__(mcs, name, bases, dict_)
+        return type.__new__(cls, name, bases, dict_)
 
 
 @skipIf(not TEST_OPTIONS["run_slow"], "Skipping slow tests.")

--- a/test/utils/utils.py
+++ b/test/utils/utils.py
@@ -65,9 +65,9 @@ def get_large_circuit(backend: IBMBackend) -> QuantumCircuit:
     """
     n_qubits = min(backend.configuration().n_qubits, 20)
     circuit = QuantumCircuit(n_qubits, n_qubits)
-    for n in range(n_qubits - 1):
-        circuit.h(n)
-        circuit.cx(n, n + 1)
+    for qubit in range(n_qubits - 1):
+        circuit.h(qubit)
+        circuit.cx(qubit, qubit + 1)
     circuit.measure(list(range(n_qubits)), list(range(n_qubits)))
 
     return circuit


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I'm indifferent about most of the remaining rules, but this PR takes care of : 
`invalid-name`, `super-with-arguments`, and `bad-mcs-classmethod-argument` 


Highlighted the remaining rules in a comment [here](https://github.com/Qiskit/qiskit-ibm-runtime/issues/42#issuecomment-1026077843)

### Details and comments
Fixes part of #42 

