### PR TITLE
Update docstring for session_id

### DIFF
--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -185,7 +185,7 @@ class Session:
         """Return the session ID.
 
         Returns:
-            Session ID.
+            Session ID. None until a job runs in the session.
         """
         return self._session_id
 


### PR DESCRIPTION

### Summary

The Session.session_id is None until the first job in the session is run since it implicitly creates the session and sets the session_id from that. This is a bit confusing though if you do something like this and expect something other than None:

```python
with Session(service=service) as session:
    print(f"Session id: {session.session_id}")
```

### Details and comments

n/a

