### PR TITLE
Add callback to primitive interface

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -189,7 +189,7 @@ class Estimator(BaseEstimator):
             backend = session or backend
             self._session = get_default_session(service, backend)
 
-    def run(
+    def run(  # pylint: disable=arguments-differ
         self,
         circuits: QuantumCircuit | Sequence[QuantumCircuit],
         observables: BaseOperator | PauliSumOp | Sequence[BaseOperator | PauliSumOp],
@@ -241,7 +241,7 @@ class Estimator(BaseEstimator):
             **kwargs,
         )
 
-    def _run(
+    def _run(  # pylint: disable=arguments-differ
         self,
         circuits: Sequence[QuantumCircuit],
         observables: Sequence[BaseOperator | PauliSumOp],

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 import copy
-from typing import Iterable, Optional, Dict, Sequence, Any, Union
+from typing import Iterable, Optional, Dict, Sequence, Any, Union, Callable
 
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.quantum_info import SparsePauliOp
@@ -194,6 +194,7 @@ class Estimator(BaseEstimator):
         circuits: QuantumCircuit | Sequence[QuantumCircuit],
         observables: BaseOperator | PauliSumOp | Sequence[BaseOperator | PauliSumOp],
         parameter_values: Sequence[float] | Sequence[Sequence[float]] | None = None,
+        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the estimator primitive program.
@@ -205,6 +206,12 @@ class Estimator(BaseEstimator):
             observables: Observable objects.
 
             parameter_values: Concrete parameters to be bound.
+
+            callback: Callback function to be invoked for any interim results and final result.
+                The callback function will receive 2 positional parameters:
+
+                    1. Job ID
+                    2. Job result.
 
             **kwargs: Individual options to overwrite the default primitive options.
 
@@ -230,6 +237,7 @@ class Estimator(BaseEstimator):
             circuits=circuits,
             observables=observables,
             parameter_values=parameter_values,
+            callback=callback,
             **kwargs,
         )
 
@@ -238,6 +246,7 @@ class Estimator(BaseEstimator):
         circuits: Sequence[QuantumCircuit],
         observables: Sequence[BaseOperator | PauliSumOp],
         parameter_values: Sequence[Sequence[float]],
+        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the estimator primitive program.
@@ -271,6 +280,7 @@ class Estimator(BaseEstimator):
             program_id=self._PROGRAM_ID,
             inputs=inputs,
             options=Options._get_runtime_options(combined),
+            callback=callback,
             result_decoder=EstimatorResultDecoder,
         )
 

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -157,7 +157,7 @@ class Sampler(BaseSampler):
             backend = session or backend
             self._session = get_default_session(service, backend)
 
-    def run(
+    def run(  # pylint: disable=arguments-differ
         self,
         circuits: QuantumCircuit | Sequence[QuantumCircuit],
         parameter_values: Sequence[float] | Sequence[Sequence[float]] | None = None,
@@ -200,7 +200,7 @@ class Sampler(BaseSampler):
             **kwargs,
         )
 
-    def _run(
+    def _run(  # pylint: disable=arguments-differ
         self,
         circuits: Sequence[QuantumCircuit],
         parameter_values: Sequence[Sequence[float]],

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -13,7 +13,7 @@
 """Sampler primitive."""
 
 from __future__ import annotations
-from typing import Dict, Iterable, Optional, Sequence, Any, Union
+from typing import Dict, Iterable, Optional, Sequence, Any, Union, Callable
 import copy
 
 from qiskit.circuit import QuantumCircuit, Parameter
@@ -161,6 +161,7 @@ class Sampler(BaseSampler):
         self,
         circuits: QuantumCircuit | Sequence[QuantumCircuit],
         parameter_values: Sequence[float] | Sequence[Sequence[float]] | None = None,
+        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the sampler primitive program.
@@ -169,6 +170,11 @@ class Sampler(BaseSampler):
             circuits: A (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or
                 a list of (parameterized) :class:`~qiskit.circuit.QuantumCircuit`.
             parameter_values: Concrete parameters to be bound.
+            callback: Callback function to be invoked for any interim results and final result.
+                The callback function will receive 2 positional parameters:
+
+                    1. Job ID
+                    2. Job result.
             **kwargs: Individual options to overwrite the default primitive options.
 
         Returns:
@@ -190,6 +196,7 @@ class Sampler(BaseSampler):
         return super().run(
             circuits=circuits,
             parameter_values=parameter_values,
+            callback=callback,
             **kwargs,
         )
 
@@ -197,6 +204,7 @@ class Sampler(BaseSampler):
         self,
         circuits: Sequence[QuantumCircuit],
         parameter_values: Sequence[Sequence[float]],
+        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the sampler primitive program.
@@ -204,9 +212,8 @@ class Sampler(BaseSampler):
         Args:
             circuits: A (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or
                 a list of (parameterized) :class:`~qiskit.circuit.QuantumCircuit`.
-
             parameter_values: An optional list of concrete parameters to be bound.
-
+            callback: Callback function to be invoked for any interim results and final result.
             **kwargs: Individual options to overwrite the default primitive options.
 
         Returns:
@@ -225,6 +232,7 @@ class Sampler(BaseSampler):
             program_id=self._PROGRAM_ID,
             inputs=inputs,
             options=Options._get_runtime_options(combined),
+            callback=callback,
             result_decoder=SamplerResultDecoder,
         )
 

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -12,7 +12,7 @@
 
 """Qiskit Runtime flexible session."""
 
-from typing import Dict, Optional, Type, Union
+from typing import Dict, Optional, Type, Union, Callable
 from types import TracebackType
 from functools import wraps
 
@@ -108,6 +108,7 @@ class Session:
         program_id: str,
         inputs: Union[Dict, ParameterNamespace],
         options: Optional[Dict] = None,
+        callback: Optional[Callable] = None,
         result_decoder: Optional[Type[ResultDecoder]] = None,
     ) -> RuntimeJob:
         """Run a program in the session.
@@ -127,6 +128,7 @@ class Session:
                 * instance: The hub/group/project to use, in that format. This is only supported
                     for ``ibm_quantum`` channel. If ``None``, a hub/group/project that provides
                     access to the target backend is randomly selected.
+            callback: Callback function to be invoked for any interim results and final result.
 
         Returns:
             Submitted job.
@@ -146,6 +148,7 @@ class Session:
             session_id=self._session_id,
             start_session=self._session_id is None,
             max_execution_time=max_time,
+            callback=callback,
             result_decoder=result_decoder,
         )
 

--- a/releasenotes/notes/primitives-callback-80a7c2dcda960f4d.yaml
+++ b/releasenotes/notes/primitives-callback-80a7c2dcda960f4d.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The `run()` methods of the primitives now accept a `callback` parameter.
+    This parameter can be used to stream the interim and final results of the
+    primitives.

--- a/test/integration/test_estimator.py
+++ b/test/integration/test_estimator.py
@@ -14,6 +14,7 @@
 
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.quantum_info import SparsePauliOp
+from qiskit.test.reference_circuits import ReferenceCircuits
 
 from qiskit_ibm_runtime import Estimator, EstimatorResult, BaseEstimator, Session
 
@@ -24,11 +25,13 @@ from ..ibm_test_case import IBMIntegrationTestCase
 class TestIntegrationEstimator(IBMIntegrationTestCase):
     """Integration tests for Estimator primitive."""
 
+    def setUp(self) -> None:
+        super().setUp()
+        self.backend = "ibmq_qasm_simulator"
+
     @run_integration_test
     def test_estimator_session(self, service):
         """Verify if estimator primitive returns expected results"""
-
-        backend = "ibmq_qasm_simulator"
 
         psi1 = RealAmplitudes(num_qubits=2, reps=2)
         psi2 = RealAmplitudes(num_qubits=2, reps=3)
@@ -38,7 +41,7 @@ class TestIntegrationEstimator(IBMIntegrationTestCase):
         H2 = SparsePauliOp.from_list([("IZ", 1)])
         H3 = SparsePauliOp.from_list([("ZI", 1), ("ZZ", 1)])
 
-        with Session(service, backend) as session:
+        with Session(service, self.backend) as session:
             estimator = Estimator(session=session)
             self.assertIsInstance(estimator, BaseEstimator)
 
@@ -105,7 +108,7 @@ class TestIntegrationEstimator(IBMIntegrationTestCase):
     def test_estimator_primitive(self, service):
         """Test to verify that estimator as a primitive still works."""
 
-        options = {"backend": "ibmq_qasm_simulator"}
+        options = {"backend": self.backend}
 
         psi1 = RealAmplitudes(num_qubits=2, reps=2)
         psi2 = RealAmplitudes(num_qubits=2, reps=3)
@@ -163,3 +166,29 @@ class TestIntegrationEstimator(IBMIntegrationTestCase):
             self.assertIsInstance(result5, EstimatorResult)
             self.assertEqual(len(result5.values), len(circuits5))
             self.assertEqual(len(result5.metadata), len(circuits5))
+
+    @run_integration_test
+    def test_estimator_callback(self, service):
+        """Test Estimator callback function."""
+
+        def _callback(job_id_, result_):
+            nonlocal ws_result
+            ws_result.append(result_)
+            nonlocal job_ids
+            job_ids.add(job_id_)
+
+        ws_result = []
+        job_ids = set()
+
+        bell = ReferenceCircuits.bell()
+        obs = SparsePauliOp.from_list([("IZ", 1)])
+
+        with Session(service, self.backend) as session:
+            estimator = Estimator(session=session)
+            job = estimator.run(
+                circuits=bell, observables=[obs], callback=_callback
+            )
+            result = job.result()
+            self.assertEqual(result.values, ws_result[-1].values)
+            self.assertEqual(len(job_ids), 1)
+            self.assertEqual(job.job_id(), job_ids.pop())

--- a/test/integration/test_estimator.py
+++ b/test/integration/test_estimator.py
@@ -185,9 +185,7 @@ class TestIntegrationEstimator(IBMIntegrationTestCase):
 
         with Session(service, self.backend) as session:
             estimator = Estimator(session=session)
-            job = estimator.run(
-                circuits=bell, observables=[obs], callback=_callback
-            )
+            job = estimator.run(circuits=bell, observables=[obs], callback=_callback)
             result = job.result()
             self.assertEqual(result.values, ws_result[-1].values)
             self.assertEqual(len(job_ids), 1)

--- a/test/integration/test_sampler.py
+++ b/test/integration/test_sampler.py
@@ -13,7 +13,6 @@
 """Integration tests for Sampler primitive."""
 
 from math import sqrt
-from dataclasses import asdict
 
 from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.circuit.library import RealAmplitudes

--- a/test/integration/test_sampler.py
+++ b/test/integration/test_sampler.py
@@ -13,6 +13,8 @@
 """Integration tests for Sampler primitive."""
 
 from math import sqrt
+from dataclasses import asdict
+
 from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.test.reference_circuits import ReferenceCircuits
@@ -172,3 +174,25 @@ class TestIntegrationIBMSampler(IBMIntegrationTestCase):
             self.assertIsInstance(result, SamplerResult)
             self.assertEqual(len(result.quasi_dists), len(circuits0))
             self.assertEqual(len(result.metadata), len(circuits0))
+
+    @run_integration_test
+    def test_sampler_callback(self, service):
+        """Test Sampler callback function."""
+
+        def _callback(job_id_, result_):
+            nonlocal ws_result
+            ws_result.append(result_)
+            nonlocal job_ids
+            job_ids.add(job_id_)
+
+        ws_result = []
+        job_ids = set()
+
+        with Session(service, self.backend) as session:
+            sampler = Sampler(session=session)
+            job = sampler.run(circuits=self.bell, callback=_callback)
+            result = job.result()
+
+            self.assertEqual(result.quasi_dists, ws_result[-1].quasi_dists)
+            self.assertEqual(len(job_ids), 1)
+            self.assertEqual(job.job_id(), job_ids.pop())

--- a/test/unit/test_runtime_ws.py
+++ b/test/unit/test_runtime_ws.py
@@ -13,12 +13,16 @@
 """Test for the Websocket client."""
 
 import time
+from unittest.mock import MagicMock
 
 from qiskit.providers.fake_provider import FakeQasmSimulator
-
-from qiskit_ibm_runtime import RuntimeJob
+from qiskit.test.reference_circuits import ReferenceCircuits
+from qiskit.quantum_info import SparsePauliOp
+from qiskit_ibm_runtime import RuntimeJob, QiskitRuntimeService, Sampler, Estimator, Session
 from qiskit_ibm_runtime.api.client_parameters import ClientParameters
 from qiskit_ibm_runtime.exceptions import RuntimeInvalidStateError
+from qiskit_ibm_runtime.ibm_backend import IBMBackend
+
 from .mock.fake_runtime_client import BaseFakeRuntimeClient
 from .mock.ws_handler import (
     websocket_handler,
@@ -64,6 +68,32 @@ class TestRuntimeWebsocketClient(IBMTestCase):
         time.sleep(JOB_PROGRESS_RESULT_COUNT + 2)
         self.assertEqual(JOB_PROGRESS_RESULT_COUNT, len(results))
         self.assertFalse(job._ws_client.connected)
+
+    def test_primitive_interim_result_callback(self):
+        """Test primitive interim result callback."""
+
+        def result_callback(job_id, interim_result):
+            nonlocal results
+            results.append(interim_result)
+            self.assertEqual(JOB_ID_PROGRESS_DONE, job_id)
+
+        def _patched_run(callback, *args, **kwargs):
+            return self._get_job(callback=callback, backend=MagicMock(spec=IBMBackend))
+
+        service = MagicMock(spec=QiskitRuntimeService)
+        service.run = _patched_run
+
+        qx = ReferenceCircuits.bell()
+        obs = SparsePauliOp.from_list([("IZ", 1)])
+        primitives = [Sampler, Estimator]
+        for cls in primitives:
+            with self.subTest(primitive=cls):
+                results = []
+                inst = cls(session=Session(service=service))
+                job = inst.run(qx, observables=obs, callback=result_callback)
+                time.sleep(JOB_PROGRESS_RESULT_COUNT + 2)
+                self.assertEqual(JOB_PROGRESS_RESULT_COUNT, len(results))
+                self.assertFalse(job._ws_client.connected)
 
     def test_stream_results(self):
         """Test streaming results."""
@@ -184,13 +214,14 @@ class TestRuntimeWebsocketClient(IBMTestCase):
         self.assertEqual(0, len(results))
         self.assertFalse(job._ws_client.connected)
 
-    def _get_job(self, callback=None, job_id=JOB_ID_PROGRESS_DONE):
+    def _get_job(self, callback=None, job_id=JOB_ID_PROGRESS_DONE, backend=None):
         """Get a runtime job."""
         params = ClientParameters(
             channel="ibm_quantum", token="my_token", url=MockWsServer.VALID_WS_URL
         )
+        backend = backend or FakeQasmSimulator()
         job = RuntimeJob(
-            backend=FakeQasmSimulator(),
+            backend=backend,
             api_client=BaseFakeRuntimeClient(),
             client_params=params,
             job_id=job_id,

--- a/test/unit/test_runtime_ws.py
+++ b/test/unit/test_runtime_ws.py
@@ -18,7 +18,13 @@ from unittest.mock import MagicMock
 from qiskit.providers.fake_provider import FakeQasmSimulator
 from qiskit.test.reference_circuits import ReferenceCircuits
 from qiskit.quantum_info import SparsePauliOp
-from qiskit_ibm_runtime import RuntimeJob, QiskitRuntimeService, Sampler, Estimator, Session
+from qiskit_ibm_runtime import (
+    RuntimeJob,
+    QiskitRuntimeService,
+    Sampler,
+    Estimator,
+    Session,
+)
 from qiskit_ibm_runtime.api.client_parameters import ClientParameters
 from qiskit_ibm_runtime.exceptions import RuntimeInvalidStateError
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
@@ -77,20 +83,20 @@ class TestRuntimeWebsocketClient(IBMTestCase):
             results.append(interim_result)
             self.assertEqual(JOB_ID_PROGRESS_DONE, job_id)
 
-        def _patched_run(callback, *args, **kwargs):
+        def _patched_run(callback, *args, **kwargs):  # pylint: disable=unused-argument
             return self._get_job(callback=callback, backend=MagicMock(spec=IBMBackend))
 
         service = MagicMock(spec=QiskitRuntimeService)
         service.run = _patched_run
 
-        qx = ReferenceCircuits.bell()
+        circ = ReferenceCircuits.bell()
         obs = SparsePauliOp.from_list([("IZ", 1)])
         primitives = [Sampler, Estimator]
         for cls in primitives:
             with self.subTest(primitive=cls):
                 results = []
                 inst = cls(session=Session(service=service))
-                job = inst.run(qx, observables=obs, callback=result_callback)
+                job = inst.run(circ, observables=obs, callback=result_callback)
                 time.sleep(JOB_PROGRESS_RESULT_COUNT + 2)
                 self.assertEqual(JOB_PROGRESS_RESULT_COUNT, len(results))
                 self.assertFalse(job._ws_client.connected)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Allow users to specify a callback function to stream interim results, such as error mitigation progress, of primitives. 


### Details and comments
Fixes #504 

