### PR TITLE
Fix TODO in howto doc

### DIFF
--- a/docs/how_to/retrieve_job_results.ipynb
+++ b/docs/how_to/retrieve_job_results.ipynb
@@ -4,16 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Retrieve job results\n",
+    "# Retrieve job and job results\n",
     "\n",
-    "This guide shows you how to view final job results after running a job.\n",
+    "This guide shows you how to retrieve a job you ran previously and its final results.\n",
     "\n",
     "## Before you begin\n",
     "\n",
-    "Throughout this guide we will assume that you have set the job you want to retrieve results as variable `job` by any of the following methods:\n",
-    "\n",
-    "1. [run a job using QiskitRuntimeService.run().](run_a_job.ipynb)\n",
-    "2. retrieve a job that has been ran before.\n",
+    "If you haven't already, check out the guide on [running a job using QiskitRuntimeService.run().](run_a_job.ipynb)\n",
     "\n",
     "We will retrieve an old job with job id in this guide."
    ]
@@ -25,8 +22,9 @@
     "tags": []
    },
    "source": [
-    "(Hidden cell)\n",
-    "TODO: link to how to retrieve job"
+    "## Retrieve a job\n",
+    "\n",
+    "If you have the job ID, you can use the [QiskitRuntimeService.job()](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.QiskitRuntimeService.job.html#qiskit_ibm_runtime.QiskitRuntimeService.job) method to retrieve a job you ran previously:"
    ]
   },
   {
@@ -47,11 +45,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If you don't have the job ID, or if you want to retrieve multiple jobs, you can instead use the [QiskitRuntimeService.jobs()](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.QiskitRuntimeService.jobs.html#qiskit_ibm_runtime.QiskitRuntimeService.jobs) method. This method has several filters that allow you to narrow down your search. The API documentation provides a list of all the filters and their descriptions. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This example retrieves the last 5 jobs using the 'sampler' program.\n",
+    "jobs = service.jobs(program_id=\"sampler\", limit=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `jobs()` method returns a list of [RuntimeJob](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.RuntimeJob.html#qiskit_ibm_runtime.RuntimeJob) instances. The `job` variable used in this guide is of the same type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "\n",
     "## Check job status\n",
     "\n",
-    "You can only retrieve job results afer the job has been completed. To check the job status, you can run:"
+    "You can only retrieve a job any time after running it. But you can only retrieve job results after the job has been completed. To check the job status, you can run:"
    ]
   },
   {
@@ -78,11 +100,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If it returns `<JobStatus.DONE: 'job has successfully run'>`, the job has been completed and you can proceed to retrieve job results.\n",
+    "If it returns `<JobStatus.DONE: 'job has successfully run'>`, the job has been completed.\n",
     "\n",
     "## Retrieve job results\n",
     "\n",
-    "You can retrieve job results using:"
+    "You can retrieve job results using the [RuntimeJob.result](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.RuntimeJob.result.html#qiskit_ibm_runtime.RuntimeJob.result) method. \n",
+    "\n",
+    "You don't have to wait for the job to complete before calling this method, but the method will block until the job is completed and results retrieved. "
    ]
   },
   {

--- a/docs/how_to/retrieve_job_results.ipynb
+++ b/docs/how_to/retrieve_job_results.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Retrieve job and job results\n",
     "\n",
-    "This guide shows you how to retrieve a job you ran previously and its final results.\n",
+    "This guide shows you how to retrieve a previously run job and its final results.\n",
     "\n",
     "## Before you begin\n",
     "\n",
@@ -73,7 +73,7 @@
     "\n",
     "## Check job status\n",
     "\n",
-    "You can only retrieve a job any time after running it. But you can only retrieve job results after the job has been completed. To check the job status, you can run:"
+    "You can retrieve a job any time after running it. But you can only retrieve job results after the job has been completed. To check the job status, you can run:"
    ]
   },
   {

--- a/releasenotes/notes/fix-howto-retrieve-job-ef991e8d6b444096.yaml
+++ b/releasenotes/notes/fix-howto-retrieve-job-ef991e8d6b444096.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes the missing section on retrieving jobs in the how-to guide.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The "how to retrieve job result" how-to guide had a `TODO: link to how to retrieve job`, and there isn't actually a guide on retrieving jobs. 

This PR replaces that TODO with actual steps on retrieving a job. 

### Details and comments
Fixes #

