### PR TITLE
Enabled disabled pylint rules pt.3

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -70,7 +70,7 @@ disable=arguments-renamed,              # TODO: investigate / re-enable
         bad-mcs-classmethod-argument,   # TODO: investigate / re-enable
         bad-continuation, bad-whitespace, # differences of opinion with black
         consider-using-f-string,        # TODO: investigate / re-enable
-        consider-using-with,            # TODO: investigate / re-enable
+        consider-using-with,            # unnecessary
         docstring-first-line-empty,     # TODO: investigate / re-enable
         duplicate-code,                 # too verbose
         fixme,                          # avoid that to do annotations show up as warnings
@@ -80,7 +80,7 @@ disable=arguments-renamed,              # TODO: investigate / re-enable
         no-member,                      # TODO: investigate / re-enable
         no-self-use,                    # too verbose
         protected-access,               # we don't strictly follow the public vs. private convention
-        raise-missing-from,             # TODO: investigate / re-enable
+        raise-missing-from,             # unnecessary
         super-with-arguments,           # TODO: investigate / re-enable
         too-few-public-methods,         # too verbose
         too-many-ancestors,             # too verbose

--- a/.pylintrc
+++ b/.pylintrc
@@ -93,7 +93,6 @@ disable=arguments-renamed,              # TODO: investigate / re-enable
         too-many-public-methods,        # too verbose
         too-many-statements,            # too verbose
         unnecessary-pass,               # allow for methods with just "pass", for clarity
-        unspecified-encoding,           # TODO: investigate / re-enable
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -70,7 +70,7 @@ disable=arguments-renamed,              # TODO: investigate / re-enable
         bad-mcs-classmethod-argument,   # TODO: investigate / re-enable
         bad-continuation, bad-whitespace, # differences of opinion with black
         consider-using-f-string,        # TODO: investigate / re-enable
-        consider-using-with,            # unnecessary
+        consider-using-with,            # too verbose, not all resource-allocating operations should have `with`
         docstring-first-line-empty,     # TODO: investigate / re-enable
         duplicate-code,                 # too verbose
         fixme,                          # avoid that to do annotations show up as warnings
@@ -80,7 +80,7 @@ disable=arguments-renamed,              # TODO: investigate / re-enable
         no-member,                      # TODO: investigate / re-enable
         no-self-use,                    # too verbose
         protected-access,               # we don't strictly follow the public vs. private convention
-        raise-missing-from,             # unnecessary
+        raise-missing-from,             # not every exception needs `from`, adding `from None` is too verbose
         super-with-arguments,           # TODO: investigate / re-enable
         too-few-public-methods,         # too verbose
         too-many-ancestors,             # too verbose

--- a/qiskit_ibm_runtime/accounts/storage.py
+++ b/qiskit_ibm_runtime/accounts/storage.py
@@ -26,7 +26,7 @@ def save_config(filename: str, name: str, config: dict, overwrite: bool) -> None
     logger.debug("Save configuration data for '%s' in '%s'", name, filename)
     _ensure_file_exists(filename)
 
-    with open(filename, mode="r") as json_in:
+    with open(filename, mode="r", encoding='utf-8') as json_in:
         data = json.load(json_in)
 
     if data.get(name) and not overwrite:
@@ -35,7 +35,7 @@ def save_config(filename: str, name: str, config: dict, overwrite: bool) -> None
             f"Set overwrite=True to overwrite."
         )
 
-    with open(filename, mode="w") as json_out:
+    with open(filename, mode="w", encoding='utf-8') as json_out:
         data[name] = config
         json.dump(data, json_out, sort_keys=True, indent=4)
 
