### PR TITLE
Fix spelling of "implementing" in the VQE sample program

### DIFF
--- a/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
+++ b/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
@@ -1256,7 +1256,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We have demonstrated how to create, upload, and use a custom Qiskit Runtime by creating our own VQE solver from scratch.  This tutorial was meant to touch upon every aspect of the process for a real-world example.  Within the current limitations of the runtime environment, this example should enable readers to develop their own single-file runtime program.  This program is also a good starting point for exploring additional flavors of VQE runtime.  For example, it is straightforward to vary the number of shots per iteration, increasing shots as the number of iterations increases.  Those looking to go deeper can consider implimenting an [adaptive VQE](https://doi.org/10.1038/s41467-019-10988-2), where the ansatz is not fixed at initialization."
+    "We have demonstrated how to create, upload, and use a custom Qiskit Runtime by creating our own VQE solver from scratch.  This tutorial was meant to touch upon every aspect of the process for a real-world example.  Within the current limitations of the runtime environment, this example should enable readers to develop their own single-file runtime program.  This program is also a good starting point for exploring additional flavors of VQE runtime.  For example, it is straightforward to vary the number of shots per iteration, increasing shots as the number of iterations increases.  Those looking to go deeper can consider implementing an [adaptive VQE](https://doi.org/10.1038/s41467-019-10988-2), where the ansatz is not fixed at initialization."
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix a typo in the VQE sample program, `implimenting` to `implementing`.

### Details and comments
Fixes #439

