### PR TITLE
Fix custom_max_execution_time test 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,7 @@ numfig_format = {
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # For Adding Locale
 locale_dirs = ['locale/']   # path is example but recommended.

--- a/test/integration/test_job.py
+++ b/test/integration/test_job.py
@@ -127,20 +127,10 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
             service, max_execution_time=max_execution_time
         )
         inputs = {"iterations": 1, "sleep_per_iteration": 60}
-        job = self._run_program(
-            service, program_id=program_id, inputs=inputs, max_execution_time=1
-        )
-        job.wait_for_final_state()
-        job_result_raw = service._api_client.job_results(job.job_id)
-        self.assertEqual(JobStatus.ERROR, job.status())
-        self.assertIn(
-            API_TO_JOB_ERROR_MESSAGE["CANCELLED - RAN TOO LONG"].format(
-                job.job_id, job_result_raw
-            ),
-            job.error_message(),
-        )
-        with self.assertRaises(RuntimeJobFailureError):
-            job.result()
+        with self.assertRaises(IBMRuntimeError):
+            self._run_program(
+                service, program_id=program_id, inputs=inputs, max_execution_time=1
+            )
 
     @run_integration_test
     def test_run_program_failed_invalid_execution_time(self, service):

--- a/test/integration/test_job.py
+++ b/test/integration/test_job.py
@@ -122,15 +122,20 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
     def test_run_program_failed_custom_max_execution_time(self, service):
         """Test a program that failed with a custom max_execution_time."""
         # check that program max execution time is overridden
-        max_execution_time = 300
+        program_max_execution_time = 400
+        job_max_execution_time = 350
         program_id = self._upload_program(
-            service, max_execution_time=max_execution_time
+            service, max_execution_time=program_max_execution_time
         )
-        inputs = {"iterations": 1, "sleep_per_iteration": 60}
+        job = self._run_program(
+            service, program_id=program_id, max_execution_time=job_max_execution_time
+        )
+        job.wait_for_final_state()
+        self.assertEqual(
+            job._api_client.job_get(job.job_id)["cost"], job_max_execution_time
+        )
         with self.assertRaises(IBMRuntimeError):
-            self._run_program(
-                service, program_id=program_id, inputs=inputs, max_execution_time=1
-            )
+            self._run_program(service, program_id=program_id, max_execution_time=1)
 
     @run_integration_test
     def test_run_program_failed_invalid_execution_time(self, service):

--- a/test/integration/test_job.py
+++ b/test/integration/test_job.py
@@ -119,9 +119,8 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
             job.result()
 
     @run_integration_test
-    def test_run_program_failed_custom_max_execution_time(self, service):
-        """Test a program that failed with a custom max_execution_time."""
-        # check that program max execution time is overridden
+    def test_run_program_override_max_execution_time(self, service):
+        """Test that the program max execution time is overridden."""
         program_max_execution_time = 400
         job_max_execution_time = 350
         program_id = self._upload_program(
@@ -134,8 +133,12 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
         self.assertEqual(
             job._api_client.job_get(job.job_id)["cost"], job_max_execution_time
         )
+
+    @run_integration_test
+    def test_invalid_max_execution_time_fails(self, service):
+        """Test that program fails when max_execution_time is less than 300."""
         with self.assertRaises(IBMRuntimeError):
-            self._run_program(service, program_id=program_id, max_execution_time=1)
+            self._run_program(service, max_execution_time=299)
 
     @run_integration_test
     def test_run_program_failed_invalid_execution_time(self, service):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Job no longer queues if an invalid `max_execution_time` is given 

### Details and comments
Fixes #

