### PR TITLE
No need to pass parameters from client

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -289,7 +289,6 @@ class Estimator(BaseEstimator):
             "circuit_ids": circuit_ids,
             "observables": observables,
             "observable_indices": list(range(len(observables))),
-            "parameters": [circ.parameters for circ in circuits],
             "parameter_values": parameter_values,
         }
 

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -241,7 +241,6 @@ class Sampler(BaseSampler):
 
         inputs = {
             "circuits": circuits_map,
-            "parameters": [circ.parameters for circ in circuits],
             "circuit_ids": circuit_ids,
             "parameter_values": parameter_values,
         }


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The primitive programs on the server side do this and hence no need to pass from client.

Should fix below error when running circuit from #568:
```
File "/code/program.py", line 1158, in main\n
2022-10-10T13:20:37.811939030Z     result = estimator.run(\n
2022-10-10T13:20:37.811959070Z   File "/code/program.py", line 207, in run\n
2022-10-10T13:20:37.812024750Z     self._validate_parameters(\n
2022-10-10T13:20:37.812041987Z   File "/code/program.py", line 585, in _validate_parameters\n
2022-10-10T13:20:37.812278740Z     raise QiskitError(\n2022-10-10T13:20:37.812298997Z qiskit.exceptions.QiskitError: \'Different number of parameters (15) and circuits (60).\'\n'
```

### Details and comments
Fixes #

