### PR TITLE
fix: update url for development cluster

### DIFF
--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -126,7 +126,7 @@ def _is_experimental_runtime_url(url: str) -> bool:
     Args:
         url: The URL.
     """
-    return isinstance(url, str) and "experimental" in url and url.endswith(".cloud")
+    return isinstance(url, str) and "experimental" in url
 
 
 def _location_from_crn(crn: str) -> str:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Development cluster URL will no longer have cloud in it so we need to lose the restriction. There should not be any other url that contains "experimental" in it so this check should be good enough.
