### PR TITLE
Fix spelling of "interim" in the VQE sample program

### DIFF
--- a/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
+++ b/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
@@ -364,7 +364,7 @@
     "    # x0 and calls 'vqe_func' everytime the optimizer needs to evaluate the cost\n",
     "    # function.  The result is returned as a SciPy OptimizerResult object.\n",
     "    # Additionally, after every iteration, we use the 'callback' function to\n",
-    "    # publish the interm results back to the user. This is important to do\n",
+    "    # publish the interim results back to the user. This is important to do\n",
     "    # so that if the Program terminates unexpectedly, the user can start where they\n",
     "    # left off.\n",
     "\n",
@@ -870,7 +870,7 @@
    "source": [
     "### Listening for interim results and final result\n",
     "\n",
-    "To listen for interm results and final result we need to pass a callback function to `service.run` that stores the results.  The callback takes two arguments `job_id` and the returned data:"
+    "To listen for interim results and final result we need to pass a callback function to `service.run` that stores the results.  The callback takes two arguments `job_id` and the returned data:"
    ]
   },
   {
@@ -880,11 +880,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interm_results = []\n",
+    "interim_results = []\n",
     "\n",
     "\n",
     "def vqe_callback(job_id, data):\n",
-    "    interm_results.append(data)"
+    "    interim_results.append(data)"
    ]
   },
   {
@@ -949,7 +949,7 @@
     }
    ],
    "source": [
-    "print(interm_results)"
+    "print(interim_results)"
    ]
   },
   {
@@ -1038,23 +1038,23 @@
    "outputs": [],
    "source": [
     "class RuntimeJobWrapper:\n",
-    "    \"\"\"A simple Job wrapper that attaches interm results directly to the job object itself\n",
-    "    in the `interm_results attribute` via the `_callback` function.\n",
+    "    \"\"\"A simple Job wrapper that attaches interim results directly to the job object itself\n",
+    "    in the `interim_results attribute` via the `_callback` function.\n",
     "    \"\"\"\n",
     "\n",
     "    def __init__(self):\n",
     "        self._job = None\n",
     "        self._decoder = VQEResultDecoder\n",
-    "        self.interm_results = []\n",
+    "        self.interim_results = []\n",
     "\n",
     "    def _callback(self, job_id, xk):\n",
-    "        \"\"\"The callback function that attaches interm results:\n",
+    "        \"\"\"The callback function that attaches interim results:\n",
     "\n",
     "        Parameters:\n",
     "            job_id (str): The job ID.\n",
     "            xk (array_like): A list or NumPy array to attach.\n",
     "        \"\"\"\n",
-    "        self.interm_results.append(xk)\n",
+    "        self.interim_results.append(xk)\n",
     "\n",
     "    def __getattr__(self, attr):\n",
     "        if attr == \"result\":\n",
@@ -1225,7 +1225,7 @@
    "id": "ef281bc5",
    "metadata": {},
    "source": [
-    "The interim results are now attached to the job `interm_results` attribute and, as expected, we see that the length matches the number of iterations performed."
+    "The interim results are now attached to the job `interim_results` attribute and, as expected, we see that the length matches the number of iterations performed."
    ]
   },
   {
@@ -1246,7 +1246,7 @@
     }
    ],
    "source": [
-    "len(job4.interm_results)"
+    "len(job4.interim_results)"
    ]
   },
   {

--- a/docs/tutorials/sample_vqe_program/sample_vqe.py
+++ b/docs/tutorials/sample_vqe_program/sample_vqe.py
@@ -161,7 +161,7 @@ def main(
     # x0 and calls 'vqe_func' everytime the optimizer needs to evaluate the cost
     # function.  The result is returned as a SciPy OptimizerResult object.
     # Additionally, after every iteration, we use the 'callback' function to
-    # publish the interm results back to the user. This is important to do
+    # publish the interim results back to the user. This is important to do
     # so that if the Program terminates unexpectedly, the user can start where they
     # left off.
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes the spelling of "interim" in the VQE sample program.

### Details and comments


