### PR TITLE
Fix typos in runtime expval notebook

### DIFF
--- a/docs/tutorials/sample_expval_program/qiskit_runtime_expval_program.ipynb
+++ b/docs/tutorials/sample_expval_program/qiskit_runtime_expval_program.ipynb
@@ -63,7 +63,7 @@
     "- `circuits`: A single QuantumCircuit or list of QuantumCircuits to be executed on the target backend.\n",
     "\n",
     "\n",
-    "- `expectation_operators`: The operators we want to evaluate.  These can be strings of diagonal Pauli's, eg, `ZIZZ`, or custom operators defined by dictionaries. For example, the projection operator on all ones state of 4 qubits is `{'1111': 1}`.\n",
+    "- `expectation_operators`: The operators we want to evaluate.  These can be strings of diagonal Pauli's, eg, `ZIZZ`, or custom operators defined by dictionaries. For example, the projection operator on the all ones state of 4 qubits is `{'1111': 1}`.\n",
     "\n",
     "\n",
     "- `shots`: How many times to sample each circuit.\n",
@@ -531,7 +531,7 @@
    "id": "29268312",
    "metadata": {},
    "source": [
-    "The first two projectors should be nearly $0.50$ as they tell use the probability of being in all zeros and ones states, respectively, which should be 50/50 for our GHZ state.  The final expectation value of `ZZZZ` should be one since this is a GHZ over an even number of qubits.  It should go close to zero for an odd number."
+    "The first two projectors should be nearly $0.50$ as they tell us the probability of being in the all zeros and ones states, respectively, which should be 50/50 for our GHZ state.  The final expectation value of `ZZZZ` should be one since this is a GHZ over an even number of qubits.  It should go close to zero for an odd number."
    ]
   },
   {

--- a/docs/tutorials/sample_expval_program/qiskit_runtime_expval_program.ipynb
+++ b/docs/tutorials/sample_expval_program/qiskit_runtime_expval_program.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "## Background\n",
     "\n",
-    "The primary method by which information is obtained from quantum computers is via expectation values.  Indeed, the samples that come from executing a quantum circuit multiple times, once converted to probabilities, can be viewed as just a finite sample approximation to the expectation value for the projection operators corresponding to each bitstring.  More practically, many quantum algorithms require computing expectation values over Pauli operators, e.g. Variational Quantum Eigensolvers, and thus having a runtime program that computes these quantities is of fundamental importance.  Here we look at one such example, where an user passes one or more circuits and expectation operators and gets back the computed expectation values, and possibly error bounds.\n",
+    "The primary method by which information is obtained from quantum computers is via expectation values.  Indeed, the samples that come from executing a quantum circuit multiple times, once converted to probabilities, can be viewed as just a finite sample approximation to the expectation value for the projection operators corresponding to each bitstring.  More practically, many quantum algorithms require computing expectation values over Pauli operators, e.g. Variational Quantum Eigensolvers, and thus having a runtime program that computes these quantities is of fundamental importance.  Here we look at one such example, where a user passes one or more circuits and expectation operators and gets back the computed expectation values, and possibly error bounds.\n",
     "\n",
     "### Expectation value of a diagonal operator\n",
     "\n",
@@ -63,7 +63,7 @@
     "- `circuits`: A single QuantumCircuit or list of QuantumCircuits to be executed on the target backend.\n",
     "\n",
     "\n",
-    "- `expectation_operators`: The operators we want to evaluate.  These can be strings of diagonal Pauli's, eg, `ZIZZ`, or custom operators defined by dictionaries. For example, the projection operator on the all ones state of 4 qubits is `{'1111': 1}`.\n",
+    "- `expectation_operators`: The operators we want to evaluate.  These can be strings of diagonal Pauli's, eg, `ZIZZ`, or custom operators defined by dictionaries. For example, the projection operator on all ones state of 4 qubits is `{'1111': 1}`.\n",
     "\n",
     "\n",
     "- `shots`: How many times to sample each circuit.\n",
@@ -81,7 +81,7 @@
     "- `return_stddev`: Flag to return bound on standard deviation.  If using measurement mitigation this adds some overhead to the computation.\n",
     "\n",
     "\n",
-    "- `use_measurement_mitigation`: Use M3 measurement mitigation and compute expecation value and standard deviation bound from quasi-probabilities.\n",
+    "- `use_measurement_mitigation`: Use M3 measurement mitigation and compute expectation value and standard deviation bound from quasi-probabilities.\n",
     "\n",
     "At the top of the cell below you will see a commented out `%%writefile sample_expval.py`.  We will use this to convert the cell to a Python module named `sample_expval.py` to upload."
    ]
