### PR TITLE
Set websocket-client version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ requests_ntlm>=1.1.0
 numpy>=1.13
 urllib3>=1.21.1
 python-dateutil>=2.8.0
-websocket-client>=1.0.1
+websocket-client<=1.3.3
 typing-extensions>=4.0.0
 ibm-platform-services>=0.22.6

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIREMENTS = [
     "numpy>=1.13",
     "urllib3>=1.21.1",
     "python-dateutil>=2.8.0",
-    "websocket-client>=1.0.1",
+    "websocket-client<=1.3.3",
     "typing-extensions>=4.0.0",  # remove when support for Python 3.7 is dropped (use "from typing import" instead)
     "ibm-platform-services>=0.22.6",
 ]


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

On 8/24 websocket-client 1.4 was released and since then, the `test_websocket_proxy` test case has been failing on cloud. For now we can avoid this version and use 1.3.3 instead. 

### Details and comments
Fixes #508 

