### PR TITLE
Convert `EstimatorResult.values` to ndarray if necessary

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -14,6 +14,7 @@
 
 from typing import Iterable, Optional, Dict, Sequence, Any, Union
 
+import numpy as np
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.quantum_info import SparsePauliOp
 
@@ -302,7 +303,7 @@ class Estimator(BaseEstimator):
         )
         raw_result = self._session.read()
         return EstimatorResult(
-            values=raw_result["values"],
+            values=np.asarray(raw_result["values"]),
             metadata=raw_result["metadata"],
         )
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR converts `ExpectationValues.results` into ndarray if necessary to be compatible with the [definition](https://github.com/Qiskit/qiskit-terra/blob/cf951202c77b49d28e7d23f43088b191638f282a/qiskit/primitives/estimator_result.py#L43).

### Details and comments

The job page of IQX dashboard displays binary data as expectation values.
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/31178928/182336493-9e94a7b9-afb2-483c-83f5-2a61efdf58ca.png">

I'm working on make the values as a list of float values. So, we need to convert them back to ndarray to construct `EstiamtorResult`.
