### PR TITLE
Check ibmq provider custom client header env variable 

### DIFF
--- a/qiskit_ibm_runtime/api/session.py
+++ b/qiskit_ibm_runtime/api/session.py
@@ -40,6 +40,7 @@ STATUS_FORCELIST = (
     524,  # Cloudflare Timeout
 )
 CUSTOM_HEADER_ENV_VAR = "QISKIT_IBM_RUNTIME_CUSTOM_CLIENT_APP_HEADER"
+QE_PROVIDER_HEADER_ENV_VAR = "QE_CUSTOM_CLIENT_APP_HEADER"
 logger = logging.getLogger(__name__)
 # Regex used to match the `/backends` endpoint, capturing the device name as group(2).
 # The number of letters for group(2) must be greater than 1, so it does not match
@@ -212,7 +213,9 @@ class RetrySession(Session):
         client_app_header = CLIENT_APPLICATION
 
         # Append custom header to the end if specified
-        custom_header = os.getenv(CUSTOM_HEADER_ENV_VAR)
+        custom_header = os.getenv(CUSTOM_HEADER_ENV_VAR) or os.getenv(
+            QE_PROVIDER_HEADER_ENV_VAR
+        )
         if custom_header:
             client_app_header += "/" + custom_header
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Different env variables are used for the custom client header in ibmq provider and the runtime provider. The qiskit version returned is unaffected, this will make sure the custom client header (if it exists) is appended.

```
CUSTOM_HEADER_ENV_VAR = 'QE_CUSTOM_CLIENT_APP_HEADER'
CUSTOM_HEADER_ENV_VAR = "QISKIT_IBM_RUNTIME_CUSTOM_CLIENT_APP_HEADER"
```

### Details and comments
Fixes #460 

