### PR TITLE
Poll status API after stream closes in wait_for_final_state until it is final

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,2 +1,1 @@
 .. release-notes:: Release Notes
-    :version: 0.4.0, 0.3.0, 0.2.0, 0.1.0, 0.1.0rc2, 0.1.0rc1


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
wait_for_final_state used to poll for status every x seconds.
This poll logic was a bit heavy on the server and hence PR #33 used the end of the results websocket stream to figure the end of the job, but there is a delay between when the stream closes and the status is updated in the db. So if status is queried in between that time it returns running. So as a short term fix until this is fixed on server side, we can poll for status after stream closes and until it is final.

### Details and comments
Fixes #311 
Also fixes this intermittent integration test failure due to this https://github.com/Qiskit/qiskit-ibm-runtime/runs/6585776699?check_suite_focus=true#step:5:1795
