### PR TITLE
Fix spelling of probabilities

### DIFF
--- a/docs/tutorials/sample_expval_program/qiskit_runtime_expval_program.ipynb
+++ b/docs/tutorials/sample_expval_program/qiskit_runtime_expval_program.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "### Expectation value of a diagonal operator\n",
     "\n",
-    "Consider a generic observable given by the tensor product of diagonal operators over $N$ qubits  $O = O_{N-1}\\dots O_{0}$ where the subscript indicates the qubit on which the operator acts.  Then for a set of observed $M$ bitstrings $\\{b_{0}, \\dots b_{M-1}\\}$, where $M \\leq 2^N $, with corresponding approximate probabilites $p_{m}$ the expectation value is given by\n",
+    "Consider a generic observable given by the tensor product of diagonal operators over $N$ qubits  $O = O_{N-1}\\dots O_{0}$ where the subscript indicates the qubit on which the operator acts.  Then for a set of observed $M$ bitstrings $\\{b_{0}, \\dots b_{M-1}\\}$, where $M \\leq 2^N $, with corresponding approximate probabilities $p_{m}$ the expectation value is given by\n",
     "\n",
     "$$\n",
     "\\langle O\\rangle \\simeq \\sum_{m=0}^{M-1} p_{m}\\prod_{n=0}^{N-1}O_{n}[b_{m}[N-n-1], b_{m}[N-n-1]],\n",

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -59,7 +59,7 @@ class Sampler(BaseSampler):
             The default level is ``WARNING``.
 
     The returned instance can be called repeatedly with the following parameters to
-    calculate probabilites or quasi-probabilities.
+    calculate probabilities or quasi-probabilities.
 
     * circuit_indices: A list of circuit indices.
 
@@ -185,7 +185,7 @@ class Sampler(BaseSampler):
         ] = None,
         **run_options: Any,
     ) -> SamplerResult:
-        """Calculates probabilites or quasi-probabilities for given inputs in a runtime session.
+        """Calculates probabilities or quasi-probabilities for given inputs in a runtime session.
 
         Args:
             circuit_indices: A list of circuit indices.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes the spelling of probabilities in a few places (each case where this particular misspelling occurred).

### Details and comments

