### PR TITLE
Sleep less when polling for status

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -271,7 +271,7 @@ class RuntimeJob(Job):
                     raise RuntimeJobTimeoutError(
                         f"Timed out waiting for job to complete after {timeout} secs."
                     )
-                time.sleep(3)
+                time.sleep(0.1)
                 status = self.status()
         except futures.TimeoutError:
             raise RuntimeJobTimeoutError(


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A `sleep()` was added to `job.wait_for_final_state` because job status may not become final when websocket is closed. But sleeping for 3s seems a bit excessive and is really hurting our performance numbers. 


### Details and comments
Fixes #

