### PR TITLE
Update test_coder_operators

### DIFF
--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -59,7 +59,7 @@ from qiskit.opflow import (
     TensoredOp,
 )
 from qiskit.providers.fake_provider import FakeNairobi
-from qiskit.quantum_info import SparsePauliOp, Pauli, PauliTable, Statevector
+from qiskit.quantum_info import SparsePauliOp, Pauli, Statevector
 from qiskit.result import Result
 from qiskit_aer.noise import NoiseModel
 

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -133,8 +133,6 @@ class TestDataSerialization(IBMTestCase):
         coeff_y = coeff_x + 1
         quantum_circuit = QuantumCircuit(1)
         quantum_circuit.h(0)
-        coeffs = np.array([1, 2, 3, 4, 5, 6])
-        table = PauliTable.from_labels(["III", "IXI", "IYY", "YIZ", "XYZ", "III"])
         operator = 2.0 * I ^ I
         z2_symmetries = Z2Symmetries(
             [Pauli("IIZI"), Pauli("ZIII")],
@@ -152,7 +150,6 @@ class TestDataSerialization(IBMTestCase):
             PauliSumOp.from_list(
                 [("II", -1.052373245772859), ("IZ", 0.39793742484318045)]
             ),
-            PauliSumOp(SparsePauliOp(table, coeffs), coeff=10),
             MatrixOp(primitive=np.array([[0, -1j], [1j, 0]]), coeff=coeff_x),
             PauliOp(primitive=Pauli("Y"), coeff=coeff_x),
             CircuitOp(quantum_circuit, coeff=coeff_x),


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The PauliTable class has been deprecated in the latest version of terra causing this unit test to fail 

### Details and comments
Fixes #

