### PR TITLE
Update black to fix issue with click

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ nbconvert>=5.3.1
 qiskit-aer
 websockets>=8
 scikit-quant;platform_system != 'Windows'
-black==22.1.0
+black==22.3.0
 coverage>=6.3
 pylatexenc
 mthree


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
click 8.1.0 released breaking changes and black 22.3.0 adapts to those breaking changes.

Fixes below build issue.
```
black --check qiskit_ibm_runtime setup.py test docs/tutorials program_source
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.10/x64/bin/black", line [8](https://github.com/Qiskit/qiskit-ibm-runtime/runs/5737839698?check_suite_focus=true#step:5:8), in <module>
    sys.exit(patched_main())
  File "src/black/__init__.py", line 1423, in patched_main
  File "src/black/__init__.py", line 140[9](https://github.com/Qiskit/qiskit-ibm-runtime/runs/5737839698?check_suite_focus=true#step:5:9), in patch_click
ImportError: cannot import name '_unicodefun' from 'click' (/opt/hostedtoolcache/Python/3.9.[10](https://github.com/Qiskit/qiskit-ibm-runtime/runs/5737839698?check_suite_focus=true#step:5:10)/x64/lib/python3.9/site-packages/click/__init__.py)
make: *** [Makefile:24: style] Error 1
```


### Details and comments
Fixes #

