### PR TITLE
Fix environment options in from_dict

### DIFF
--- a/qiskit_ibm_runtime/options.py
+++ b/qiskit_ibm_runtime/options.py
@@ -284,13 +284,15 @@ class Options:
     @classmethod
     def _from_dict(cls, data: Dict) -> "Options":
         data = copy.copy(data)
+        environ_dict = data.pop("environment", {})
         if "image" in data.keys():
             issue_deprecation_msg(
                 msg="The 'image' option has been moved to the 'environment' category",
                 version="0.7",
                 remedy="Please specify 'environment':{'image': image} instead.",
             )
-        environment = EnvironmentOptions(image=data.pop("image", None))
+            environ_dict["image"] = data.pop("image")
+        environment = EnvironmentOptions(**environ_dict)
         transp = TranspilationOptions(**data.pop("transpilation", {}))
         execution = ExecutionOptions(**data.pop("execution", {}))
         return cls(

--- a/test/unit/test_options.py
+++ b/test/unit/test_options.py
@@ -44,6 +44,10 @@ class TestOptions(IBMTestCase):
             {},
             {"resilience_level": 9},
             {"resilience_level": 9, "transpilation": {"seed_transpiler": 24}},
+            {
+                "execution": {"shots": 100},
+                "environment": {"image": "foo:bar", "log_level": "INFO"},
+            },
         ]
         for new_ops in options_vars:
             with self.subTest(new_ops=new_ops):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix a bug in `Options._from_dict` where it only looked at `image` and ignored the other options. 


### Details and comments
Fixes #

