### PR TITLE
Specify service parameter channel through env variable

### DIFF
--- a/qiskit_ibm_runtime/accounts/management.py
+++ b/qiskit_ibm_runtime/accounts/management.py
@@ -145,7 +145,7 @@ class AccountManager:
                 )
             return Account.from_saved_format(saved_account)
 
-        channel_ = channel or _DEFAULT_CHANNEL_TYPE
+        channel_ = channel or os.getenv("QISKIT_IBM_CHANNEL") or _DEFAULT_CHANNEL_TYPE
         env_account = cls._from_env_variables(channel_)
         if env_account is not None:
             return env_account

--- a/releasenotes/notes/parameterize-service-channel-d14de7391dfb5ee1.yaml
+++ b/releasenotes/notes/parameterize-service-channel-d14de7391dfb5ee1.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The :class:`qiskit_ibm_runtime.QiskitRuntimeService` ``channel`` can now be stored
+    as an environment variable, ``QISKIT_IBM_CHANNEL``. This way, when using Runtime 
+    Primitives, the service does not have to be instantiated manually and can instead 
+    be created directly from environment variables.
+

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -716,6 +716,25 @@ class TestEnableAccount(IBMTestCase):
                 channel = channel or "ibm_cloud"
                 self.assertEqual(service._account.channel, channel)
 
+    def test_enable_account_only_env_variables(self):
+        """Test initializing account with only environment variables."""
+        subtests = ["ibm_quantum", "ibm_cloud"]
+        token = uuid.uuid4().hex
+        url = uuid.uuid4().hex
+        for channel in subtests:
+            envs = {
+                "QISKIT_IBM_TOKEN": token,
+                "QISKIT_IBM_URL": url,
+                "QISKIT_IBM_CHANNEL": channel,
+                "QISKIT_IBM_INSTANCE": "h/g/p"
+                if channel == "ibm_quantum"
+                else "crn:12",
+            }
+            with custom_envs(envs):
+                service = FakeRuntimeService()
+            self.assertEqual(service._account.channel, channel)
+            self.assertEqual(service._account.url, url)
+
     def test_enable_account_by_env_token_url(self):
         """Test initializing account by environment variable and extra."""
         token = uuid.uuid4().hex
@@ -822,9 +841,9 @@ class TestEnableAccount(IBMTestCase):
         token = "token-x"
         proxies = {"urls": {"https": "localhost:8080"}}
         str_contents = f"""
-        [ibmq] 
+        [ibmq]
         token = {token}
-        url = https://auth.quantum-computing.ibm.com/api 
+        url = https://auth.quantum-computing.ibm.com/api
         verify = True
         default_provider = ibm-q/open/main
         proxies = {proxies}


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

``channel`` can now be stored as an environment variable so the service does not have to be instantiated manually and instead can be created from the env variables.

Example: 
```
from qiskit_ibm_runtime import Sampler
import os

os.environ["QISKIT_IBM_CHANNEL"] = channel
os.environ["QISKIT_IBM_TOKEN"] = token
os.environ["QISKIT_IBM_INSTANCE"] = instance
os.environ["QISKIT_IBM_URL"] = url

with Sampler(...) as sampler:
    result = sampler(...)
```

### Details and comments
Fixes #444 

