### PR TITLE
Final result is also streamed now along with interim results

### DIFF
--- a/docs/tutorials/02_introduction_legacy_runtime.ipynb
+++ b/docs/tutorials/02_introduction_legacy_runtime.ipynb
@@ -286,7 +286,7 @@
     "- `program_id`: ID of the program to run.\n",
     "- `inputs`: Program input parameters. These input values are passed to the runtime program.\n",
     "- `options`: Runtime options. These options control the execution environment. Currently the only available option is `backend_name`, which is required.\n",
-    "- `callback`: Callback function to be invoked for any interim results. The callback function will receive two positional parameters: job ID and interim result.\n",
+    "- `callback`: Callback function to be invoked for any interim results and final result. The callback function will receive two positional parameters: job ID and result.\n",
     "- `result_decoder`: Optional class used to decode the job result."
    ]
   },
@@ -295,9 +295,9 @@
    "id": "abe247c4",
    "metadata": {},
    "source": [
-    "Before we run a quantum program, we may want to define a callback function that would process interim results, which are intermediate data provided by a program while its still running. \n",
+    "Before we run a quantum program, we may want to define a callback function that would process interim results, which are intermediate data provided by a program while its still running and also the final result. \n",
     "\n",
-    "As we saw earlier, the metadata of `hello-world` says that its interim results are the iteration number and the counts of the randomly generated circuit. Here we define a simple callback function that just prints these interim results:"
+    "As we saw earlier, the metadata of `hello-world` says that its interim results are the iteration number and the counts of the randomly generated circuit. Here we define a simple callback function that just prints these results:"
    ]
   },
   {
@@ -307,8 +307,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def interim_result_callback(job_id, interim_result):\n",
-    "    print(f\"interim result: {interim_result}\")"
+    "def result_callback(job_id, result):\n",
+    "    print(f\"result: {result}\")"
    ]
   },
   {
@@ -330,9 +330,10 @@
      "output_type": "stream",
      "text": [
       "job id: c7f3i9a0jbtu2e0bc440\n",
-      "interim result: {'iteration': 0, 'counts': {'00000': 1024}}\n",
-      "interim result: {'iteration': 1, 'counts': {'01111': 119, '01101': 129, '00111': 381, '00101': 395}}\n",
-      "interim result: {'iteration': 2, 'counts': {'01001': 52, '00001': 44, '01000': 462, '00000': 466}}\n",
+      "result: {'iteration': 0, 'counts': {'00000': 1024}}\n",
+      "result: {'iteration': 1, 'counts': {'01111': 119, '01101': 129, '00111': 381, '00101': 395}}\n",
+      "result: {'iteration': 2, 'counts': {'01001': 52, '00001': 44, '01000': 462, '00000': 466}}\n",
+      "result: All done!\n",
       "All done!\n"
      ]
     }
@@ -348,13 +349,13 @@
     "    program_id=\"hello-world\",\n",
     "    options=options,\n",
     "    inputs=program_inputs,\n",
-    "    callback=interim_result_callback,\n",
+    "    callback=result_callback,\n",
     ")\n",
     "\n",
     "# Printing the job ID in case we need to retrieve it later.\n",
     "print(f\"job id: {job.job_id}\")\n",
     "\n",
-    "# Get the job result - this is blocking this is blocking and control may not return immediately.\n",
+    "# Get the job result - this is blocking and control may not return immediately.\n",
     "result = job.result()\n",
     "print(result)"
    ]
@@ -397,7 +398,7 @@
     "- `result()`: Wait for the job to finish and return the final result.\n",
     "- `cancel()`: Cancel the job.\n",
     "- `wait_for_final_state()`: Wait for the job to finish.\n",
-    "- `stream_results()`: Stream interim results. This can be used to start streaming the interim results if a `callback` function was not passed to the `run()` method. This method can also be used to reconnect a lost websocket connection.\n",
+    "- `stream_results()`: Stream interim results and final result. This can be used to start streaming the results if a `callback` function was not passed to the `run()` method. This method can also be used to reconnect a lost websocket connection.\n",
     "- `logs()`: Return job logs.\n",
     "- `error_message()`: Returns the reason if the job failed and `None` otherwise.\n",
     "\n",

--- a/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
+++ b/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
@@ -868,9 +868,9 @@
    "id": "917857da",
    "metadata": {},
    "source": [
-    "### Listening for interim results\n",
+    "### Listening for interim results and final result\n",
     "\n",
-    "To listen for interm results we need to pass a callback function to `service.run` that stores the results.  The callback takes two arguments `job_id` and the returned data:"
+    "To listen for interm results and final result we need to pass a callback function to `service.run` that stores the results.  The callback takes two arguments `job_id` and the returned data:"
    ]
   },
   {

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -113,11 +113,11 @@ program, a
 methods, such as :meth:`RuntimeJob.status`, :meth:`RuntimeJob.result`, and
 :meth:`RuntimeJob.cancel`.
 
-Interim results
----------------
+Interim and final results
+-------------------------
 
 Some runtime programs provide interim results that inform you about program
-progress. You can choose to stream the interim results when you run the
+progress. You can choose to stream the interim results and final result when you run the
 program by passing in the ``callback`` parameter, or at a later time using
 the :meth:`RuntimeJob.stream_results` method. For example::
 
@@ -127,14 +127,14 @@ the :meth:`RuntimeJob.stream_results` method. For example::
     service = IBMRuntimeService()
     backend = "ibmq_qasm_simulator"
 
-    def interim_result_callback(job_id, interim_result):
-        print(interim_result)
+    def result_callback(job_id, result):
+        print(result)
 
-    # Stream interim results as soon as the job starts running.
+    # Stream results as soon as the job starts running.
     job = service.run(program_id="sampler",
                       options=options,
                       inputs=program_inputs,
-                      callback=interim_result_callback)
+                      callback=result_callback)
 
 Backend data
 ------------

