### PR TITLE
Use backend service in session if known

### DIFF
--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -92,7 +92,11 @@ class Session:
         """
 
         if service is None:
-            self._service = backend.service if isinstance(backend, IBMBackend) else QiskitRuntimeService()
+            self._service = (
+                backend.service
+                if isinstance(backend, IBMBackend)
+                else QiskitRuntimeService()
+            )
         else:
             self._service = service
 

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -73,8 +73,9 @@ class Session:
         """Session constructor.
 
         Args:
-            service: Optional instance of the ``QiskitRuntimeService`` class,
-                defaults to ``QiskitRuntimeService()`` which tries to initialize
+            service: Optional instance of the ``QiskitRuntimeService`` class.
+                If ``None``, the service associated with the backend, if known, is used.
+                Otherwise ``QiskitRuntimeService()`` is used to initialize
                 your default saved account.
             backend: Optional instance of :class:`qiskit_ibm_runtime.IBMBackend` class or
                 string name of backend. If not specified, a backend will be selected
@@ -90,7 +91,10 @@ class Session:
             ValueError: If an input value is invalid.
         """
 
-        self._service = service or QiskitRuntimeService()
+        if service is None:
+            self._service = backend.service if isinstance(backend, IBMBackend) else QiskitRuntimeService()
+        else:
+            self._service = service
 
         if self._service.channel == "ibm_quantum" and not backend:
             raise ValueError('"backend" is required for ``ibm_quantum`` channel.')

--- a/releasenotes/notes/use-backend-service-020daf6e4a4d044e.yaml
+++ b/releasenotes/notes/use-backend-service-020daf6e4a4d044e.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    If a :class:`qiskit_ibm_runtime.IBMBackend` instance is passed to
+    the :class:`qiskit_ibm_runtime.Session` constructor, the service used
+    to initialize the ``IBMBackend`` instance is used for the session
+    instead of the default account service.

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -49,6 +49,13 @@ class TestSession(IBMTestCase):
         session = Session(service=MagicMock(), backend=backend)
         self.assertEqual(session.backend(), "ibm_gotham")
 
+    def test_using_ibm_backend_service(self):
+        """Test using service from an IBMBackend instance."""
+        backend = MagicMock(spec=IBMBackend)
+        backend.name = "ibm_gotham"
+        session = Session(backend=backend)
+        self.assertEqual(session.service, backend.service)
+
     def test_max_time(self):
         """Test max time."""
         max_times = [


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If I pass an `IBMBackend` instance to `Session` constructor, the service used to initialize the backend instance should be used for the session, if no other `service` parameter is passed. 

### Details and comments
Fixes #

