### PR TITLE
Fix last remaining issue in legacy-staging integration tests

### DIFF
--- a/test/test_integration_backend.py
+++ b/test/test_integration_backend.py
@@ -78,6 +78,8 @@ class TestIBMBackend(IBMIntegrationTestCase):
         with self.subTest(backend=backend.name()):
             if backend.configuration().simulator:
                 raise SkipTest("Skip since simulator does not have defaults.")
+            if not backend.configuration().open_pulse:
+                raise SkipTest("Skip for backends that do not support pulses.")
             self.assertIsNotNone(backend.defaults())
 
     def test_backend_configuration(self):


### PR DESCRIPTION
### Summary
See https://github.com/Qiskit/qiskit-ibm-runtime/runs/5061940445?check_suite_focus=true for details. Skip pulse test for backends on staging that do not support pulses.

```
FAIL: test_backend_pulse_defaults (test.test_integration_backend.TestIBMBackend) (backend='backend1')
Check the backend pulse defaults of each backend.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/test_integration_backend.py", line 81, in test_backend_pulse_defaults
    self.assertIsNotNone(backend.defaults())
AssertionError: unexpectedly None
```


### Details and comments
Stabilize legacy-staging integration tests

One more issue left... :)
<img width="1720" alt="image" src="https://user-images.githubusercontent.com/16404496/152532498-ad77b54e-f695-4576-9d12-bc80d8774539.png">
