### PR TITLE
Move conversion of QuasiDistribution to result decoder

### DIFF
--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -263,24 +263,10 @@ class Sampler(BaseSampler):
             program_id=self._PROGRAM_ID,
             inputs=inputs,
             options=Options._get_runtime_options(combined),
-            result_decoder=SamplerResultDecoder,
         ).result()
-        quasi_dists = []
-        for quasi, meta in zip(raw_result["quasi_dists"], raw_result["metadata"]):
-            shots = meta.get("shots", float("inf"))
-            overhead = meta.get("readout_mitigation_overhead", 1.0)
 
-            # M3 mitigation overhead is gamma^2
-            # https://github.com/Qiskit-Partners/mthree/blob/423d7e83a12491c59c9f58af46b75891bc622949/mthree/mitigation.py#L457
-            #
-            # QuasiDistribution stddev_upper_bound is gamma / sqrt(shots)
-            # https://github.com/Qiskit/qiskit-terra/blob/ff267b5de8b83aef86e2c9ac6c7f918f58500505/qiskit/result/mitigation/local_readout_mitigator.py#L288
-            stddev = sqrt(overhead / shots)
-            quasi_dists.append(
-                QuasiDistribution(quasi, shots=shots, stddev_upper_bound=stddev)
-            )
         return SamplerResult(
-            quasi_dists=quasi_dists,
+            quasi_dists=raw_result["quasi_dists"],
             metadata=raw_result["metadata"],
         )
 
@@ -305,7 +291,21 @@ class SamplerResultDecoder(ResultDecoder):
     def decode(cls, raw_result: str) -> SamplerResult:
         """Convert the result to SamplerResult."""
         decoded: Dict = super().decode(raw_result)
+        quasi_dists = []
+        for quasi, meta in zip(decoded["quasi_dists"], decoded["metadata"]):
+            shots = meta.get("shots", float("inf"))
+            overhead = meta.get("readout_mitigation_overhead", 1.0)
+
+            # M3 mitigation overhead is gamma^2
+            # https://github.com/Qiskit-Partners/mthree/blob/423d7e83a12491c59c9f58af46b75891bc622949/mthree/mitigation.py#L457
+            #
+            # QuasiDistribution stddev_upper_bound is gamma / sqrt(shots)
+            # https://github.com/Qiskit/qiskit-terra/blob/ff267b5de8b83aef86e2c9ac6c7f918f58500505/qiskit/result/mitigation/local_readout_mitigator.py#L288
+            stddev = sqrt(overhead / shots)
+            quasi_dists.append(
+                QuasiDistribution(quasi, shots=shots, stddev_upper_bound=stddev)
+            )
         return SamplerResult(
-            quasi_dists=decoded["quasi_dists"],
+            quasi_dists=quasi_dists,
             metadata=decoded["metadata"],
         )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#455 converted `SamplerResult.quasi_dists` from dict to `QuasiDistribution` to match the `SamplerResult` description. That PR was written before we deprecated `_call` and moved to `_run`, so it only applied to the old path. It is also why the latest integration test failed.

This PR moved that code to `SamplerResultDecoder`, which does result processing when `job.result()` is called. 

@t-imamichi Are you ok if I use the old code in the old path - i.e. the result returned by `_call()` will be `SamplerResult` with a list of dict instead of `QuasiDistribution`? This way it's no longer a breaking change, and people using the new `run()` method will get the correct output (list of `QuasiDistribution`). 

### Details and comments
Fixes #

