### PR TITLE
Set an explicit branch on release notes directive

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,1 +1,2 @@
 .. release-notes:: Release Notes
+   :branch: main


### PR DESCRIPTION


<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit sets an explicit branch on the reno directive for the docs
build. Without this for the first 0.1.0 release the reno history search
is incorrectly treating the stable/0.1 branch as the origin point for
the history and it is not finding any of the release notes for 0.1
because it's not before the branch point of the stable branch. To fix
workaround this issue, this commit explicitly sets the branch to use for
the release notes to main, this will work only for docs builds on main
as it might have unintended consequences for stable patch releases. We
might need to revert this if/when a 0.1.1 release goes out to ensure the
history scan finds stable branch release notes.

### Details and comments