### PR TITLE
Move callback to Options

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -300,7 +300,7 @@ class Estimator(BaseEstimator):
             program_id=self._PROGRAM_ID,
             inputs=inputs,
             options=Options._get_runtime_options(combined),
-            callback=combined["environment"]["callback"],
+            callback=combined.get("environment", {}).get("callback", None),
             result_decoder=EstimatorResultDecoder,
         )
 

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 import copy
 import json
-from typing import Iterable, Optional, Dict, Sequence, Any, Union, Callable
+from typing import Iterable, Optional, Dict, Sequence, Any, Union
 
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.quantum_info import SparsePauliOp
@@ -209,7 +209,6 @@ class Estimator(BaseEstimator):
         circuits: QuantumCircuit | Sequence[QuantumCircuit],
         observables: BaseOperator | PauliSumOp | Sequence[BaseOperator | PauliSumOp],
         parameter_values: Sequence[float] | Sequence[Sequence[float]] | None = None,
-        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the estimator primitive program.
@@ -221,12 +220,6 @@ class Estimator(BaseEstimator):
             observables: Observable objects.
 
             parameter_values: Concrete parameters to be bound.
-
-            callback: Callback function to be invoked for any interim results and final result.
-                The callback function will receive 2 positional parameters:
-
-                    1. Job ID
-                    2. Job result.
 
             **kwargs: Individual options to overwrite the default primitive options.
 
@@ -252,7 +245,6 @@ class Estimator(BaseEstimator):
             circuits=circuits,
             observables=observables,
             parameter_values=parameter_values,
-            callback=callback,
             **kwargs,
         )
 
@@ -261,7 +253,6 @@ class Estimator(BaseEstimator):
         circuits: Sequence[QuantumCircuit],
         observables: Sequence[BaseOperator | PauliSumOp],
         parameter_values: Sequence[Sequence[float]],
-        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the estimator primitive program.
@@ -309,7 +300,7 @@ class Estimator(BaseEstimator):
             program_id=self._PROGRAM_ID,
             inputs=inputs,
             options=Options._get_runtime_options(combined),
-            callback=callback,
+            callback=combined["environment"]["callback"],
             result_decoder=EstimatorResultDecoder,
         )
 

--- a/qiskit_ibm_runtime/options.py
+++ b/qiskit_ibm_runtime/options.py
@@ -12,7 +12,7 @@
 
 """Primitive options."""
 
-from typing import Optional, List, Dict, Union, Any, ClassVar
+from typing import Optional, List, Dict, Union, Any, ClassVar, Callable
 from dataclasses import dataclass, asdict, fields, field, make_dataclass
 import copy
 
@@ -160,6 +160,7 @@ class EnvironmentOptions:
     log_level: str = "WARNING"
     image: Optional[str] = None
     instance: Optional[str] = None
+    callback: Optional[Callable] = None
 
 
 @_flexible
@@ -263,6 +264,11 @@ class Options:
             * instance: The hub/group/project to use, in that format. This is only supported
                 for ``ibm_quantum`` channel. If ``None``, a hub/group/project that provides
                 access to the target backend is randomly selected.
+            * callback: Callback function to be invoked for any interim results and final result.
+                The callback function will receive 2 positional parameters:
+
+                    1. Job ID
+                    2. Job result.
     """
 
     optimization_level: int = 1

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -252,7 +252,7 @@ class Sampler(BaseSampler):
             program_id=self._PROGRAM_ID,
             inputs=inputs,
             options=Options._get_runtime_options(combined),
-            callback=combined["environment"]["callback"],
+            callback=combined.get("environment", {}).get("callback", None),
             result_decoder=SamplerResultDecoder,
         )
 

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -13,7 +13,7 @@
 """Sampler primitive."""
 
 from __future__ import annotations
-from typing import Dict, Iterable, Optional, Sequence, Any, Union, Callable
+from typing import Dict, Iterable, Optional, Sequence, Any, Union
 import copy
 import json
 
@@ -176,7 +176,6 @@ class Sampler(BaseSampler):
         self,
         circuits: QuantumCircuit | Sequence[QuantumCircuit],
         parameter_values: Sequence[float] | Sequence[Sequence[float]] | None = None,
-        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the sampler primitive program.
@@ -185,11 +184,6 @@ class Sampler(BaseSampler):
             circuits: A (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or
                 a list of (parameterized) :class:`~qiskit.circuit.QuantumCircuit`.
             parameter_values: Concrete parameters to be bound.
-            callback: Callback function to be invoked for any interim results and final result.
-                The callback function will receive 2 positional parameters:
-
-                    1. Job ID
-                    2. Job result.
             **kwargs: Individual options to overwrite the default primitive options.
 
         Returns:
@@ -211,7 +205,6 @@ class Sampler(BaseSampler):
         return super().run(
             circuits=circuits,
             parameter_values=parameter_values,
-            callback=callback,
             **kwargs,
         )
 
@@ -219,7 +212,6 @@ class Sampler(BaseSampler):
         self,
         circuits: Sequence[QuantumCircuit],
         parameter_values: Sequence[Sequence[float]],
-        callback: Optional[Callable] = None,
         **kwargs: Any,
     ) -> RuntimeJob:
         """Submit a request to the sampler primitive program.
@@ -228,7 +220,6 @@ class Sampler(BaseSampler):
             circuits: A (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or
                 a list of (parameterized) :class:`~qiskit.circuit.QuantumCircuit`.
             parameter_values: An optional list of concrete parameters to be bound.
-            callback: Callback function to be invoked for any interim results and final result.
             **kwargs: Individual options to overwrite the default primitive options.
 
         Returns:
@@ -261,7 +252,7 @@ class Sampler(BaseSampler):
             program_id=self._PROGRAM_ID,
             inputs=inputs,
             options=Options._get_runtime_options(combined),
-            callback=callback,
+            callback=combined["environment"]["callback"],
             result_decoder=SamplerResultDecoder,
         )
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Move the `callback` parameter to the `Options` class to keep `run()` more consistent with the base classes. 


### Details and comments
Fixes #

