### PR TITLE
`dedicated` is not part of the BackendStatus schema and would have never worked

### DIFF
--- a/qiskit_ibm_runtime/api/rest/backend.py
+++ b/qiskit_ibm_runtime/api/rest/backend.py
@@ -105,10 +105,6 @@ class Backend(RestAdapterBase):
         else:
             ret["pending_jobs"] = 0
 
-        # Not part of the schema.
-        if "busy" in response:
-            ret["dedicated"] = response["busy"]
-
         return ret
 
     def job_limit(self) -> Dict[str, Any]:

--- a/qiskit_ibm_runtime/api/rest/cloud_backend.py
+++ b/qiskit_ibm_runtime/api/rest/cloud_backend.py
@@ -92,7 +92,4 @@ class CloudBackend(RestAdapterBase):
             ret["pending_jobs"] = max(response["length_queue"], 0)
         else:
             ret["pending_jobs"] = 0
-        # Not part of the schema.
-        if "busy" in response:
-            ret["dedicated"] = response["busy"]
         return ret


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes build failures due to "qiskit_ibm_runtime.exceptions.IBMBackendApiProtocolError: "Unexpected return value received from the server when getting backend status: __init__() got an unexpected keyword argument 'dedicated'""


### Details and comments
Fixes #

