### PR TITLE
Use base primitives from terra 0.22

### DIFF
--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -218,14 +218,6 @@ from .estimator import Estimator
 from .sampler import Sampler
 from .options import Options
 
-# TODO remove when terra code is released
-from .qiskit.primitives import (
-    BaseEstimator,
-    EstimatorResult,
-    BaseSampler,
-    SamplerResult,
-)
-
 # Setup the logger for the IBM Quantum Provider package.
 logger = logging.getLogger(__name__)
 setup_logger(logger)

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -24,11 +24,9 @@ from qiskit.quantum_info import SparsePauliOp
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.providers.options import Options as TerraOptions
+from qiskit.primitives import BaseEstimator, EstimatorResult
 
-# pylint: disable=unused-import,cyclic-import
-
-# TODO import BaseEstimator and EstimatorResult from terra once released
-from .qiskit.primitives import BaseEstimator, EstimatorResult
+# TODO import _circuit_key from terra once 0.23 is released
 from .qiskit.primitives.utils import _circuit_key
 from .qiskit_runtime_service import QiskitRuntimeService
 from .utils.estimator_result_decoder import EstimatorResultDecoder

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -21,9 +21,9 @@ from dataclasses import asdict
 
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.providers.options import Options as TerraOptions
+from qiskit.primitives import BaseSampler, SamplerResult
 
-# TODO import BaseSampler and SamplerResult from terra once released
-from .qiskit.primitives import BaseSampler, SamplerResult
+# TODO import _circuit_key from terra once 0.23 released
 from .qiskit.primitives.utils import _circuit_key
 from .qiskit_runtime_service import QiskitRuntimeService
 from .options import Options
@@ -114,7 +114,7 @@ class Sampler(BaseSampler):
                 The ``backend`` keyword is still supported but is deprecated.
 
             skip_transpilation (DEPRECATED): Transpilation is skipped if set to True. False by default.
