### PR TITLE
Request job params if they don't exist

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -524,6 +524,9 @@ class RuntimeJob(Job):
         Returns:
             Input parameters used in this job.
         """
+        if not self._params:
+            response = self._api_client.job_get(job_id=self.job_id())
+            self._params = response.get("params", {})
         return self._params
 
     @property


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We recently removed job params from the list jobs endpoint so they may not exist if a user uses `jobs()` and then `job.input` for one of those jobs

integration tests failed [here](https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/4081008276/jobs/7034017990#step:5:1905)

### Details and comments
Fixes #