@@ -48,7 +48,7 @@ def read_config(
     logger.debug("Read configuration data for '%s' from '%s'", name, filename)
     _ensure_file_exists(filename)
 
-    with open(filename) as json_file:
+    with open(filename, encoding='utf-8') as json_file:
         data = json.load(json_file)
         if name is None:
             return data
@@ -67,11 +67,11 @@ def delete_config(
     logger.debug("Delete configuration data for '%s' from '%s'", name, filename)
 
     _ensure_file_exists(filename)
-    with open(filename, mode="r") as json_in:
+    with open(filename, mode="r", encoding='utf-8') as json_in:
         data = json.load(json_in)
 
     if name in data:
-        with open(filename, mode="w") as json_out:
+        with open(filename, mode="w", encoding='utf-8') as json_out:
             del data[name]
             json.dump(data, json_out, sort_keys=True, indent=4)
             return True
@@ -87,5 +87,5 @@ def _ensure_file_exists(filename: str, initial_content: str = "{}") -> None:
         os.makedirs(os.path.dirname(filename), exist_ok=True)
 
         # initialize file
-        with open(filename, mode="w") as json_file:
+        with open(filename, mode="w", encoding='utf-8') as json_file:
             json_file.write(initial_content)

--- a/qiskit_ibm_runtime/accounts/storage.py
+++ b/qiskit_ibm_runtime/accounts/storage.py
@@ -26,7 +26,7 @@ def save_config(filename: str, name: str, config: dict, overwrite: bool) -> None
     logger.debug("Save configuration data for '%s' in '%s'", name, filename)
     _ensure_file_exists(filename)
 
-    with open(filename, mode="r", encoding='utf-8') as json_in:
+    with open(filename, mode="r", encoding="utf-8") as json_in:
         data = json.load(json_in)
 
     if data.get(name) and not overwrite:
@@ -35,7 +35,7 @@ def save_config(filename: str, name: str, config: dict, overwrite: bool) -> None
             f"Set overwrite=True to overwrite."
         )
 
-    with open(filename, mode="w", encoding='utf-8') as json_out:
+    with open(filename, mode="w", encoding="utf-8") as json_out:
         data[name] = config
         json.dump(data, json_out, sort_keys=True, indent=4)
 
@@ -48,7 +48,7 @@ def read_config(
     logger.debug("Read configuration data for '%s' from '%s'", name, filename)
     _ensure_file_exists(filename)
 
-    with open(filename, encoding='utf-8') as json_file:
+    with open(filename, encoding="utf-8") as json_file:
         data = json.load(json_file)
         if name is None:
             return data
@@ -67,11 +67,11 @@ def delete_config(
     logger.debug("Delete configuration data for '%s' from '%s'", name, filename)
 
     _ensure_file_exists(filename)
-    with open(filename, mode="r", encoding='utf-8') as json_in:
+    with open(filename, mode="r", encoding="utf-8") as json_in:
         data = json.load(json_in)
 
     if name in data:
-        with open(filename, mode="w", encoding='utf-8') as json_out:
+        with open(filename, mode="w", encoding="utf-8") as json_out:
             del data[name]
             json.dump(data, json_out, sort_keys=True, indent=4)
             return True
@@ -87,5 +87,5 @@ def _ensure_file_exists(filename: str, initial_content: str = "{}") -> None:
         os.makedirs(os.path.dirname(filename), exist_ok=True)
 
         # initialize file
-        with open(filename, mode="w", encoding='utf-8') as json_file:
+        with open(filename, mode="w", encoding="utf-8") as json_file:
             json_file.write(initial_content)

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -916,7 +916,7 @@ class IBMRuntimeService:
 
         if "def main(" not in data:
             # This is the program file
-            with open(data, "r") as file:
+            with open(data, "r", encoding='utf-8') as file:
                 data = file.read()
 
         try:
@@ -948,7 +948,7 @@ class IBMRuntimeService:
         upd_metadata: dict = {}
         if metadata is not None:
             if isinstance(metadata, str):
-                with open(metadata, "r") as file:
+                with open(metadata, "r", encoding='utf-8') as file:
                     upd_metadata = json.load(file)
             else:
                 upd_metadata = metadata
@@ -1004,7 +1004,7 @@ class IBMRuntimeService:
         if data:
             if "def main(" not in data:
                 # This is the program file
-                with open(data, "r") as file:
+                with open(data, "r", encoding='utf-8') as file:
                     data = file.read()
             data = to_base64_string(data)
 

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -916,7 +916,7 @@ class IBMRuntimeService:
 
         if "def main(" not in data:
             # This is the program file
-            with open(data, "r", encoding='utf-8') as file:
+            with open(data, "r", encoding="utf-8") as file:
                 data = file.read()
 
         try:
@@ -948,7 +948,7 @@ class IBMRuntimeService:
         upd_metadata: dict = {}
         if metadata is not None:
             if isinstance(metadata, str):
-                with open(metadata, "r", encoding='utf-8') as file:
+                with open(metadata, "r", encoding="utf-8") as file:
                     upd_metadata = json.load(file)
             else:
                 upd_metadata = metadata
@@ -1004,7 +1004,7 @@ class IBMRuntimeService:
         if data:
             if "def main(" not in data:
                 # This is the program file
-                with open(data, "r", encoding='utf-8') as file:
+                with open(data, "r", encoding="utf-8") as file:
                     data = file.read()
             data = to_base64_string(data)
 

--- a/qiskit_ibm_runtime/version.py
+++ b/qiskit_ibm_runtime/version.py
@@ -60,7 +60,7 @@ def git_version() -> str:
     return git_revision
 
 
-with open(os.path.join(ROOT_DIR, "VERSION.txt"), "r") as version_file:
+with open(os.path.join(ROOT_DIR, "VERSION.txt"), "r", encoding='utf-8') as version_file:
     VERSION = version_file.read().strip()
 
 

--- a/qiskit_ibm_runtime/version.py
+++ b/qiskit_ibm_runtime/version.py
@@ -60,7 +60,7 @@ def git_version() -> str:
     return git_revision
 
 
-with open(os.path.join(ROOT_DIR, "VERSION.txt"), "r", encoding='utf-8') as version_file:
+with open(os.path.join(ROOT_DIR, "VERSION.txt"), "r", encoding="utf-8") as version_file:
     VERSION = version_file.read().strip()
 
 

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -165,7 +165,7 @@ class TestLogger(IBMTestCase):
                 )
 
                 # Assert the messages were logged.
-                with open(temp_log_file.name) as file_:
+                with open(temp_log_file.name, encoding='utf-8') as file_:
                     content_as_str = file_.read()
 
                     # Check whether the appropriate substrings are in the file.

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -165,7 +165,7 @@ class TestLogger(IBMTestCase):
                 )
 
                 # Assert the messages were logged.
-                with open(temp_log_file.name, encoding='utf-8') as file_:
+                with open(temp_log_file.name, encoding="utf-8") as file_:
                     content_as_str = file_.read()
 
                     # Check whether the appropriate substrings are in the file.

--- a/test/test_tutorials.py
+++ b/test/test_tutorials.py
@@ -62,7 +62,7 @@ class TestTutorials(IBMTestCase, metaclass=TutorialsTestCaseMeta):
 
         # Open the notebook.
         file_path = os.path.dirname(os.path.abspath(filename))
-        with open(filename, encoding='utf-8') as file_:
+        with open(filename, encoding="utf-8") as file_:
             notebook = nbformat.read(file_, as_version=4)
 
         with warnings.catch_warnings():

--- a/test/test_tutorials.py
+++ b/test/test_tutorials.py
@@ -62,7 +62,7 @@ class TestTutorials(IBMTestCase, metaclass=TutorialsTestCaseMeta):
 
         # Open the notebook.
         file_path = os.path.dirname(os.path.abspath(filename))
-        with open(filename) as file_:
+        with open(filename, encoding='utf-8') as file_:
             notebook = nbformat.read(file_, as_version=4)
 
         with warnings.catch_warnings():


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Indifferent about the remaining rules, this PR takes care of:
`unspecified-encoding`
`consider-using-with`: should probably stay disabled - there are cases where using `with` is not necessarily beneficial 
`raise-missing-from`: not every exception needs `from`, and adding `from None` seems too verbose 

### Details and comments
Fixes part of #42 

