### PR TITLE
Pass start_session flag and also call new close session API

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -315,6 +315,14 @@ class RuntimeClient(BaseBackendClient):
         """
         return self._api.program_job(job_id).logs()
 
+    def close_session(self, session_id: str) -> None:
+        """Close the runtime session.
+
+        Args:
+            session_id: Session ID.
+        """
+        self._api.runtime_session(session_id=session_id).close()
+
     # IBM Cloud only functions
 
     def list_backends(self) -> List[str]:

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -124,6 +124,7 @@ class RuntimeClient(BaseBackendClient):
         session_id: Optional[str],
         job_tags: Optional[List[str]] = None,
         max_execution_time: Optional[int] = None,
+        start_session: Optional[bool] = False,
     ) -> Dict:
         """Run the specified program.
 
@@ -137,6 +138,7 @@ class RuntimeClient(BaseBackendClient):
             session_id: Job ID of the first job in a runtime session.
             job_tags: Tags to be assigned to the job.
             max_execution_time: Maximum execution time in seconds.
+            start_session: Set to True to explicitly start a runtime session. Defaults to False.
 
         Returns:
             JSON response.
@@ -154,6 +156,7 @@ class RuntimeClient(BaseBackendClient):
             session_id=session_id,
             job_tags=job_tags,
             max_execution_time=max_execution_time,
+            start_session=start_session,
             **hgp_dict
         )
 

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -20,6 +20,7 @@ import json
 from .base import RestAdapterBase
 from .program import Program
 from .program_job import ProgramJob
+from .runtime_session import RuntimeSession
 from ...utils import RuntimeEncoder
 from ...utils.converters import local_to_utc
 from .cloud_backend import CloudBackend
@@ -57,6 +58,17 @@ class Runtime(RestAdapterBase):
             The program job adapter.
         """
         return ProgramJob(self.session, job_id)
+
+    def runtime_session(self, session_id: str) -> "RuntimeSession":
+        """Return an adapter for the session.
+
+        Args:
+            session_id: Job ID of the first job in a session.
+
+        Returns:
+            The session adapter.
+        """
+        return RuntimeSession(self.session, session_id)
 
     def list_programs(self, limit: int = None, skip: int = None) -> Dict[str, Any]:
         """Return a list of runtime programs.

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -124,6 +124,7 @@ class Runtime(RestAdapterBase):
         session_id: Optional[str] = None,
         job_tags: Optional[List[str]] = None,
         max_execution_time: Optional[int] = None,
+        start_session: Optional[bool] = False,
     ) -> Dict:
         """Execute the program.
 
@@ -139,6 +140,7 @@ class Runtime(RestAdapterBase):
             session_id: ID of the first job in a runtime session.
             job_tags: Tags to be assigned to the job.
             max_execution_time: Maximum execution time in seconds.
+            start_session: Set to True to explicitly start a runtime session. Defaults to False.
 
         Returns:
             JSON response.
@@ -160,6 +162,8 @@ class Runtime(RestAdapterBase):
             payload["tags"] = job_tags
         if max_execution_time:
             payload["cost"] = max_execution_time
+        if start_session:
+            payload["start_session"] = start_session
         if all([hub, group, project]):
             payload["hub"] = hub
             payload["group"] = group

--- a/qiskit_ibm_runtime/api/rest/runtime_session.py
+++ b/qiskit_ibm_runtime/api/rest/runtime_session.py
@@ -1,0 +1,43 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Runtime Session REST adapter."""
+
+from typing import Any
+
+from .base import RestAdapterBase
+from ..session import RetrySession
+
+
+class RuntimeSession(RestAdapterBase):
+    """Rest adapter for session related endpoints."""
+
+    URL_MAP = {
+        "close": "/close",
+    }
+
+    def __init__(
+        self, session: RetrySession, session_id: str, url_prefix: str = ""
+    ) -> None:
+        """Job constructor.
+
+        Args:
+            session: RetrySession to be used in the adapter.
+            session_id: Job ID of the first job in a runtime session.
+            url_prefix: Prefix to use in the URL.
+        """
+        super().__init__(session, "{}/sessions/{}".format(url_prefix, session_id))
+
+    def close(self) -> None:
+        """Close this session."""
+        url = self.get_url("close")
+        self.session.delete(url)

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -832,6 +832,7 @@ class QiskitRuntimeService:
         session_id: Optional[str] = None,
         job_tags: Optional[List[str]] = None,
         max_execution_time: Optional[int] = None,
