### PR TITLE
just a typing error

### DIFF
--- a/docs/how_to/error-mitigation.rst
+++ b/docs/how_to/error-mitigation.rst
@@ -193,7 +193,7 @@ As a part of the beta release of the resilience options, users will be able conf
 |                                                               | ``CxAmplifier``                  | Amplifies noise of all CNOT gates by performing local  |
 |                                                               |                                  | gate folding.                                          |
 |                                                               +----------------------------------+--------------------------------------------------------+
-|                                                               | ``LocalFoldingAmplifier``         | Amplifies noise of all gates by performing local       |
+|                                                               | ``LocalFoldingAmplifier``        | Amplifies noise of all gates by performing local       |
 |                                                               |                                  | gate folding.                                          |
 |                                                               +----------------------------------+--------------------------------------------------------+
 |                                                               | ``GlobalFoldingAmplifier``       | Amplifies noise of the input circuit by performing     |

--- a/docs/how_to/error-mitigation.rst
+++ b/docs/how_to/error-mitigation.rst
@@ -193,7 +193,7 @@ As a part of the beta release of the resilience options, users will be able conf
 |                                                               | ``CxAmplifier``                  | Amplifies noise of all CNOT gates by performing local  |
 |                                                               |                                  | gate folding.                                          |
 |                                                               +----------------------------------+--------------------------------------------------------+
-|                                                               | ``LocalFoldingAmplifer``         | Amplifies noise of all gates by performing local       |
+|                                                               | ``LocalFoldingAmplifier``         | Amplifies noise of all gates by performing local       |
 |                                                               |                                  | gate folding.                                          |
 |                                                               +----------------------------------+--------------------------------------------------------+
 |                                                               | ``GlobalFoldingAmplifier``       | Amplifies noise of the input circuit by performing     |
@@ -224,7 +224,7 @@ Example of adding ``resilience_options`` into your estimator session
     options.optimization_level = 3
     options.resilience_level = 2
     options.resilience.noise_factors = (1, 2, 3, 4)
-    options.resilience.noise_amplifer = 'CxAmplifer'
+    options.resilience.noise_amplifier = 'CxAmplifier'
     options.resilience.extrapolator = 'QuadraticExtrapolator'
 
 


### PR DESCRIPTION
changed "amplifer" to "amplifier"

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
In "Advanced resilience options" section and in "Example of adding resilience_options into your estimator session" section
the word "amplifier" was typed as "amplifer" this was not letting these options be applied to the Options() from qiskit_ibm_runtime.
So, just changed "Amplifer" to "amplifier"


### Details and comments
Fixes #
Now, error mitigation routines are applied correctly in Options() from qiskit_ibm_runtime
