### PR TITLE
Raise RuntimeJobTimeoutError

### DIFF
--- a/qiskit_ibm_runtime/exceptions.py
+++ b/qiskit_ibm_runtime/exceptions.py
@@ -85,3 +85,9 @@ class RuntimeInvalidStateError(IBMRuntimeError):
     """Errors raised when the state is not valid for the operation."""
 
     pass
+
+
+class RuntimeJobTimeoutError(IBMRuntimeError):
+    """Error raised when waiting for job times out."""
+
+    pass

--- a/releasenotes/notes/upgrade-runtime-job-timeout-error-3e01617412bbc37f.yaml
+++ b/releasenotes/notes/upgrade-runtime-job-timeout-error-3e01617412bbc37f.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    ``RuntimeJobTimeoutError`` is now raised when the ``timeout`` set in
+    :meth:`~qiskit_ibm_runtime.RuntimeJob.result` or
+    :meth:`~qiskit_ibm_runtime.RuntimeJob.wait_for_final_state` expires.

--- a/test/integration/test_results.py
+++ b/test/integration/test_results.py
@@ -16,6 +16,8 @@ import time
 
 from qiskit.providers.jobstatus import JobStatus
 
+from qiskit_ibm_runtime.exceptions import RuntimeJobTimeoutError
+
 from ..unit.mock.proxy_server import MockProxyServer, use_proxies
 from ..ibm_test_case import IBMIntegrationJobTestCase
 from ..decorators import run_integration_test
@@ -139,6 +141,20 @@ class TestIntegrationResults(IBMIntegrationJobTestCase):
         job.wait_for_final_state()
         interim_results = job.interim_results()
         self.assertIn(int_res, interim_results[0])
+
+    @run_integration_test
+    def test_result_timeout(self, service):
+        """Test job result timeout"""
+        job = self._run_program(service)
+        with self.assertRaises(RuntimeJobTimeoutError):
+            job.result(0.1)
+
+    @run_integration_test
+    def test_wait_for_final_state_timeout(self, service):
+        """Test job wait_for_final_state timeout"""
+        job = self._run_program(service)
+        with self.assertRaises(RuntimeJobTimeoutError):
+            job.wait_for_final_state(0.1)
 
     @run_integration_test
     def test_callback_error(self, service):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Raise `RuntimeJobTimeoutError` when `timeout` expires for `result()` or `wait_for_final_state()`.

### Details and comments
Fixes #316 

