### PR TITLE
Bump min terra version to 0.21.0

### DIFF
--- a/releasenotes/notes/fix-terra-min-version-613f427851adfab0.yaml
+++ b/releasenotes/notes/fix-terra-min-version-613f427851adfab0.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes issue `#428 <https://github.com/Qiskit/qiskit-ibm-runtime/issues/428>__`
+    by raising the minimum required ``qiskit-terra`` version to ``0.21.0``, since latest version
+    of ``qiskit-ibm-runtime`` is not compatible with ``0.20.0`` or earlier of ``qiskit-terra``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.20.0
+qiskit-terra>=0.21.0
 requests>=2.19
 requests_ntlm>=1.1.0
 numpy>=1.13

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import os
 import setuptools
 
 REQUIREMENTS = [
-    "qiskit-terra>=0.20.0",
+    "qiskit-terra>=0.21.0",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",
     "numpy>=1.13",


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Bump min terra version to 0.21.0 (since earlier versions are not compatible with latest of qiskit-ibm-runtime).


### Details and comments
Fixes #428 

