### PR TITLE
Point tutorial links to stable branch instead of tag

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ nbsphinx_prolog = """
         __"""
 
 vers = release.split(".")
-link_str = f" https://github.com/Qiskit/qiskit-ibm-runtime/blob/{vers[0]}.{vers[1]}/docs/"
+link_str = f" https://github.com/Qiskit/qiskit-ibm-runtime/blob/stable/{vers[0]}.{vers[1]}/docs/"
 nbsphinx_prolog += link_str + "{{ docname }}"
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The github links at the top of tutorials right now points to the tutorials in a release tag. Docs are usually ready only after releasing the library. Once docs are ready the stable branch can be updated with the doc changes. This PR makes the tutorial links to point to the stable branch instead of the tag so that links are not broken anymore when docs are deployed to qiskit.org and updated in stable branch.

I have now updated stable/0.4 branch with the latest docs and tutorials.

### Details and comments
Fixes #286 

