### PR TITLE
Fix staging integration tests against legacy environment

### DIFF
--- a/test/test_basic_server_paths.py
+++ b/test/test_basic_server_paths.py
@@ -43,7 +43,7 @@ class TestBasicServerPaths(IBMTestCase):
         for hgp in self._get_hgps():
             with self.subTest(hgp=hgp):
                 pulse_backends = self.service.backends(
-                    simulator=False, operational=True, instance=hgp
+                    simulator=False, operational=True, instance=hgp, open_pulse=True
                 )
                 if not pulse_backends:
                     raise self.skipTest(


### PR DESCRIPTION
### Summary
Change makes sure to run pulse tests only against pulse backends. Needed for staging where simulators pretend to be real backends but don't have pulse defaults.


### Details and comments
Fixes broken integration tests against legacy-staging
```
FAIL: test_device_properties_and_defaults (test.test_basic_server_paths.TestBasicServerPaths) (hgp='***')
Test device properties and defaults.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/test_basic_server_paths.py", line 55, in test_device_properties_and_defaults
    self.assertIsNotNone(pulse_backends[0].defaults())
AssertionError: unexpectedly None
```

### Verified locally
![image](https://user-images.githubusercontent.com/16404496/152329012-16763d64-1598-4551-8eac-61ebff71340a.png)
