### PR TITLE
Remove backend.run

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -14,12 +14,9 @@
 
 import logging
 
-from typing import Iterable, Union, Optional, Any, List, Callable, Type, Dict
+from typing import Iterable, Union, Optional, Any, List
 from datetime import datetime as python_datetime
 
-
-from qiskit.circuit import QuantumCircuit
-from qiskit.pulse import Schedule, LoConfig
 from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
@@ -32,7 +29,6 @@ from qiskit.providers.models import (
     PulseBackendConfiguration,
 )
 from qiskit.pulse.channels import (
-    PulseChannel,
     AcquireChannel,
     ControlChannel,
     DriveChannel,
@@ -43,8 +39,6 @@ from qiskit.transpiler.target import Target
 from qiskit_ibm_runtime import (  # pylint: disable=unused-import,cyclic-import
     qiskit_runtime_service,
 )
-from qiskit_ibm_runtime.program.result_decoder import ResultDecoder
-from qiskit_ibm_runtime.runtime_job import RuntimeJob
 
 from .api.clients import AccountClient, RuntimeClient
 from .api.clients.backend import BaseBackendClient
@@ -485,97 +479,11 @@ class IBMBackend(Backend):
         # For backward compatibility only, can be removed later.
         return self
 
-    def run(
-        self,
-        circuits: Union[
-            QuantumCircuit, Schedule, List[Union[QuantumCircuit, Schedule]]
-        ],
-        program_id: str = "circuit-runner",
-        shots: Optional[Union[int, float]] = None,
-        qubit_lo_freq: Optional[List[int]] = None,
-        meas_lo_freq: Optional[List[int]] = None,
-        schedule_los: Optional[
-            Union[
-                List[Union[Dict[PulseChannel, float], LoConfig]],
-                Union[Dict[PulseChannel, float], LoConfig],
-            ]
-        ] = None,
-        rep_delay: Optional[float] = None,
-        init_qubits: Optional[bool] = None,
-        use_measure_esp: Optional[bool] = None,
-        callback: Optional[Callable] = None,
-        result_decoder: Optional[Type[ResultDecoder]] = None,
-        instance: Optional[str] = None,
-        session_id: Optional[str] = None,
-        job_tags: Optional[List[str]] = None,
-        max_execution_time: Optional[int] = None,
-        start_session: Optional[bool] = None,
-        **kwargs: Any
-    ) -> RuntimeJob:
-        """Run on the backend by calling the ciruict-runner program.
-
-        Args:
-            circuits: An individual or a
-                list of :class:`~qiskit.circuits.QuantumCircuit` or
-                :class:`~qiskit.pulse.Schedule` objects to run on the backend.
-            program_id: Program ID which defaults to ``circuit-runner``.
-            shots: Number of repetitions of each circuit, for sampling. Default: 4000
-                or ``max_shots`` from the backend configuration, whichever is smaller.
-            qubit_lo_freq: List of default qubit LO frequencies in Hz. Will be overridden by
-                ``schedule_los`` if set.
-            meas_lo_freq: List of default measurement LO frequencies in Hz. Will be overridden
-                by ``schedule_los`` if set.
-            schedule_los: schedule_los: Experiment LO configurations, frequencies are given in Hz.
-            rep_delay: Delay between programs in seconds.
-            init_qubits: Whether to reset the qubits to the ground state for each shot.
-            use_measure_esp: Whether to use excited state promoted (ESP) readout for measurements
-                which are the terminal instruction to a qubit.
-            callback: Callback function to be invoked for any interim results and final result.
-            result_decoder: A :class:`ResultDecoder` subclass used to decode job results.
-            instance: This is only supported for ``ibm_quantum`` runtime and is in the
-                hub/group/project format.
-            session_id: Job ID of the first job in a runtime session.
-            job_tags: Tags to be assigned to the job.
-            max_execution_time: Maximum execution time in seconds.
-            start_session: Set to True to explicitly start a runtime session. Defaults to False.
-            **kwargs: Additional arguments for inputs.
-
-        Returns:
-             A ``RuntimeJob`` instance representing the execution.
-        """
+    def run(self, *args: Any, **kwargs: Any) -> None:
+        """Not supported method"""
         # pylint: disable=arguments-differ
-        options = {"backend_name": self.name}
-        inputs = {"circuits": circuits}
-        if shots:
-            inputs["shots"] = shots
-        if qubit_lo_freq:
-            inputs["qubit_lo_freq"] = qubit_lo_freq
-        if meas_lo_freq:
-            inputs["meas_lo_freq"] = meas_lo_freq
-        if schedule_los:
-            inputs["schedule_los"] = schedule_los
-        if rep_delay:
-            inputs["rep_delay"] = rep_delay
-        if init_qubits is not None:
-            inputs["init_qubits"] = init_qubits
-        if use_measure_esp is not None:
-            inputs["use_measure_esp"] = use_measure_esp
-        if kwargs:
-            for key, value in kwargs.items():
-                inputs[key] = value
-
-        return qiskit_runtime_service.QiskitRuntimeService.run(
-            self.service,
-            program_id=program_id,
-            inputs=inputs,
-            options=options,
-            callback=callback,
-            result_decoder=result_decoder,
-            instance=instance,
-            session_id=session_id,
-            job_tags=job_tags,
-            max_execution_time=max_execution_time,
-            start_session=start_session,
+        raise RuntimeError(
+            "IBMBackend.run() is not supported in the Qiskit Runtime environment."
         )
 
 

--- a/releasenotes/notes/0.7/add-backend-run-911bda849f637ca0.yaml
+++ b/releasenotes/notes/0.7/add-backend-run-911bda849f637ca0.yaml
@@ -1,5 +1,0 @@
----
-upgrade:
-  - |
-    Users can now call :meth:`~qiskit_ibm_runtime.IBMBackend.run` to run jobs
-    on the given backend through the ``circuit-runner`` program. 

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -12,13 +12,9 @@
 
 """Tests for backend functions using real runtime service."""
 
-import os
 from unittest import SkipTest
 
 from qiskit.transpiler.target import Target
-from qiskit.providers.jobstatus import JobStatus
-from qiskit.test.reference_circuits import ReferenceCircuits
-
 from qiskit_ibm_runtime import QiskitRuntimeService
 
 from ..ibm_test_case import IBMIntegrationTestCase
@@ -137,18 +133,8 @@ class TestIBMBackend(IBMIntegrationTestCase):
                 backend.foobar  # pylint: disable=pointless-statement
 
     def test_backend_run(self):
-        """Test running a job from a backend."""
-        if self.dependencies.channel == "ibm_cloud":
-            raise SkipTest(
-                "Skip since cloud account does not have circuit-runner program."
-            )
-        if os.environ.get("QISKIT_IBM_USE_STAGING_CREDENTIALS", ""):
-            backend = self.dependencies.service.backend("ibmq_qasm_simulator")
-            job = backend.run(ReferenceCircuits.bell(), shots=10)
-        else:
-            job = self.backend.run(ReferenceCircuits.bell(), shots=10)
-        job.wait_for_final_state()
-        result = job.result()
-        self.assertTrue(result)
-        self.assertEqual(result["results"][0]["shots"], 10)
-        self.assertEqual(JobStatus.DONE, job.status())
+        """Check one cannot do backend.run"""
+        backend = self.backend
+        with self.subTest(backend=backend.name):
+            with self.assertRaises(RuntimeError):
+                backend.run()


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After some discussion with @tmittal947 we thought it's better not add `backend.run()` in `qiskit-ibm-runtime` for a number of reasons:

1. It's not supported by all channels
2. `qiskit-ibm-runtime` is supposed to focus on the "managed services" experience, and `backend.run()` is the opposite of that. Instead, any need of direct access should be done using the new `qiskit-ibm-provider`.
3. It's confusing to users when we have `backend.run()` in both `qiskit-ibm-runtime` and `qiskit-ibm-provider`. 

Sorry @kt474 


### Details and comments
Fixes #

