### PR TITLE
Fix how-to guide bullet points

### DIFF
--- a/docs/tutorials/how-to-getting-started-with-estimator.ipynb
+++ b/docs/tutorials/how-to-getting-started-with-estimator.ipynb
@@ -32,11 +32,11 @@
     "### Specify program inputs\n",
     "\n",
     "The Estimator takes in:\n",
-    "* The **circuits** you want to investigate.\n",
-    "* The **parameters** input to evaluate the circuits.\n",
-    "* The **observables** (Hamiltonians) to be evaluated.\n",
-    "* Optional: The **backend** to run on. If one is not specified, the least busy backend is used.\n",
-    "* Optional: The instruction to **skip_transpilation**.\n",
+    "- The **circuits** you want to investigate.\n",
+    "- The **parameters** input to evaluate the circuits.\n",
+    "- The **observables** (Hamiltonians) to be evaluated.\n",
+    "- Optional: The **backend** to run on. If one is not specified, the least busy backend is used.\n",
+    "- Optional: The instruction to **skip_transpilation**.\n",
     "\n",
     "Example:"
    ]
@@ -160,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/how-to-getting-started-with-estimator.ipynb
+++ b/docs/tutorials/how-to-getting-started-with-estimator.ipynb
@@ -32,6 +32,7 @@
     "### Specify program inputs\n",
     "\n",
     "The Estimator takes in:\n",
+    "\n",
     "- The **circuits** you want to investigate.\n",
     "- The **parameters** input to evaluate the circuits.\n",
     "- The **observables** (Hamiltonians) to be evaluated.\n",

--- a/docs/tutorials/how-to-getting-started-with-sampler.ipynb
+++ b/docs/tutorials/how-to-getting-started-with-sampler.ipynb
@@ -29,6 +29,7 @@
     "### Specify program inputs\n",
     "\n",
     "The Sampler takes in:\n",
+    "\n",
     "- The **circuits** you want to investigate.\n",
     "- The **parameters** input to evaluate the circuits.\n",
     "- Optional: The **backend** to run on. If one is not specified, the least busy backend is used.\n",

--- a/docs/tutorials/how-to-getting-started-with-sampler.ipynb
+++ b/docs/tutorials/how-to-getting-started-with-sampler.ipynb
@@ -29,10 +29,10 @@
     "### Specify program inputs\n",
     "\n",
     "The Sampler takes in:\n",
-    "* The **circuits** you want to investigate.\n",
-    "* The **parameters** input to evaluate the circuits.\n",
-    "* Optional: The **backend** to run on. If one is not specified, the least busy backend is used.\n",
-    "* Optional: The instruction to **skip_transpilation**.\n",
+    "- The **circuits** you want to investigate.\n",
+    "- The **parameters** input to evaluate the circuits.\n",
+    "- Optional: The **backend** to run on. If one is not specified, the least busy backend is used.\n",
+    "- Optional: The instruction to **skip_transpilation**.\n",
     "\n",
     "Example:"
    ]
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The bullet points under [Specify program inputs](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/tutorials/how-to-getting-started-with-estimator.html#Specify-program-inputs) in the two how-to guides are not rendered correctly.

This is possibly due to the bullet points are created by `*` instead of `-` in markdown. This PR replace `*` with `-` in an attempt to fix it. I need to build the website locally to verify this actually fixes the problem.

EDIT: The problem could be due to missing empty line before the bullets instead. I added that in the second commit. At least ReviewNB renders the bullet point correctly.

<img width="875" alt="image" src="https://user-images.githubusercontent.com/7631333/162945200-3b040668-6723-4a5f-92e7-d43505c9faa0.png">


### Details and comments
Fixes #

