### PR TITLE
Fix docstring formatting on wait_for_final_state

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -246,9 +246,10 @@ class RuntimeJob(Job):
         self,
         timeout: Optional[float] = None,
     ) -> None:
-        """Use the websocket server to wait for the final the state of a job. The server
-            will remain open if the job is still running and the connection will be terminated
-            once the job completes. Then update and return the status of the job.
+        """Use the websocket server to wait for the final the state of a job.
+
+        The server will remain open if the job is still running and the connection will
+        be terminated once the job completes. Then update and return the status of the job.
 
         Args:
             timeout: Seconds to wait for the job. If ``None``, wait indefinitely.


### PR DESCRIPTION
### Summary

For a python docstring if it's multiple lines there should be a first line and then a break with a paragraph for additional wording, otherwise it doesn't get formatted properly as seen here [1].

![image](https://user-images.githubusercontent.com/3237936/202477104-d2d98127-3a56-4818-835a-415a9a7452b9.png)

[1] https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.RuntimeJob.html#qiskit_ibm_runtime.RuntimeJob

### Details and comments

n/a

