### PR TITLE
Update wait for final state

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -228,7 +228,8 @@ class RuntimeJob:
         """
         if self._status not in JOB_FINAL_STATES and not self._is_streaming():
             self._ws_client_future = self._executor.submit(self._start_websocket_client)
-        self._ws_client_future.result(timeout)
+        if self._is_streaming():
+            self._ws_client_future.result(timeout)
         self.status()
 
     def stream_results(


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If a job is already finished, calling `wait_for_final_state` will result in NoneType error. We should only use the websocket server to wait for the final states if the results are still streaming. 

### Details and comments
Fixes #

