### PR TITLE
Set optimization level default to 1 for alpha release

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -193,7 +193,7 @@ class Estimator(BaseEstimator):
                         * 1: light optimization
                         * 2: heavy optimization
                         * 3: even heavier optimization
-                        If ``None``, level 3 will be chosen as default.
+                        If ``None``, level 1 will be chosen as default.
 
             resilience_settings: (EXPERIMENTAL setting, can break between releases without warning)
                 Using these settings allows you to build resilient algorithms by

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -204,8 +204,6 @@ class Estimator(BaseEstimator):
                     at the expense of longer processing times.
                     * 0: no resilience
                     * 1: light resilience
-                    * 2: heavy resilience
-                    * 3: even heavier resilience
                     If ``None``, level 0 will be chosen as default.
 
             max_time: (EXPERIMENTAL setting, can break between releases without warning)

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -182,8 +182,6 @@ class Sampler(BaseSampler):
                     at the expense of longer processing times.
                     * 0: no resilience
                     * 1: light resilience
-                    * 2: heavy resilience
-                    * 3: even heavier resilience
                     If ``None``, level 0 will be chosen as default.
 
             max_time: (EXPERIMENTAL setting, can break between releases without warning)

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -171,7 +171,7 @@ class Sampler(BaseSampler):
                         * 1: light optimization
                         * 2: heavy optimization
                         * 3: even heavier optimization
-                        If ``None``, level 3 will be chosen as default.
+                        If ``None``, level 1 will be chosen as default.
 
             resilience_settings: (EXPERIMENTAL setting, can break between releases without warning)
                 Using these settings allows you to build resilient algorithms by


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Set optimization level default to 1 for alpha release (will be changed back to 3 if needed post alpha). Also remove resilience levels 2 and 3 for alpha release.


### Details and comments
Fixes #

