### PR TITLE
Remove callback from tutorial doc

### DIFF
--- a/docs/tutorials/how-to-getting-started-with-estimator.ipynb
+++ b/docs/tutorials/how-to-getting-started-with-estimator.ipynb
@@ -78,7 +78,6 @@
     "- **circuits**: A list of (parameterized) circuits that you want to investigate.\n",
     "- **observables**: A list of observables to measure the expectation values.\n",
     "- **parameter_values**: An optional list of concrete parameters to be bound.\n",
-    "- **callback**: A callback function to be invoked for any interim results and final result.\n",
     "- **kwargs**: Additional options to overwrite the default values. \n",
     "\n",
     "You can find more details in [the Estimator API reference](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.Estimator.html).\n",

--- a/docs/tutorials/how-to-getting-started-with-sampler.ipynb
+++ b/docs/tutorials/how-to-getting-started-with-sampler.ipynb
@@ -75,7 +75,6 @@
     "\n",
     "- **circuits**: A list of (parameterized) circuits that you want to investigate.\n",
     "- **parameter_values**: An optional list of concrete parameters to be bound.\n",
-    "- **callback**: A callback function to be invoked for any interim results and final result.\n",
     "- **kwargs**: Additional options to overwrite the default values. \n",
     "  \n",
     "You can find more details in [the Sampler API reference](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.Sampler.html).\n",


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`callback` was moved into `Options` to make `run()` more consistent with the base classes. This PR updates the tutorials which still referenced `callback` as a parameters to `run()`. 

### Details and comments
Fixes #

