### PR TITLE
Fix log_level from old options

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -186,7 +186,16 @@ class Estimator(BaseEstimator):
             skip_transpilation = options.get("transpilation", {}).get(
                 "skip_transpilation", False
             )
+            log_level = options_copy.pop("log_level", None)
             _options = Options(**options_copy)
+            if log_level:
+                issue_deprecation_msg(
+                    msg="The 'log_level' option has been moved to the 'environment' category",
+                    version="0.7",
+                    remedy="Please specify 'environment':{'log_level': log_level} instead.",
+                )
+                _options.environment.log_level = log_level  # type: ignore[union-attr]
+
         _options.transpilation.skip_transpilation = (  # type: ignore[union-attr]
             skip_transpilation
         )

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -16,12 +16,12 @@ from typing import Optional, Union, ClassVar
 from dataclasses import dataclass, fields, field
 import copy
 
-from ..runtime_options import RuntimeOptions
 from .utils import _flexible, Dict
 from .environment_options import EnvironmentOptions
 from .execution_options import ExecutionOptions
 from .simulator_options import SimulatorOptions
 from .transpilation_options import TranspilationOptions
+from ..runtime_options import RuntimeOptions
 
 
 @_flexible
@@ -133,6 +133,9 @@ class Options:
         for fld in fields(RuntimeOptions):
             if fld.name in environment:
                 out[fld.name] = environment[fld.name]
+
+        if "image" in options:
+            out["image"] = options["image"]
 
         return out
 

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -148,7 +148,8 @@ class Sampler(BaseSampler):
                 _options.transpilation.skip_transpilation  # type: ignore[union-attr]
             )
         else:
-            backend = options.pop("backend", None)
+            options_copy = copy.deepcopy(options)
+            backend = options_copy.pop("backend", None)
             if backend is not None:
                 issue_deprecation_msg(
                     msg="The 'backend' key in 'options' has been deprecated",
@@ -158,7 +159,16 @@ class Sampler(BaseSampler):
             skip_transpilation = options.get("transpilation", {}).get(
                 "skip_transpilation", False
             )
-            _options = Options(**options)
+            log_level = options_copy.pop("log_level", None)
+            _options = Options(**options_copy)
+            if log_level:
+                issue_deprecation_msg(
+                    msg="The 'log_level' option has been moved to the 'environment' category",
+                    version="0.7",
+                    remedy="Please specify 'environment':{'log_level': log_level} instead.",
+                )
+                _options.environment.log_level = log_level  # type: ignore[union-attr]
+
         _options.transpilation.skip_transpilation = (  # type: ignore[union-attr]
             skip_transpilation
         )

--- a/test/unit/test_ibm_primitives.py
+++ b/test/unit/test_ibm_primitives.py
@@ -136,7 +136,7 @@ class TestPrimitives(IBMTestCase):
             for opt in options:
                 with self.subTest(primitive=cls, options=opt):
                     inst = cls(session=session, options=opt)
-                    inst.run(self.qx, observable=self.obs)
+                    inst.run(self.qx, observables=self.obs)
                     _, kwargs = session.run.call_args
                     run_options = kwargs["options"]
                     for key, val in opt.items():

--- a/test/unit/test_ibm_primitives.py
+++ b/test/unit/test_ibm_primitives.py
@@ -126,6 +126,22 @@ class TestPrimitives(IBMTestCase):
                         )
                     self.assertEqual(inst.session.backend(), backend_name)
 
+    def test_old_options(self):
+        """Test specifying old runtime options."""
+        primitives = [Sampler, Estimator]
+        session = MagicMock(spec=MockSession)
+        options = [{"log_level": "WARNING"}, {"image": "foo:bar"}]
+
+        for cls in primitives:
+            for opt in options:
+                with self.subTest(primitive=cls, options=opt):
+                    inst = cls(session=session, options=opt)
+                    inst.run(self.qx, observable=self.obs)
+                    _, kwargs = session.run.call_args
+                    run_options = kwargs["options"]
+                    for key, val in opt.items():
+                        self.assertEqual(run_options[key], val)
+
     def test_runtime_options(self):
         """Test RuntimeOptions specified as primitive options."""
         session = MagicMock(spec=MockSession)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The old `options` parameter in `Sampler` and `Estimator` constructors [allowed `log_level` to be specified](https://github.com/Qiskit/qiskit-ibm-runtime/blob/0.6.2/qiskit_ibm_runtime/sampler.py#L58-L60). Since `log_level` is now under `environment`, we should still accept it with a deprecation warning. 

It also allowed `image`, which is now an implicit option but still needs to be copied to runtime options.

### Details and comments
Fixes #

