### PR TITLE
Fix docs build 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ Sphinx>=1.8.3
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-automodapi
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints<=1.19.2
 matplotlib>=2.1
 jupyter
 jupyter-sphinx


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was an update to `sphinx-autodocs-typehints` today that seems to have broken our docs build 

broken build [here](https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/3131462331/jobs/5082827492)

https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/1.19.3

### Details and comments
Fixes #

