### PR TITLE
Fix spelling of "function" in the VQE sample program

### DIFF
--- a/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
+++ b/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
@@ -169,7 +169,7 @@
    "source": [
     "## Main program\n",
     "\n",
-    "We are now in a position to start building our main program.  However, before doing so we point out that it makes the code cleaner to make a separate fuction that takes strings of Pauli operators that define our Hamiltonian and convert them to a list of circuits with single-qubit gates that change the measurement basis for each qubit, if needed. This function is given in [Appendix B](#Appendix-B)."
+    "We are now in a position to start building our main program.  However, before doing so we point out that it makes the code cleaner to make a separate function that takes strings of Pauli operators that define our Hamiltonian and convert them to a list of circuits with single-qubit gates that change the measurement basis for each qubit, if needed. This function is given in [Appendix B](#Appendix-B)."
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix a typo in the VQE sample program, `fuction` to `function`.

### Details and comments
Fixes #433

