### PR TITLE
Update Docs: how-to-getting-started-with-sampler.ipynb

### DIFF
--- a/docs/tutorials/how-to-getting-started-with-sampler.ipynb
+++ b/docs/tutorials/how-to-getting-started-with-sampler.ipynb
@@ -154,7 +154,7 @@
     "\n",
     "In this example, we run multiple parameterized circuits. When it is run, this line `result = sampler(circuits=[0, 0, 1], parameter_values=[theta1, theta2, theta3])` specifies which parameter to send to each circuit.  \n",
     "\n",
-    "In our example, the parameter labeled `theta` is sent to the first circuit, `theta2` is sent to the first circuit, and `theta3` is sent to the second circuit."
+    "In our example, the parameter labeled `theta1` is sent to the first circuit, `theta2` is sent to the first circuit, and `theta3` is sent to the second circuit."
    ]
   },
   {
@@ -200,7 +200,7 @@
    "source": [
     "### Result\n",
     "\n",
-    "The results align with the parameter - circuit pairs specified previously.  For example, the first result (`{'11': 0.42578125, '00': 0.14453125, '10': 0.0888671875, '01': 0.3408203125}`) is the output of the parameter labeled `theta` being sent to the first circuit."
+    "The results align with the parameter - circuit pairs specified previously.  For example, the first result (`{'11': 0.42578125, '00': 0.14453125, '10': 0.0888671875, '01': 0.3408203125}`) is the output of the parameter labeled `theta1` being sent to the first circuit."
    ]
   }
  ],


### PR DESCRIPTION
Updated two typos of `theta` to `theta1` in [how-to-getting-started-with-sampler.ipynb](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/docs/tutorials/how-to-getting-started-with-sampler.ipynb).

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Small typos in documents tutorials.


### Details and comments
Fixes #400

