### PR TITLE
Replace sklearn package with scikit-learn

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,5 +21,5 @@ black==22.3.0
 coverage>=6.3
 pylatexenc
 mthree
-sklearn
+scikit-learn
 sphinx-design>=0.2.0


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

sklearn has been deprecated, causing our code quality check build to break 

https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/3595252302/jobs/6054515435#step:4:194


### Details and comments
Fixes #

