### PR TITLE
Fix error when just one QuantumCircuit is passed to primitives

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -54,7 +54,7 @@ class Estimator(BaseEstimator):
                 selected automatically on IBM Cloud only).
         """
         super().__init__(
-            circuits=circuits,
+            circuits=circuits if isinstance(circuits, Iterable) else [circuits],
             observables=observables,
             parameters=parameters,
         )

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -50,7 +50,7 @@ class Sampler(BaseSampler):
                 selected automatically on IBM Cloud only).
         """
         super().__init__(
-            circuits=circuits,
+            circuits=circuits if isinstance(circuits, Iterable) else [circuits],
             parameters=parameters,
         )
         self._skip_transpilation = skip_transpilation

--- a/releasenotes/notes/fix-error-single-circuit-89a0e7b64deedbaa.yaml
+++ b/releasenotes/notes/fix-error-single-circuit-89a0e7b64deedbaa.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed `#291 <https://github.com/Qiskit/qiskit-ibm-runtime/issues/219>`__
+    where passing a single ``QuantumCircuit`` to sampler or estimator primitives
+    was throwing an error.

--- a/test/integration/test_ibm_sampler.py
+++ b/test/integration/test_ibm_sampler.py
@@ -37,7 +37,7 @@ class TestIntegrationIBMSampler(IBMIntegrationTestCase):
         bell.measure_all()
 
         # executes a Bell circuit
-        with sampler_factory(circuits=[bell]) as sampler:
+        with sampler_factory(circuits=bell) as sampler:
             self.assertIsInstance(sampler, BaseSampler)
 
             circuit_indices = [0]


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix error when just one QuantumCircuit is passed to primitives

I will be authoring unit tests for most of the scenarios as a separate task and hence don't want to cover this scenario in integration test for estimator.

### Details and comments
Fixes #219 

