### PR TITLE
Fix issue - "AttributeError: 'AerProvider' object has no attribute" in the qiskit_runtime_vqe_program.ipynb

### DIFF
--- a/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
+++ b/docs/tutorials/sample_vqe_program/qiskit_runtime_vqe_program.ipynb
@@ -416,7 +416,7 @@
     "# Use the local Aer simulator\n",
     "from qiskit import Aer\n",
     "\n",
-    "backend = Aer.backend(\"qasm_simulator\")"
+    "backend = Aer.get_backend(\"qasm_simulator\")"
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix a wrong attritube of Aer in the qiskit_runtime_vqe_program.ipynb


### Details and comments
**Fixes** 
Modify from Aer.backend() to Aer.get_backend()

**Source codes**
```
# Use the local Aer simulator
from qiskit import Aer

backend = Aer.backend("qasm_simulator")
```
**Error messages**
```

Traceback (most recent call last):
  Input In [5] in <cell line: 4>
    backend = Aer.backend("qasm_simulator")
  File /opt/conda/lib/python3.8/site-packages/qiskit/__init__.py:126 in __getattr__
    return getattr(self.aer, attr)
AttributeError: 'AerProvider' object has no attribute 'backend'

Use %tb to get the full traceback.

```