### PR TITLE
Pass in correct instance in service.run()

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -932,7 +932,9 @@ class QiskitRuntimeService(Provider):
         hgp_name = None
         if self._channel == "ibm_quantum":
             # Find the right hgp
-            hgp = self._get_hgp(instance=instance, backend_name=qrt_options.backend)
+            hgp = self._get_hgp(
+                instance=qrt_options.instance, backend_name=qrt_options.backend
+            )
             backend = hgp.backend(qrt_options.backend)
             hgp_name = hgp.name
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`qrt_options.instance` should be passed in instead of `instance`

Currently, this wouldn't use the correct instance 

```python
options = Options(environment= {'instance':'ibm-q/open/main'})
with Session(service=service, backend="ibmq_qasm_simulator") as session:
    sampler = Sampler(session=session, options=options)
    job = sampler.run(...)
```