-                Ignored ``skip_transpilation`` is also specified in ``options``.
+                Ignored if ``skip_transpilation`` is also specified in ``options``.
         """
         # `_options` in this class is an instance of qiskit_ibm_runtime.Options class.
         # The base class, however, uses a `_run_options` which is an instance of

--- a/qiskit_ibm_runtime/utils/estimator_result_decoder.py
+++ b/qiskit_ibm_runtime/utils/estimator_result_decoder.py
@@ -15,8 +15,9 @@
 from typing import Dict
 import numpy as np
 
+from qiskit.primitives import EstimatorResult
+
 from ..program.result_decoder import ResultDecoder
-from ..qiskit.primitives import EstimatorResult
 
 
 class EstimatorResultDecoder(ResultDecoder):

--- a/qiskit_ibm_runtime/utils/sampler_result_decoder.py
+++ b/qiskit_ibm_runtime/utils/sampler_result_decoder.py
@@ -14,9 +14,11 @@
 
 from typing import Dict
 from math import sqrt
+
 from qiskit.result import QuasiDistribution
+from qiskit.primitives import SamplerResult
+
 from ..program.result_decoder import ResultDecoder
-from ..qiskit.primitives import SamplerResult
 
 
 class SamplerResultDecoder(ResultDecoder):

--- a/releasenotes/notes/upgrade-terra-80a543c559e259ce.yaml
+++ b/releasenotes/notes/upgrade-terra-80a543c559e259ce.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    This version of qiskit-ibm-runtime requires qiskit-terra version 0.22 or
+    higher. The ``requirements.txt`` file has been updated accordingly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.21.2
+qiskit-terra>=0.22
 requests>=2.19
 requests_ntlm>=1.1.0
 numpy>=1.13

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import os
 import setuptools
 
 REQUIREMENTS = [
-    "qiskit-terra>=0.21.2",
+    "qiskit-terra>=0.22",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",
     "numpy>=1.13",

--- a/test/integration/test_estimator.py
+++ b/test/integration/test_estimator.py
@@ -16,8 +16,9 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.test.reference_circuits import ReferenceCircuits
+from qiskit.primitives import BaseEstimator, EstimatorResult
 
-from qiskit_ibm_runtime import Estimator, EstimatorResult, BaseEstimator, Session
+from qiskit_ibm_runtime import Estimator, Session
 from qiskit_ibm_runtime.exceptions import RuntimeJobFailureError
 
 from ..decorators import run_integration_test

--- a/test/integration/test_sampler.py
+++ b/test/integration/test_sampler.py
@@ -17,8 +17,9 @@ from math import sqrt
 from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.test.reference_circuits import ReferenceCircuits
+from qiskit.primitives import BaseSampler, SamplerResult
 
-from qiskit_ibm_runtime import Sampler, BaseSampler, SamplerResult, Session
+from qiskit_ibm_runtime import Sampler, Session
 from qiskit_ibm_runtime.exceptions import RuntimeJobFailureError
 
 from ..decorators import run_integration_test

--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -15,13 +15,12 @@
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.test.reference_circuits import ReferenceCircuits
+from qiskit.primitives import EstimatorResult, SamplerResult
 
 from qiskit_ibm_runtime import (
     Estimator,
-    EstimatorResult,
     Session,
     Sampler,
-    SamplerResult,
 )
 
 from ..decorators import run_integration_test

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -59,7 +59,7 @@ from qiskit.opflow import (
     TensoredOp,
 )
 from qiskit.providers.fake_provider import FakeNairobi
-from qiskit.quantum_info import SparsePauliOp, Pauli, PauliTable, Statevector
+from qiskit.quantum_info import SparsePauliOp, Pauli, Statevector
 from qiskit.result import Result
 from qiskit_aer.noise import NoiseModel
 
@@ -133,8 +133,6 @@ class TestDataSerialization(IBMTestCase):
         coeff_y = coeff_x + 1
         quantum_circuit = QuantumCircuit(1)
         quantum_circuit.h(0)
-        coeffs = np.array([1, 2, 3, 4, 5, 6])
-        table = PauliTable.from_labels(["III", "IXI", "IYY", "YIZ", "XYZ", "III"])
         operator = 2.0 * I ^ I
         z2_symmetries = Z2Symmetries(
             [Pauli("IIZI"), Pauli("ZIII")],
@@ -152,7 +150,6 @@ class TestDataSerialization(IBMTestCase):
             PauliSumOp.from_list(
                 [("II", -1.052373245772859), ("IZ", 0.39793742484318045)]
             ),
-            PauliSumOp(SparsePauliOp(table, coeffs), coeff=10),
             MatrixOp(primitive=np.array([[0, -1j], [1j, 0]]), coeff=coeff_x),
             PauliOp(primitive=Pauli("Y"), coeff=coeff_x),
             CircuitOp(quantum_circuit, coeff=coeff_x),

--- a/test/unit/test_estimator.py
+++ b/test/unit/test_estimator.py
@@ -13,7 +13,7 @@
 """Tests for estimator class."""
 
 import json
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.quantum_info import SparsePauliOp
@@ -21,10 +21,9 @@ from qiskit.quantum_info import SparsePauliOp
 from qiskit_ibm_runtime.utils.json import RuntimeEncoder
 from qiskit_ibm_runtime.utils.utils import _hash
 from qiskit_ibm_runtime.qiskit.primitives.utils import _circuit_key
-
 from qiskit_ibm_runtime import Estimator, Session
-from ..ibm_test_case import IBMTestCase
 
+from ..ibm_test_case import IBMTestCase
 from .mock.fake_runtime_service import FakeRuntimeService
 
 
@@ -54,7 +53,7 @@ class TestEstimator(IBMTestCase):
 
             # calculate [ <psi1(theta1)|H1|psi1(theta1)> ]
             with patch.object(estimator._session, "run") as mock_run:
-                estimator.run([psi1, psi2], [H1, H2], [[ANY] * 6, [ANY] * 8])
+                estimator.run([psi1, psi2], [H1, H2], [[1] * 6, [1] * 8])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {psi1_id: psi1, psi2_id: psi2})
@@ -62,21 +61,21 @@ class TestEstimator(IBMTestCase):
 
             # calculate [ <psi2(theta2)|H2|psi2(theta2)> ]
             with patch.object(estimator._session, "run") as mock_run:
-                estimator.run([psi2], [H1], [[ANY] * 8])
+                estimator.run([psi2], [H1], [[1] * 8])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {})
                 self.assertEqual(inputs["circuit_ids"], [psi2_id])
 
             with patch.object(estimator._session, "run") as mock_run:
-                estimator.run([psi3], [H1], [[ANY] * 6])
+                estimator.run([psi3], [H1], [[1] * 6])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {psi3_id: psi3})
                 self.assertEqual(inputs["circuit_ids"], [psi3_id])
 
             with patch.object(estimator._session, "run") as mock_run:
-                estimator.run([psi4, psi1], [H2, H1], [[ANY] * 8, [ANY] * 6])
+                estimator.run([psi4, psi1], [H2, H1], [[1] * 8, [1] * 6])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {psi4_id: psi4})

--- a/test/unit/test_ibm_primitives.py
+++ b/test/unit/test_ibm_primitives.py
@@ -30,9 +30,9 @@ from qiskit_ibm_runtime.ibm_backend import IBMBackend
 import qiskit_ibm_runtime.session as session_pkg
 from qiskit_ibm_runtime.utils.utils import _hash
 from qiskit_ibm_runtime.qiskit.primitives.utils import _circuit_key
+
 from ..ibm_test_case import IBMTestCase
 from ..utils import dict_paritally_equal, flat_dict_partially_equal, dict_keys_equal
-
 from .mock.fake_runtime_service import FakeRuntimeService
 
 
@@ -458,7 +458,7 @@ class TestPrimitives(IBMTestCase):
 
             # calculate [ <psi1(theta1)|H1|psi1(theta1)> ]
             with patch.object(estimator._session, "run") as mock_run:
-                estimator.run([psi1, psi2], [H1, H2], [[ANY] * 6, [ANY] * 8])
+                estimator.run([psi1, psi2], [H1, H2], [[1] * 6, [1] * 8])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {psi1_id: psi1, psi2_id: psi2})
@@ -466,21 +466,21 @@ class TestPrimitives(IBMTestCase):
 
             sampler = Sampler(session=session)
             with patch.object(sampler._session, "run") as mock_run:
-                sampler.run([psi1, psi2], [[ANY] * 6, [ANY] * 8])
+                sampler.run([psi1, psi2], [[1] * 6, [1] * 8])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {})
                 self.assertEqual(inputs["circuit_ids"], [psi1_id, psi2_id])
 
             with patch.object(estimator._session, "run") as mock_run:
-                estimator.run([psi3], [H1], [[ANY] * 6])
+                estimator.run([psi3], [H1], [[1] * 6])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {psi3_id: psi3})
                 self.assertEqual(inputs["circuit_ids"], [psi3_id])
 
             with patch.object(sampler._session, "run") as mock_run:
-                sampler.run([psi4, psi1], [[ANY] * 8, [ANY] * 6])
+                sampler.run([psi4, psi1], [[1] * 8, [1] * 6])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {psi4_id: psi4})

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -13,17 +13,16 @@
 """Tests for sampler class."""
 
 import json
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 
 from qiskit.circuit.library import RealAmplitudes
 
 from qiskit_ibm_runtime.utils.json import RuntimeEncoder
 from qiskit_ibm_runtime.utils.utils import _hash
 from qiskit_ibm_runtime.qiskit.primitives.utils import _circuit_key
-
 from qiskit_ibm_runtime import Sampler, Session
-from ..ibm_test_case import IBMTestCase
 
+from ..ibm_test_case import IBMTestCase
 from .mock.fake_runtime_service import FakeRuntimeService
 
 
@@ -52,28 +51,28 @@ class TestSampler(IBMTestCase):
         ) as session:
             sampler = Sampler(session=session)
             with patch.object(sampler._session, "run") as mock_run:
-                sampler.run([pqc, pqc2], [[ANY] * 6, [ANY] * 8])
+                sampler.run([pqc, pqc2], [[1] * 6, [1] * 8])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {pqc_id: pqc, pqc2_id: pqc2})
                 self.assertEqual(inputs["circuit_ids"], [pqc_id, pqc2_id])
 
             with patch.object(sampler._session, "run") as mock_run:
-                sampler.run([pqc2], [[ANY] * 8])
+                sampler.run([pqc2], [[1] * 8])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {})
                 self.assertEqual(inputs["circuit_ids"], [pqc2_id])
 
             with patch.object(sampler._session, "run") as mock_run:
-                sampler.run([pqc3], [[ANY] * 6])
+                sampler.run([pqc3], [[1] * 6])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {pqc3_id: pqc3})
                 self.assertEqual(inputs["circuit_ids"], [pqc3_id])
 
             with patch.object(sampler._session, "run") as mock_run:
-                sampler.run([pqc4, pqc], [[ANY] * 8, [ANY] * 6])
+                sampler.run([pqc4, pqc], [[1] * 8, [1] * 6])
                 _, kwargs = mock_run.call_args
                 inputs = kwargs["inputs"]
                 self.assertDictEqual(inputs["circuits"], {pqc4_id: pqc4})


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since `qiskit-terra` 0.22 was released, we can use the base primitives from it. Unfortunately we still need the local `_circuit_key` which is not in the 0.22 release. 

Fixes #567 

### Details and comments

Putting in draft until I can confirm it works with QRT primitives (waiting on the Sampler fix)

