### PR TITLE
Fix branding

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,6 +21,6 @@ assignees: ''
 
 **Additional Information**
 
-- **Qiskit IBM Runtime version**:
+- **qiskit-ibm-runtime version**:
 - **Python version**:
 - **Operating system**:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,6 @@ assignees: ''
 
 **Additional Information**
 
-- **Qiskit IBM Runtime version**:
+- **qiskit-ibm-runtime version**:
 - **Python version**:
 - **Operating system**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ included in the qiskit documentation:
 https://qiskit.org/documentation/contributing_to_qiskit.html
 
 
-Contributing to Qiskit IBM Runtime
----------------------------
+Contributing to qiskit-ibm-runtime
+-----------------------------------
 
 In addition to the general guidelines there are specific details for
-contributing to the Qiskit IBM Runtime, these are documented below.
+contributing to qiskit-ibm-runtime, these are documented below.
 
 ### Pull request checklist
 
@@ -245,8 +245,8 @@ QISKIT_IBM_INSTANCE=crn:v1:bluemix:...                          # The CRN value 
 ```
 
 
-To enable test cases against external system in your private fork, make sure to set above values as 
-[encrypted environment secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment). 
+To enable test cases against external system in your private fork, make sure to set above values as
+[encrypted environment secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment).
 The names of the environments must match the ones that the [CI workflow](.github/workflows/ci.yml) relies
 upon.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Qiskit IBM Runtime
+# Qiskit Runtime IBM Quantum Client
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-ibm-runtime.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)[![CI](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/ci.yml/badge.svg)](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/ci.yml)[![](https://img.shields.io/github/release/Qiskit/qiskit-ibm-runtime.svg?style=popout-square)](https://github.com/Qiskit/qiskit-ibm-runtime/releases)[![](https://img.shields.io/pypi/dm/qiskit-ibm-runtime.svg?style=popout-square)](https://pypi.org/project/qiskit-ibm-runtime/)[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)[![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-ibm-runtime/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-ibm-runtime?branch=main)
 
 
@@ -7,13 +7,13 @@
 **Qiskit Runtime** is a new architecture offered by IBM Quantum that streamlines quantum computations.
 It is designed to use classical compute resources to execute quantum circuits with more efficiency on quantum processors.
 
-Using Qiskit Runtime, for example, a research team at IBM Quantum was able to achieve 120x speed 
-up in their lithium hydride simulation. For more information, see the 
+Using Qiskit Runtime, for example, a research team at IBM Quantum was able to achieve 120x speed
+up in their lithium hydride simulation. For more information, see the
 [IBM Research blog](https://research.ibm.com/blog/120x-quantum-speedup).
 
-Qiskit Runtime allows authorized users to upload quantum programs. A quantum program, also called a 
+Qiskit Runtime allows authorized users to upload quantum programs. A quantum program, also called a
 Qiskit runtime program, is a piece of Python code that takes certain inputs, performs
-quantum and classical computation, and returns the processing results. The users can then 
+quantum and classical computation, and returns the processing results. The users can then
 invoke these quantum programs by simply passing in the required input parameters.
 
 This module provides the interface to access Qiskit Runtime.
@@ -26,19 +26,19 @@ You can install this package using pip:
 pip install qiskit-ibm-runtime
 ```
 
-## Account Setup 
+## Account Setup
 
 ### Qiskit Runtime on IBM Cloud
 
