### PR TITLE
Remove unnecessary qubit property conversions 

### DIFF
--- a/qiskit_ibm_runtime/utils/backend_converter.py
+++ b/qiskit_ibm_runtime/utils/backend_converter.py
@@ -142,13 +142,11 @@ def qubit_props_list_from_props(
     """
     qubit_props: List[IBMQubitProperties] = []
     for qubit, _ in enumerate(properties.qubits):
-        t_1 = properties.t1(qubit) * 1e-6  # microseconds to seconds
-        t_2 = properties.t2(qubit) * 1e-6  # microseconds to seconds
-        frequency = properties.frequency(qubit) * 1e9  # GHz to Hz
+        t_1 = properties.t1(qubit)
+        t_2 = properties.t2(qubit)
+        frequency = properties.frequency(qubit)
         try:
-            anharmonicity = (
-                properties.qubit_property(qubit, "anharmonicity")[0] * 1e9
-            )  # GHz to Hz
+            anharmonicity = properties.qubit_property(qubit, "anharmonicity")[0]
         except Exception:  # pylint: disable=broad-except
             anharmonicity = None
         qubit_props.append(


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `apply_prefix` method [here](https://github.com/Qiskit/qiskit-terra/blob/beea6f0f2de0aa8f0484fb14c5024f22c0b5b715/qiskit/providers/models/backendproperties.py#L200) in `BackendProperties` is already converting to seconds and hz

### Details and comments
Fixes #

