### PR TITLE
Fix target acquire alignment typo

### DIFF
--- a/qiskit_ibm_runtime/utils/backend_converter.py
+++ b/qiskit_ibm_runtime/utils/backend_converter.py
@@ -106,7 +106,7 @@ def convert_to_target(
         target.granularity = configuration.timing_constraints.get("granularity")
         target.min_length = configuration.timing_constraints.get("min_length")
         target.pulse_alignment = configuration.timing_constraints.get("pulse_alignment")
-        target.aquire_alignment = configuration.timing_constraints.get(
+        target.acquire_alignment = configuration.timing_constraints.get(
             "acquire_alignment"
         )
     # If pulse defaults exists use that as the source of truth

--- a/releasenotes/notes/fix-target-acquire-alignment-typo-883ed510c83139be.yaml
+++ b/releasenotes/notes/fix-target-acquire-alignment-typo-883ed510c83139be.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the typo for :attr:`Target.acquire_alignment` in `.utils.backend_converter.convert_to_target`.
+    This is a follow up fix of a [related PR](https://github.com/Qiskit/qiskit-terra/pull/7734) in
+    qiskit-terra. Previsouly it followed the mispelling `aquire_alignment` in qiskit-terra.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes the typo of target.acquire_alignment attribute in the `utils.backend_converter.py`. It followed the same misspelling in terra which I also submitted a PR to fix. 

### Details and comments
Related Terra PR: https://github.com/Qiskit/qiskit-terra/pull/7734