--- a/qiskit_ibm_runtime/ibm_runtime_service.py
+++ b/qiskit_ibm_runtime/ibm_runtime_service.py
@@ -786,11 +786,11 @@ class IBMRuntimeService:
                 to the runtime program.
             options: Runtime options that control the execution environment. See
                 :class:`RuntimeOptions` for all available options.
-            callback: Callback function to be invoked for any interim results.
+            callback: Callback function to be invoked for any interim results and final result.
                 The callback function will receive 2 positional parameters:
 
                     1. Job ID
-                    2. Job interim result.
+                    2. Job result.
 
             result_decoder: A :class:`ResultDecoder` subclass used to decode job results.
                 ``ResultDecoder`` is used if not specified.

--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -66,7 +66,7 @@ class RuntimeJob:
     If the program has any interim results, you can use the ``callback``
     parameter of the
     :meth:`~qiskit_ibm_runtime.IBMRuntimeService.run`
-    method to stream the interim results.
+    method to stream the interim results along with the final result.
     Alternatively, you can use the :meth:`stream_results` method to stream
     the results at a later time, but before the job finishes.
     """
@@ -237,11 +237,11 @@ class RuntimeJob:
         """Start streaming job results.
 
         Args:
-            callback: Callback function to be invoked for any interim results.
+            callback: Callback function to be invoked for any interim results and final result.
                 The callback function will receive 2 positional parameters:
 
                     1. Job ID
-                    2. Job interim result.
+                    2. Job result.
 
             decoder: A :class:`ResultDecoder` subclass used to decode job results.
 
@@ -360,7 +360,7 @@ class RuntimeJob:
         user_callback: Callable,
         decoder: Optional[Type[ResultDecoder]] = None,
     ) -> None:
-        """Stream interim results.
+        """Stream results.
 
         Args:
             result_queue: Queue used to pass websocket messages.

--- a/releasenotes/notes/stream-results-6ff5f240bbe21fc0.yaml
+++ b/releasenotes/notes/stream-results-6ff5f240bbe21fc0.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Final result is also streamed now after interim results when you specify a ``callback``
+    to :meth:`qiskit_ibm_runtime.IBMRuntimeService.run` or
+    :meth:`qiskit_ibm_runtime.RuntimeJob.stream_results`.

--- a/test/integration/test_interim_results.py
+++ b/test/integration/test_interim_results.py
@@ -57,14 +57,14 @@ class TestIntegrationInterimResults(IBMIntegrationJobTestCase):
     def test_stream_results(self, service):
         """Test stream_results method."""
 
-        def result_callback(job_id, interim_result):
+        def result_callback(job_id, result):
             nonlocal final_it
-            final_it = interim_result["iteration"]
+            final_it = result["iteration"]
             nonlocal callback_err
             if job_id != job.job_id:
                 callback_err.append(f"Unexpected job ID: {job_id}")
-            if interim_result["interim_results"] != int_res:
-                callback_err.append(f"Unexpected interim result: {interim_result}")
+            if result["interim_results"] != int_res:
+                callback_err.append(f"Unexpected interim result: {result}")
 
         int_res = "bar"
         final_it = 0
@@ -79,7 +79,7 @@ class TestIntegrationInterimResults(IBMIntegrationJobTestCase):
 
     @run_integration_test
     def test_stream_results_done(self, service):
-        """Test streaming interim results after job is done."""
+        """Test streaming results after job is done."""
 
         def result_callback(job_id, interim_result):
             # pylint: disable=unused-argument

--- a/test/unit/test_runtime_ws.py
+++ b/test/unit/test_runtime_ws.py
@@ -68,9 +68,9 @@ class TestRuntimeWebsocketClient(IBMTestCase):
     def test_stream_results(self):
         """Test streaming results."""
 
-        def result_callback(job_id, interim_result):
+        def result_callback(job_id, result):
             nonlocal results
-            results.append(interim_result)
+            results.append(result)
             self.assertEqual(JOB_ID_PROGRESS_DONE, job_id)
 
         results = []


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Final result is also streamed now after interim results when you specify a ``callback``
to `qiskit_ibm_runtime.IBMRuntimeService.run` or `qiskit_ibm_runtime.RuntimeJob.stream_results` methods.


### Details and comments
Fixes #146

