### PR TITLE
Migration guide from qiskit-ibmq-provider

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Next Steps
     Getting Started <getting_started>
     backend.run vs. Qiskit Runtime <compare>
     Introduction to primitives <primitives>
+    Migration guide from qiskit-ibmq-provider <migrate_from_ibmq>
 
 
 .. toctree::

--- a/docs/migrate_from_ibmq.rst
+++ b/docs/migrate_from_ibmq.rst
@@ -5,7 +5,7 @@ Migration guide from ``qiskit-ibmq-provider``
 Introduction
 ============
 
-The classes related with Qiskit Runtime that used to be included in ``qiskit-ibmq-provider`` are now part of ``qiskit-ibm-runtime``. Before, the provider used to populate the ``qiskit.providers.ibmq.runtime`` namespace with objects for Qiskit Runtime that now live in the ``qiskit_ibm_runtime`` module.
+The classes related to Qiskit Runtime that used to be included in ``qiskit-ibmq-provider`` are now part of ``qiskit-ibm-runtime``. Before, the provider used to populate the ``qiskit.providers.ibmq.runtime`` namespace with objects for Qiskit Runtime. These now live in the ``qiskit_ibm_runtime`` module.
 
 Changes in Class name and location
 ==================================

--- a/docs/migrate_from_ibmq.rst
+++ b/docs/migrate_from_ibmq.rst
@@ -20,7 +20,7 @@ The module from which the classes are imported has changed. Below is a table of 
      - Notes
    * - ``qiskit.providers.ibmq.runtime.IBMRuntimeService``
      - :class:`qiskit_ibm_runtime.QiskitRuntimeService`
-     - ``IBMRuntimeService`` class was removed from ``qiskit_ibm_runtime 0.6.0`` and replaced by :class:`~QiskitRuntimeService`.
+     - ``IBMRuntimeService`` class was removed from ``qiskit_ibm_runtime 0.6.0`` and replaced by :class:`qiskit_ibm_runtime.QiskitRuntimeService`.
    * - ``qiskit.providers.ibmq.runtime.RuntimeJob``
      - :class:`qiskit_ibm_runtime.RuntimeJob`
      -  

--- a/docs/migrate_from_ibmq.rst
+++ b/docs/migrate_from_ibmq.rst
@@ -20,7 +20,7 @@ The module from which the classes are imported has changed. Below is a table of 
      - Notes
    * - ``qiskit.providers.ibmq.runtime.IBMRuntimeService``
      - :class:`qiskit_ibm_runtime.QiskitRuntimeService`
-     - ``IBMRuntimeService`` class was removed from ``qiskit_ibm_runtime 0.6.0`` and replaced by :class:`qiskit_ibm_runtime.QiskitRuntimeService`.
+     - ``IBMRuntimeService`` class was removed from ``qiskit-ibm-runtime`` 0.6 and replaced by :class:`qiskit_ibm_runtime.QiskitRuntimeService`.
    * - ``qiskit.providers.ibmq.runtime.RuntimeJob``
      - :class:`qiskit_ibm_runtime.RuntimeJob`
      -  

--- a/docs/migrate_from_ibmq.rst
+++ b/docs/migrate_from_ibmq.rst
@@ -10,7 +10,7 @@ The classes related to Qiskit Runtime that used to be included in ``qiskit-ibmq-
 Changes in Class name and location
 ==================================
 
-The module from which the classes are imported changed. Below is a table of example access patterns in ``qiskit.providers.ibmq.runtime`` and the new form with ``qiskit_ibm_runtime``:
+The module from which the classes are imported has changed. Below is a table of example access patterns in ``qiskit.providers.ibmq.runtime`` and their new form in ``qiskit_ibm_runtime``:
 
 .. list-table:: Migrate from ``qiskit.providers.ibmq.runtime`` in ``qiskit-ibmq-provider`` to ``qiskit-ibm-runtime`` 
    :header-rows: 1

--- a/docs/migrate_from_ibmq.rst
+++ b/docs/migrate_from_ibmq.rst
@@ -1,0 +1,51 @@
+#############################################
+Migration guide from ``qiskit-ibmq-provider``
+#############################################
+
+Introduction
+============
+
+The classes related with Qiskit Runtime that used to be included in ``qiskit-ibmq-provider`` are now part of ``qiskit-ibm-runtime``. Before, the provider used to populate the ``qiskit.providers.ibmq.runtime`` namespace with objects for Qiskit Runtime that now live in the ``qiskit_ibm_runtime`` module.
+
+Changes in Class name and location
+==================================
+
+The module from which the classes are imported changed. Below is a table of example access patterns in ``qiskit.providers.ibmq.runtime`` and the new form with ``qiskit_ibm_runtime``:
+
+.. list-table:: Migrate from ``qiskit.providers.ibmq.runtime`` in ``qiskit-ibmq-provider`` to ``qiskit-ibm-runtime`` 
+   :header-rows: 1
+
+   * - class in ``qiskit-ibmq-provider``
+     - class in ``qiskit-ibm-runtime``
+     - Notes
+   * - ``qiskit.providers.ibmq.runtime.IBMRuntimeService``
+     - :class:`qiskit_ibm_runtime.QiskitRuntimeService`
+     - ``IBMRuntimeService`` class was removed from ``qiskit_ibm_runtime 0.6.0`` and replaced by :class:`~QiskitRuntimeService`.
+   * - ``qiskit.providers.ibmq.runtime.RuntimeJob``
+     - :class:`qiskit_ibm_runtime.RuntimeJob`
+     -  
+   * - ``qiskit.providers.ibmq.runtime.RuntimeProgram``
+     - :class:`qiskit_ibm_runtime.RuntimeProgram`
+     - 
+   * - ``qiskit.providers.ibmq.runtime.UserMessenger``
+     - :class:`qiskit_ibm_runtime.program.UserMessenger`
+     - Notice the new location, in ``qiskit_ibm_runtime.program``
+   * - ``qiskit.providers.ibmq.runtime.ProgramBackend``
+     - :class:`qiskit_ibm_runtime.program.ProgramBackend`
+     - Notice the new location, in ``qiskit_ibm_runtime.program``
+   * - ``qiskit.providers.ibmq.runtime.ResultDecoder``
+     - :class:`qiskit_ibm_runtime.program.ResultDecoder`
+     - Notice the new location, in ``qiskit_ibm_runtime.program``
+   * - ``qiskit.providers.ibmq.runtime.RuntimeEncoder``
+     - :class:`qiskit_ibm_runtime.RuntimeEncoder`
+     - 
+   * - ``qiskit.providers.ibmq.runtime.RuntimeDecoder``
+     - :class:`qiskit_ibm_runtime.RuntimeDecoder`
+     - 
+   * - ``qiskit.providers.ibmq.runtime.ParameterNamespace``
+     - :class:`qiskit_ibm_runtime.ParameterNamespace`
+     - 
+   * - ``qiskit.providers.ibmq.runtime.RuntimeOptions``
+     - :class:`qiskit_ibm_runtime.RuntimeOptions`
+     - 
+     


### PR DESCRIPTION
I was unable to find a guide to migrate `qiskit-ibmq-provider` classes into the new `qiskit-ibm-runtime`. So I wrote a small equivalence table for the documentation.

It looks like this:
![screencapture-file-Users-bel-code-qiskit-ibm-runtime-docs-build-html-migrate-from-ibmq-html-2023-02-07-14_10_19](https://user-images.githubusercontent.com/766693/217253864-b87ff640-3065-419e-9549-cb00c75575f6.png)

