### PR TITLE
Don't try to decode if results are empty

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -182,7 +182,7 @@ class RuntimeJob:
                     f"Unable to retrieve job result. " f"{self.error_message()}"
                 )
             result_raw = self._api_client.job_results(job_id=self.job_id)
-            self._results = _decoder.decode(result_raw)
+            self._results = _decoder.decode(result_raw) if result_raw else None
         return self._results
 
     def cancel(self) -> None:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The result is empty (due to admin manually cancelling a hung job) and hence when trying to decode empty result, we get below json decode error. This PR checks if the result is not empty before trying to decode.

```
Traceback (most recent call last):
  File "/var/folders/9m/2znk9kw163g8bvhxls_v1j1h0000gn/T/ipykernel_1728/1059953898.py", line 40, in <cell line: 34>
    print("runtime counts: ",jobt.result().get_counts())
  File "/opt/anaconda3/envs/QiskitDevenv/lib/python3.10/site-packages/qiskit/providers/ibmq/runtime/runtime_job.py", line 154, in result
    self._results = _decoder.decode(result_raw)
  File "/opt/anaconda3/envs/QiskitDevenv/lib/python3.10/site-packages/qiskit/providers/ibmq/runner_result.py", line 31, in decode
    return cls.from_dict(json.loads(data))
  File "/opt/anaconda3/envs/QiskitDevenv/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/opt/anaconda3/envs/QiskitDevenv/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/opt/anaconda3/envs/QiskitDevenv/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

### Details and comments
Fixes #

