### PR TITLE
Remove image from inputs

### DIFF
--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -113,7 +113,8 @@ class Options:
             }
         )
 
-        known_keys = Options.__dataclass_fields__.keys()
+        known_keys = list(Options.__dataclass_fields__.keys())
+        known_keys.append("image")
         # Add additional unknown keys.
         for key in options.keys():
             if key not in known_keys:

--- a/test/unit/test_ibm_primitives.py
+++ b/test/unit/test_ibm_primitives.py
@@ -142,6 +142,8 @@ class TestPrimitives(IBMTestCase):
                     run_options = kwargs["options"]
                     for key, val in opt.items():
                         self.assertEqual(run_options[key], val)
+                    inputs = kwargs["inputs"]
+                    self.assertTrue(all(key not in inputs.keys() for key in opt))
 
     def test_runtime_options(self):
         """Test RuntimeOptions specified as primitive options."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes a bug where when `image` is specified, it's passed to program inputs in addition to runtime options.


### Details and comments
Fixes #

