### PR TITLE
Only report coverage metrics for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,18 +134,10 @@ jobs:
           pip install -c constraints.txt -e .
           pip install -U -c constraints.txt -r requirements-dev.txt
       - name: Run integration tests
-        run: make integration-test-coverage
-      - name: Report coverage to coveralls.io
-        uses: coverallsapp/github-action@1.1.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: integration-tests_${{ matrix.environment }}
-          parallel: true
-          path-to-lcov: coverage.lcov
+        run: make integration-test
   tests-finished:
-    if: ${{ always() }}
     name: Submit code coverage metrics
-    needs: [ unit-tests, integration-tests ]
+    needs: [ unit-tests ]
     runs-on: ubuntu-latest
     steps:
       - name: Notify coveralls.io that all parallel tests have finished

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,9 +47,4 @@ jobs:
           pip install -c constraints.txt -e .
           pip install -U -c constraints.txt -r requirements-dev.txt
       - name: Run e2e tests
-        run: make e2e-test-coverage
-      - name: Upload e2e test coverage report
-        uses: actions/upload-artifact@v2
-        with:
-          name: E2E test coverage report - ${{ matrix.environment }}
-          path: htmlcov
+        run: make e2e-test

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,9 +49,4 @@ jobs:
           pip install -c constraints.txt -e .
           pip install -U -c constraints.txt -r requirements-dev.txt
       - name: Run integration tests
-        run: make integration-test-coverage
-      - name: Upload integration test coverage report
-        uses: actions/upload-artifact@v2
-        with:
-          name: Integration test coverage report - ${{ matrix.environment }}
-          path: htmlcov
+        run: make integration-test

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,5 @@ unit-test-coverage:
 	coverage run -m unittest discover --verbose --top-level-directory . --start-directory test/unit
 	coverage lcov
 
-integration-test-coverage:
-	coverage run -m unittest discover --verbose --top-level-directory . --start-directory test/integration
-	coverage lcov
-
-e2e-test-coverage:
-	coverage run -m unittest discover --verbose --top-level-directory . --start-directory test/e2e
-	coverage lcov
-
 black:
 	black qiskit_ibm_runtime setup.py test docs/tutorials program_source


### PR DESCRIPTION
### Summary
Limit collection of coverage metrics to unit tests only.


### Details and comments
Agreed with team of key contributors (@rathishcholarajan, @kt474) that we we want to start with coverage metrics for unit tests only. 

This avoids that PR comments like [this](https://github.com/Qiskit/qiskit-ibm-runtime/pull/148#issuecomment-1040455772) report decreased test coverage (because we compare the aggregated coverage of unit tests & integration tests (run for push events) against the coverage for unit tests only (run for pull_request events).