### PR TITLE
Fix test_run_program_failed_ran_too_long

### DIFF
--- a/test/integration/test_job.py
+++ b/test/integration/test_job.py
@@ -101,7 +101,7 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
     def test_run_program_failed_ran_too_long(self, service):
         """Test a program that failed since it ran longer than maximum execution time."""
         max_execution_time = 60
-        inputs = {"iterations": 1, "sleep_per_iteration": 60}
+        inputs = {"iterations": 1, "sleep_per_iteration": 61}
         program_id = self._upload_program(
             service, max_execution_time=max_execution_time
         )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This test case fails intermittently - simple fix is to increase the sleep per iteration time to make sure the job does not run

```
FAIL: test_run_program_failed_ran_too_long (test.integration.test_job.TestIntegrationJob) (service=<QiskitRuntimeService>)
Test a program that failed since it ran longer than maximum execution time.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kt/Documents/qiskit-ibm-runtime/test/decorators.py", line 69, in _wrapper
    func(self, *args, **kwargs)
  File "/Users/kt/Documents/qiskit-ibm-runtime/test/integration/test_job.py", line 112, in test_run_program_failed_ran_too_long
    self.assertEqual(JobStatus.ERROR, job.status())
AssertionError: <JobStatus.ERROR: 'job incurred error'> != <JobStatus.DONE: 'job has successfully run'>

----------------------------------------------------------------------
``` 

### Details and comments
Fixes #