-Qiskit Runtime is now part of the IBM Quantum Services on IBM Cloud. To use this service, you'll 
-need to create an IBM Cloud account and a quantum service instance. 
-[This guide](https://cloud.ibm.com/docs/quantum-computing?topic=quantum-computing-gettingstarted) 
-contains step-by-step instructions on setting this up, including directions to find your 
+Qiskit Runtime is now part of the IBM Quantum Services on IBM Cloud. To use this service, you'll
+need to create an IBM Cloud account and a quantum service instance.
+[This guide](https://cloud.ibm.com/docs/quantum-computing?topic=quantum-computing-gettingstarted)
+contains step-by-step instructions on setting this up, including directions to find your
 IBM Cloud API key and Cloud Resource Name (CRN), which you will need for authentication.
 
 ### Qiskit Runtime on IBM Quantum
 
-Prior to becoming an IBM Cloud service, Qiskit Runtime was offered on IBM Quantum. If you have an 
+Prior to becoming an IBM Cloud service, Qiskit Runtime was offered on IBM Quantum. If you have an
 existing IBM Quantum account, you can continue using Qiskit Runtime on IBM Quantum, which is referred to as legacy runtime.
 
 You will need your IBM Quantum API token to authenticate with the Qiskit Runtime service:
@@ -47,8 +47,8 @@ You will need your IBM Quantum API token to authenticate with the Qiskit Runtime
 
 1. Copy (and optionally regenerate) your API token from your
    [IBM Quantum account page].
-   
-### Saving Account on Disk   
+
+### Saving Account on Disk
 
 Once you have the account credentials, you can save them on disk, so you won't have to input
 them each time. The credentials are saved in the `$HOME/.qiskit/qiskit-ibm.json` file, where `$HOME` is your home directory.
@@ -59,7 +59,7 @@ them each time. The credentials are saved in the `$HOME/.qiskit/qiskit-ibm.json`
  ```python
 from qiskit_ibm_runtime import IBMRuntimeService
 
-# Save an IBM Cloud account.    
+# Save an IBM Cloud account.
 IBMRuntimeService.save_account(auth="cloud", token="MY_IBM_CLOUD_API_KEY", instance="MY_IBM_CLOUD_CRN")
 
 # Save an IBM Quantum account.
@@ -89,7 +89,7 @@ service = IBMRuntimeService()
 
 ### Enabling Account for Current Session
 
-As another alternative, you can also enable an account just for the current session by instantiating the 
+As another alternative, you can also enable an account just for the current session by instantiating the
 service with your credentials.
 
 ```python
@@ -114,10 +114,10 @@ service = IBMRuntimeService()
 service.pprint_programs()
 ```
 
-`pprint_programs()` prints the summary metadata of the first 20 programs visible to you. A program's metadata 
-consists of its ID, name, description, input parameters, return values, interim results, and 
+`pprint_programs()` prints the summary metadata of the first 20 programs visible to you. A program's metadata
+consists of its ID, name, description, input parameters, return values, interim results, and
 other information that helps you to know more about the program. `pprint_programs(detailed=True, limit=None)`
-will print all metadata for all programs visible to you. 
+will print all metadata for all programs visible to you.
 
 ### Executing a Program
 
@@ -144,8 +144,8 @@ result = job.result()
 
 A **backend** is a quantum device or simulator capable of running quantum circuits or pulse schedules.
 
-You can query for the backends you have access to. Attributes and methods of the returned instances 
-provide information, such as qubit counts, error rates, and statuses, of the backends. 
+You can query for the backends you have access to. Attributes and methods of the returned instances
+provide information, such as qubit counts, error rates, and statuses, of the backends.
 
 ```python
 from qiskit_ibm_runtime import IBMRuntimeService
@@ -164,7 +164,7 @@ Now you're set up and ready to check out some of the [tutorials].
 
 ## Contribution Guidelines
 
-If you'd like to contribute to Qiskit IBM Runtime, please take a look at our
+If you'd like to contribute to qiskit-ibm-runtime, please take a look at our
 [contribution guidelines]. This project adheres to Qiskit's [code of conduct].
 By participating, you are expected to uphold to this code.
 

--- a/docs/apidocs/ibm-runtime.rst
+++ b/docs/apidocs/ibm-runtime.rst
@@ -1,5 +1,5 @@
 *****************************************
-Qiskit IBM Runtime API Reference
+qiskit-ibm-runtime API Reference
 *****************************************
 
 .. toctree::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,8 +39,8 @@ import os
 os.environ['QISKIT_DOCS'] = 'TRUE'
 
 # -- Project information -----------------------------------------------------
-project = 'Qiskit IBM Runtime'
-copyright = '2021, Qiskit Development Team'  # pylint: disable=redefined-builtin
+project = 'Qiskit Runtime IBM Quantum Client'
+copyright = '2022, Qiskit Development Team'  # pylint: disable=redefined-builtin
 author = 'Qiskit Development Team'
 
 # The short X.Y version

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 #########################################
-Qiskit IBM Runtime documentation
+Qiskit Runtime documentation
 #########################################
 
 Qiskit Runtime
@@ -35,8 +35,8 @@ Eventually, you will be able to call primitives from a generic program definitio
 primitive program interface that best suits your output needs to run circuits seamlessly and efficiently
 on IBM quantum systems.
 
-Qiskit IBM Runtime
-==================
+Qiskit Runtime IBM Quantum Client
+=================================
 
 ``qiskit-ibm-runtime`` provides the interface to interact with Qiskit Runtime. You can, for example,
 use it to query and execute runtime programs:

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -17,13 +17,13 @@ Qiskit Runtime (:mod:`qiskit_ibm_runtime`)
 
 .. currentmodule:: qiskit_ibm_runtime
 
-Modules related to Qiskit IBM Runtime Service.
+Modules related to Qiskit Runtime IBM Quantum Client.
 
 Qiskit Runtime is a new architecture that
 streamlines computations requiring many iterations. These experiments will
 execute significantly faster within its improved hybrid quantum/classical process.
 
-The Qiskit Runtime Service allows authorized users to upload their Qiskit quantum programs.
+Qiskit Runtime IBM Quantum Client allows authorized users to upload their Qiskit quantum programs.
 A Qiskit quantum program, also called a runtime program, is a piece of Python
 code and its metadata that takes certain inputs, performs
 quantum and maybe classical processing, and returns the results. The same or other
@@ -192,7 +192,7 @@ Files related to writing a runtime program are in the
 Logging
 -------
 
-Qiskit IBM Runtime Service uses the ``qiskit_ibm_runtime`` logger.
+`qiskit-ibm-runtime` uses the ``qiskit_ibm_runtime`` logger.
 
 Two environment variables can be used to control the logging:
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,7 @@ with open(README_PATH) as readme_file:
 setuptools.setup(
     name="qiskit-ibm-runtime",
     version=VERSION,
-    description="Qiskit IBM Runtime service for accessing the quantum devices and "
-    "simulators at IBM",
+    description="IBM Quantum client for Qiskit Runtime.",
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/Qiskit/qiskit-ibm-runtime",

--- a/test/ibm_test_case.py
+++ b/test/ibm_test_case.py
@@ -29,7 +29,7 @@ from .templates import RUNTIME_PROGRAM, RUNTIME_PROGRAM_METADATA, PROGRAM_PREFIX
 
 
 class IBMTestCase(unittest.TestCase):
-    """Custom TestCase for use with the Qiskit IBM Runtime."""
+    """Custom TestCase for use with qiskit-ibm-runtime."""
 
     @classmethod
     def setUpClass(cls):
@@ -64,7 +64,7 @@ class IBMTestCase(unittest.TestCase):
 
 
 class IBMIntegrationTestCase(IBMTestCase):
-    """Custom integration test case for use with the Qiskit IBM Runtime."""
+    """Custom integration test case for use with qiskit-ibm-runtime."""
 
     @classmethod
     @integration_test_setup()


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#### Qiskit Runtime
1. For repo names we stick with the pattern (since we have already suggested this to partners):
```
# IBM
qiskit-ibm-runtime

# Other Partners
qiskit-dell-runtime
qiskit-ionq-runtime
qiskit-aqt-runtime
```

2. For usage as title in README/Documentation:
```
# IBM
Qiskit Runtime IBM Quantum Client

# Other Partners
Qiskit Runtime Dell Client
Qiskit Runtime IonQ Client
Qiskit Runtime AQT Client
```

3. For usage as description:
```
# IBM
IBM Quantum Client for Qiskit Runtime

# Other Partners
Dell Client for Qiskit Runtime
IonQ Client for Qiskit Runtime
AQT Client for Qiskit Runtime
```

Note: These are called `Client` and not `Provider` because they don't implement the Qiskit `Provider` interface.

4. A `Client` uses a `Service` class to connect to the API. Ex: `IBMRuntimeService`.
```
from qiskit_ibm_runtime import IBMRuntimeService
```
Similarly we could have `DellRuntimeService`, `IonQRuntimeService` or `AQTRuntimeService`. (If you are thinking of adding Qiskit or Quantum to the class name it just makes it too long, since we are importing from `qiskit_*` we don't have to repeat that)

### For other projects:
#### Qiskit Experiments
1. Repo name: `qiskit-ibm-experiment`
2. Usage as Title in README/Documentation: `Qiskit Experiments IBM Quantum Client`
3. Usage as Description: `IBM Quantum Client for Qiskit Experiments`
4. Service class name: `IBMExperimentService`

#### Providers
Any packages that implement the Qiskit `Provider` interface can be called as `Providers` (a special type of `Client`). These are generally legacy interfaces and they don't necessarily have to align with the new patterns as explained above.
1. Repo name: `qiskit-ibm-provider`
2. Usage as Title in README/Documentation: `Qiskit IBM Quantum Provider`
3. Usage as Description: `Qiskit IBM Quantum Provider`
4. Provider class name: `IBMProvider`