### PR TITLE
Add service property to IBMBackend class

### DIFF
--- a/qiskit_ibm_runtime/hub_group_project.py
+++ b/qiskit_ibm_runtime/hub_group_project.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional
 
 from qiskit_ibm_runtime import (  # pylint: disable=unused-import
     ibm_backend,
+    qiskit_runtime_service,
 )
 
 from .api.clients import AccountClient
@@ -35,6 +36,7 @@ class HubGroupProject:
         self,
         client_params: ClientParameters,
         instance: str,
+        service: "qiskit_runtime_service.QiskitRuntimeService",
     ) -> None:
         """HubGroupProject constructor
 
@@ -42,6 +44,7 @@ class HubGroupProject:
             client_params: Parameters used for server connection.
             instance: Hub/group/project.
         """
+        self._service = service
         self._api_client = AccountClient(client_params)
         # Initialize the internal list of backends.
         self._backends: Dict[str, "ibm_backend.IBMBackend"] = {}
@@ -83,6 +86,7 @@ class HubGroupProject:
                 continue
             ret[config.backend_name] = ibm_backend.IBMBackend(
                 configuration=config,
+                service=self._service,
                 api_client=self._api_client,
             )
         return ret

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -36,9 +36,9 @@ from qiskit.pulse.channels import (
 )
 from qiskit.transpiler.target import Target
 
-from qiskit_ibm_runtime import (
+from qiskit_ibm_runtime import (  # pylint: disable=unused-import,cyclic-import
     qiskit_runtime_service,
-)  # pylint: disable=unused-import,cyclic-import
+)
 
 from .api.clients import AccountClient, RuntimeClient
 from .api.clients.backend import BaseBackendClient

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -36,6 +36,10 @@ from qiskit.pulse.channels import (
 )
 from qiskit.transpiler.target import Target
 
+from qiskit_ibm_runtime import (
+    qiskit_runtime_service,
+)  # pylint: disable=unused-import,cyclic-import
+
 from .api.clients import AccountClient, RuntimeClient
 from .api.clients.backend import BaseBackendClient
 from .exceptions import IBMBackendApiProtocolError
@@ -150,12 +154,14 @@ class IBMBackend(Backend):
     def __init__(
         self,
         configuration: Union[QasmBackendConfiguration, PulseBackendConfiguration],
+        service: "qiskit_runtime_service.QiskitRuntimeService",
         api_client: BaseBackendClient,
     ) -> None:
         """IBMBackend constructor.
 
         Args:
             configuration: Backend configuration.
+            service: Instance of QiskitRuntimeService.
             api_client: IBM client used to communicate with the server.
         """
         super().__init__(
@@ -163,6 +169,7 @@ class IBMBackend(Backend):
             online_date=configuration.online_date,
             backend_version=configuration.backend_version,
         )
+        self._service = service
         self._api_client = api_client
         self._configuration = configuration
         self._properties = None
@@ -254,6 +261,15 @@ class IBMBackend(Backend):
             noise_model=None,
             seed_simulator=None,
         )
+
+    @property
+    def service(self) -> "qiskit_runtime_service.QiskitRuntimeService":
+        """Return the ``service`` object
+
+        Returns:
+            service: instance of QiskitRuntimeService
+        """
+        return self._service
 
     @property
     def dtm(self) -> float:
@@ -496,15 +512,17 @@ class IBMRetiredBackend(IBMBackend):
     def __init__(
         self,
         configuration: Union[QasmBackendConfiguration, PulseBackendConfiguration],
+        service: "qiskit_runtime_service.QiskitRuntimeService",
         api_client: Optional[AccountClient] = None,
     ) -> None:
         """IBMRetiredBackend constructor.
 
         Args:
             configuration: Backend configuration.
+            service: Instance of QiskitRuntimeService.
             api_client: IBM Quantum client used to communicate with the server.
         """
-        super().__init__(configuration, api_client)
+        super().__init__(configuration, service, api_client)
         self._status = BackendStatus(
             backend_name=self.name,
             backend_version=self.configuration().backend_version,

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -308,6 +308,7 @@ class QiskitRuntimeService:
                 continue
             ret[config.backend_name] = ibm_backend.IBMBackend(
                 configuration=config,
+                service=self,
                 api_client=self._api_client,
             )
         return ret
@@ -383,7 +384,7 @@ class QiskitRuntimeService:
             # Build the hgp.
             try:
                 hgp = HubGroupProject(
-                    client_params=hgp_params, instance=hgp_params.instance
+                    client_params=hgp_params, instance=hgp_params.instance, service=self
                 )
                 hgps[hgp.name] = hgp
             except Exception:  # pylint: disable=broad-except

--- a/releasenotes/notes/add-service-property-d6a076214c131d7a.yaml
+++ b/releasenotes/notes/add-service-property-d6a076214c131d7a.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    The ``service`` object which is an instance of :class:`~qiskit_ibm_runtime.QiskitRuntimeService`
+    class can now be accessed from :class:`~qiskit_ibm_runtime.IBMBackend` class using the ``service``
+    property.
+
+    Ex::
+
+      backend = service.get_backend("ibmq_qasm_simulator")
+      backend.service  # QiskitRuntimeService instance used to instantiate the backend

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -16,6 +16,8 @@ from unittest import SkipTest
 
 from qiskit.transpiler.target import Target
 
+from qiskit_ibm_runtime import QiskitRuntimeService
+
 from ..ibm_test_case import IBMIntegrationTestCase
 from ..decorators import run_integration_test
 
@@ -59,6 +61,11 @@ class TestIBMBackend(IBMIntegrationTestCase):
             cls.backend = cls.dependencies.service.least_busy(
                 simulator=False, min_num_qubits=5, instance=cls.dependencies.instance
             )
+
+    def test_backend_service(self):
+        """Check if the service property is set."""
+        backend = self.backend
+        self.assertIsInstance(backend.service, QiskitRuntimeService)
 
     def test_backend_target(self):
         """Check if the target property is set."""

--- a/test/unit/mock/fake_runtime_service.py
+++ b/test/unit/mock/fake_runtime_service.py
@@ -78,7 +78,9 @@ class FakeRuntimeService(QiskitRuntimeService):
                 url="some_url",
                 instance=hgp_name,
             )
-            hgp = HubGroupProject(client_params=hgp_params, instance=hgp_name)
+            hgp = HubGroupProject(
+                client_params=hgp_params, instance=hgp_name, service=self
+            )
             fake_account_client = self._fake_account_client
             if not fake_account_client:
                 specs = [


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The ``service`` object which is an instance of `QiskitRuntimeService`
class can now be accessed from `IBMBackend` class using the ``service``
property.

Ex:
```python
backend = service.get_backend("ibmq_qasm_simulator")
backend.service  # QiskitRuntimeService instance used to instantiate the backend
```


### Details and comments
Fixes #300 

