### PR TITLE
Run e2e tests on a daily basis

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,8 @@
 
 name: E2E Tests
 on:
+  schedule:
+    - cron: '0 16 * * *'
   # allow everyone with write access to the repository to trigger the workflow run manually
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
### Summary
As of today the [E2E tests](https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/1852419954) only run when manually triggered. They all succeeded today and therefore I think we can enable them to run on a daily basis.

<img width="995" alt="image" src="https://user-images.githubusercontent.com/16404496/154253845-5bd09a3e-b339-4ddb-8985-01043ed97521.png">