+        start_session: Optional[bool] = False,
     ) -> RuntimeJob:
         """Execute the runtime program.
 
@@ -856,6 +857,7 @@ class QiskitRuntimeService:
                 as a filter in the :meth:`jobs()` function call.
             max_execution_time: Maximum execution time in seconds. This overrides
                 the max_execution_time of the program and cannot exceed it.
+            start_session: Set to True to explicitly start a runtime session. Defaults to False.
 
         Returns:
             A ``RuntimeJob`` instance representing the execution.
@@ -904,6 +906,7 @@ class QiskitRuntimeService:
                 session_id=session_id,
                 job_tags=job_tags,
                 max_execution_time=max_execution_time,
+                start_session=start_session,
             )
         except RequestsApiError as ex:
             if ex.status_code == 404:

--- a/qiskit_ibm_runtime/runtime_session.py
+++ b/qiskit_ibm_runtime/runtime_session.py
@@ -71,10 +71,12 @@ class RuntimeSession:
             inputs = {}
         inputs.update(kwargs)
         if self._session_id is None:
+            self._start_session = True
             self._initial_job = self._run(inputs=inputs)
             self._job = self._initial_job
             self._session_id = self._job.job_id
         else:
+            self._start_session = False
             self._job = self._run(inputs=inputs)
 
     def _run(self, inputs: Union[Dict, ParameterNamespace]) -> RuntimeJob:
@@ -84,7 +86,7 @@ class RuntimeSession:
             options=self._options,
             inputs=inputs,
             session_id=self._session_id,
-            start_session=True,
+            start_session=self._start_session,
         )
 
     @_active_session

--- a/qiskit_ibm_runtime/runtime_session.py
+++ b/qiskit_ibm_runtime/runtime_session.py
@@ -85,6 +85,7 @@ class RuntimeSession:
             options=self._options,
             inputs=inputs,
             session_id=self._session_id,
+            start_session=True,
         )
 
     @_active_session

--- a/qiskit_ibm_runtime/runtime_session.py
+++ b/qiskit_ibm_runtime/runtime_session.py
@@ -61,6 +61,7 @@ class RuntimeSession:
         self._job: Optional[RuntimeJob] = None
         self._session_id: Optional[str] = None
         self._active = True
+        self._start_session = True
 
     @_active_session
     def write(self, **kwargs: Dict) -> None:

--- a/qiskit_ibm_runtime/runtime_session.py
+++ b/qiskit_ibm_runtime/runtime_session.py
@@ -22,7 +22,6 @@ from .runtime_job import RuntimeJob
 from .runtime_program import ParameterNamespace
 from .runtime_options import RuntimeOptions
 from .program.result_decoder import ResultDecoder
-from .exceptions import RuntimeInvalidStateError
 
 
 def _active_session(func):  # type: ignore
@@ -120,12 +119,8 @@ class RuntimeSession:
     def close(self) -> None:
         """Close the session."""
         self._active = False
-        # TODO Stop swallowing error when API is fixed
-        try:
-            if self._initial_job is not None:
-                self._initial_job.cancel()
-        except RuntimeInvalidStateError:
-            pass
+        if self._session_id:
+            self._service._api_client.close_session(self._session_id)
 
     def __enter__(self) -> "RuntimeSession":
         return self

--- a/test/ibm_test_case.py
+++ b/test/ibm_test_case.py
@@ -186,6 +186,7 @@ class IBMIntegrationJobTestCase(IBMIntegrationTestCase):
         job_tags=None,
         max_execution_time=None,
         session_id=None,
+        start_session=False,
     ):
         """Run a program."""
         self.log.debug("Running program on %s", service.channel)
@@ -211,6 +212,7 @@ class IBMIntegrationJobTestCase(IBMIntegrationTestCase):
             max_execution_time=max_execution_time,
             session_id=session_id,
             callback=callback,
+            start_session=start_session,
         )
         self.log.info("Runtime job %s submitted.", job.job_id)
         self.to_cancel[service.channel].append(job)

--- a/test/integration/test_retrieve_job.py
+++ b/test/integration/test_retrieve_job.py
@@ -141,7 +141,7 @@ class TestIntegrationRetrieveJob(IBMIntegrationJobTestCase):
     @run_integration_test
     def test_retrieve_jobs_by_session_id(self, service):
         """Test retrieving jobs by session_id."""
-        job = self._run_program(service)
+        job = self._run_program(service, start_session=True)
         job.wait_for_final_state()
         job_2 = self._run_program(service, session_id=job.job_id)
         job_2.wait_for_final_state()

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -117,6 +117,7 @@ class BaseFakeRuntimeJob:
         log_level=None,
         session_id=None,
         max_execution_time=None,
+        start_session=None,
     ):
         """Initialize a fake job."""
         self._job_id = job_id
@@ -134,6 +135,7 @@ class BaseFakeRuntimeJob:
         self.log_level = log_level
         self._session_id = session_id
         self._max_execution_time = max_execution_time
+        self._start_session = start_session
         self._creation_date = python_datetime.now(timezone.utc)
         if final_status is None:
             self._future = self._executor.submit(self._auto_progress)
@@ -364,6 +366,7 @@ class BaseFakeRuntimeClient:
         session_id: Optional[str] = None,
         job_tags: Optional[List[str]] = None,
         max_execution_time: Optional[int] = None,
+        start_session: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Run the specified program."""
         _ = self._get_program(program_id)
@@ -398,6 +401,7 @@ class BaseFakeRuntimeClient:
             session_id=session_id,
             job_tags=job_tags,
             max_execution_time=max_execution_time,
+            start_session=start_session,
             **self._job_kwargs,
         )
         self._jobs[job_id] = job


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
With the latest session aware scheduling enhancements we have to now explicitly pass the start_session flag to POST /jobs API to start a runtime session.

Also calling DELETE /sessions/{session_id}/close API will close the session.

Testing:
The existing integration tests for estimator and sampler are good enough to test these changes.

### Details and comments
Fixes #374 
Fixes #375 

