### PR TITLE
Update test_estimator_sampler

### DIFF
--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -47,7 +47,7 @@ class TestIntegrationSession(IBMIntegrationTestCase):
             self.assertIsInstance(result, EstimatorResult)
             self.assertEqual(len(result.values), 1)
             self.assertEqual(len(result.metadata), 1)
-            self.assertEqual(result.metadata[0]["shots"], 100)
+            self.assertAlmostEqual(result.metadata[0]["shots"], 100, delta=20)
 
             sampler = Sampler(session=session)
             result = sampler.run(circuits=ReferenceCircuits.bell(), shots=200).result()
@@ -64,7 +64,7 @@ class TestIntegrationSession(IBMIntegrationTestCase):
             self.assertIsInstance(result, EstimatorResult)
             self.assertEqual(len(result.values), 1)
             self.assertEqual(len(result.metadata), 1)
-            self.assertEqual(result.metadata[0]["shots"], 300)
+            self.assertAlmostEqual(result.metadata[0]["shots"], 300, delta=20)
 
             result = sampler.run(circuits=ReferenceCircuits.bell(), shots=400).result()
             self.assertIsInstance(result, SamplerResult)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

test_estimator_sampler is failing [here](https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/3421662578/jobs/5699237384) after changing the resilience level default to 1

I assume changing this default value effects the shots 

### Details and comments
Fixes #

