### PR TITLE
Increase job time for callback tests

### DIFF
--- a/test/integration/test_estimator.py
+++ b/test/integration/test_estimator.py
@@ -277,9 +277,9 @@ class TestIntegrationEstimator(IBMIntegrationTestCase):
 
         with Session(service, self.backend) as session:
             estimator = Estimator(session=session)
-            job = estimator.run(circuits=bell, observables=[obs], callback=_callback)
+            job = estimator.run(circuits=[bell]*20, observables=[obs]*20, callback=_callback)
             result = job.result()
-            self.assertEqual(result.values, ws_result[-1].values)
+            self.assertTrue((result.values==ws_result[-1].values).all())
             self.assertEqual(len(job_ids), 1)
             self.assertEqual(job.job_id(), job_ids.pop())
 

--- a/test/integration/test_estimator.py
+++ b/test/integration/test_estimator.py
@@ -277,9 +277,11 @@ class TestIntegrationEstimator(IBMIntegrationTestCase):
 
         with Session(service, self.backend) as session:
             estimator = Estimator(session=session)
-            job = estimator.run(circuits=[bell]*20, observables=[obs]*20, callback=_callback)
+            job = estimator.run(
+                circuits=[bell] * 20, observables=[obs] * 20, callback=_callback
+            )
             result = job.result()
-            self.assertTrue((result.values==ws_result[-1].values).all())
+            self.assertTrue((result.values == ws_result[-1].values).all())
             self.assertEqual(len(job_ids), 1)
             self.assertEqual(job.job_id(), job_ids.pop())
 

--- a/test/integration/test_results.py
+++ b/test/integration/test_results.py
@@ -227,7 +227,7 @@ class TestIntegrationResults(IBMIntegrationJobTestCase):
         callback_called = False
 
         with use_proxies(service, MockProxyServer.VALID_PROXIES):
-            job = self._run_program(service, iterations=1, callback=result_callback)
+            job = self._run_program(service, iterations=10, callback=result_callback)
             job.wait_for_final_state()
 
         self.assertTrue(callback_called)

--- a/test/integration/test_sampler.py
+++ b/test/integration/test_sampler.py
@@ -264,7 +264,7 @@ class TestIntegrationIBMSampler(IBMIntegrationTestCase):
 
         with Session(service, self.backend) as session:
             sampler = Sampler(session=session)
-            job = sampler.run(circuits=[self.bell]*20, callback=_callback)
+            job = sampler.run(circuits=[self.bell] * 20, callback=_callback)
             result = job.result()
 
             self.assertEqual(result.quasi_dists, ws_result[-1].quasi_dists)

--- a/test/integration/test_sampler.py
+++ b/test/integration/test_sampler.py
@@ -264,7 +264,7 @@ class TestIntegrationIBMSampler(IBMIntegrationTestCase):
 
         with Session(service, self.backend) as session:
             sampler = Sampler(session=session)
-            job = sampler.run(circuits=self.bell, callback=_callback)
+            job = sampler.run(circuits=[self.bell]*20, callback=_callback)
             result = job.result()
 
             self.assertEqual(result.quasi_dists, ws_result[-1].quasi_dists)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`test_websocket_proxy` has been failing because jobs are so much faster now 😁 that it finishes before websocket connection (through proxy) can be done. 

Update: Did the same for `test_estimator_callback` and `test_sampler_callback`. 

### Details and comments
Related to #584