@@ -124,7 +124,7 @@
     "        transpiler_config (dict): A collection of kwargs passed to transpile().\n",
     "        run_config (dict): A collection of kwargs passed to backend.run().\n",
     "        skip_transpilation (bool): Skip transpiling of circuits, default=False.\n",
-    "        return_stddev (bool): Return upper bound on standard devitation,\n",
+    "        return_stddev (bool): Return upper bound on standard deviation,\n",
     "                              default=False.\n",
     "        use_measurement_mitigation (bool): Improve resulting using measurement\n",
     "                                           error mitigation, default=False.\n",
@@ -351,7 +351,7 @@
    "source": [
     "## Upload the program\n",
     "\n",
-    "We are now in a position to upload the program.  To do so we first uncomment and excute the line `%%writefile sample_expval.py` giving use the `sample_expval.py` file we need to upload.  "
+    "We are now in a position to upload the program.  To do so we first uncomment and execute the line `%%writefile sample_expval.py` giving use the `sample_expval.py` file we need to upload.  "
    ]
   },
   {
@@ -445,7 +445,7 @@
     "        shots (int): Number of shots to take per circuit.\n",
     "        transpiler_config (dict): A collection of kwargs passed to transpile().\n",
     "        run_config (dict): A collection of kwargs passed to backend.run().\n",
-    "        return_stddev (bool): Return upper bound on standard devitation,\n",
+    "        return_stddev (bool): Return upper bound on standard deviation,\n",
     "                              default=False.\n",
     "        skip_transpilation (bool): Skip transpiling of circuits, default=False.\n",
     "        use_measurement_mitigation (bool): Improve resulting using measurement\n",
@@ -488,7 +488,7 @@
    "source": [
     "### Trying it out\n",
     "\n",
-    "Lets try running the program here with our previously made GHZ state and running on the simulator."
+    "Let's try running the program here with our previously made GHZ state and running on the simulator."
    ]
   },
   {
@@ -531,7 +531,7 @@
    "id": "29268312",
    "metadata": {},
    "source": [
-    "The first two projectors should be nearly $0.50$ as they tell use the probability of being in the all zeros and ones states, respectively, which should be 50/50 for our GHZ state.  The final expectation value of `ZZZZ` should be one since this is a GHZ over an even number of qubits.  It should go close to zero for an odd number."
+    "The first two projectors should be nearly $0.50$ as they tell use the probability of being in all zeros and ones states, respectively, which should be 50/50 for our GHZ state.  The final expectation value of `ZZZZ` should be one since this is a GHZ over an even number of qubits.  It should go close to zero for an odd number."
    ]
   },
   {
@@ -590,7 +590,7 @@
     "\n",
     "Here we formulate QV as an expectation value of a projector onto the heavy-output elements on a distribution.  We can then use our expectation value routine to compute whether a given circuit has passed the QV metric.\n",
     "\n",
-    "QV is defined in terms of heavy-ouputs of a distribution. Heavy-outputs are those bit-strings that are those that have probabilities above the median value of the distribution. Below we define the projection operator onto the set of bit-strings that are heavy-outputs for a given distribution."
+    "QV is defined in terms of heavy-outputs of a distribution. Heavy-outputs are those bit-strings that are those that have probabilities above the median value of the distribution. Below we define the projection operator onto the set of bit-strings that are heavy-outputs for a given distribution."
    ]
   },
   {
@@ -667,7 +667,7 @@
    "id": "33559bc5",
    "metadata": {},
    "source": [
-    "QV circuits have no meaasurements on them so need to add them:"
+    "QV circuits have no measurements on them so need to add them:"
    ]
   },
   {
@@ -685,7 +685,7 @@
    "id": "dd9579fb",
    "metadata": {},
    "source": [
-    "With a list of circuits and projection operators we now need only to pass both sets to our above expection value runner targeting the desired backend.  We will also set the best transpiler arguments to give us a sporting chance of getting some passing scores."
+    "With a list of circuits and projection operators we now need only to pass both sets to our above expectation value runner targeting the desired backend.  We will also set the best transpiler arguments to give us a sporting chance of getting some passing scores."
    ]
   },
   {


### PR DESCRIPTION
- Typo
line 84 :  expecation -> expectation
line 127, 448 : devitation -> deviation
line 354 : excute -> execute
line 593 : heavy-ouputs -> heavy-outputs
line 662 : meaasurements -> measurements
lint 688 : expection -> expectation

- Grammer
line 39 : where an user -> where a user
line 66, 534 : the all -> all
line 491 : Lets -> Let's

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Fixes #

