### PR TITLE
For save_account, use default channel if the channel is not specified

### DIFF
--- a/qiskit_ibm_runtime/accounts/management.py
+++ b/qiskit_ibm_runtime/accounts/management.py
@@ -51,6 +51,7 @@ class AccountManager:
     ) -> None:
         """Save account on disk."""
         cls.migrate(filename=filename)
+        channel = channel or os.getenv("QISKIT_IBM_CHANNEL") or _DEFAULT_CHANNEL_TYPE
         name = name or cls._get_default_account_name(channel)
         filename = filename if filename else _DEFAULT_ACCOUNT_CONFIG_JSON_FILE
         filename = os.path.expanduser(filename)

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -32,7 +32,6 @@ from qiskit_ibm_runtime.accounts.management import (
     _DEFAULT_ACCOUNT_NAME_CLOUD,
     _DEFAULT_ACCOUNT_NAME_IBM_QUANTUM,
     _DEFAULT_ACCOUNT_NAME_IBM_CLOUD,
-    _DEFAULT_CHANNEL_TYPE,
 )
 from qiskit_ibm_runtime.proxies import ProxyConfiguration
 from .mock.fake_runtime_service import FakeRuntimeService
@@ -668,11 +667,6 @@ class TestEnableAccount(IBMTestCase):
                     service = FakeRuntimeService(channel=channel)
                 self.assertTrue(service._account)
                 self.assertEqual(service._account.token, token)
-
-        # check that default channel is set when channel is not defined
-        service = FakeRuntimeService()
-        correct_channel = os.getenv("QISKIT_IBM_CHANNEL") or _DEFAULT_CHANNEL_TYPE
-        self.assertEqual(service._account.channel, correct_channel)
 
     def test_enable_account_by_token_url(self):
         """Test initializing account by token or url."""

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -32,6 +32,7 @@ from qiskit_ibm_runtime.accounts.management import (
     _DEFAULT_ACCOUNT_NAME_CLOUD,
     _DEFAULT_ACCOUNT_NAME_IBM_QUANTUM,
     _DEFAULT_ACCOUNT_NAME_IBM_CLOUD,
+    _DEFAULT_CHANNEL_TYPE,
 )
 from qiskit_ibm_runtime.proxies import ProxyConfiguration
 from .mock.fake_runtime_service import FakeRuntimeService
@@ -667,6 +668,11 @@ class TestEnableAccount(IBMTestCase):
                     service = FakeRuntimeService(channel=channel)
                 self.assertTrue(service._account)
                 self.assertEqual(service._account.token, token)
+
+        # check that default channel is set when channel is not defined
+        service = FakeRuntimeService()
+        correct_channel = os.getenv("QISKIT_IBM_CHANNEL") or _DEFAULT_CHANNEL_TYPE
+        self.assertEqual(service._account.channel, correct_channel)
 
     def test_enable_account_by_token_url(self):
         """Test initializing account by token or url."""


### PR DESCRIPTION

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Allow the user to invoke `QiskitRuntimeService.save_account()` without specifying a channel. 


### Details and comments
The channel will be set either to the value in environment variable `QISKIT_IBM_CHANNEL` or to `ibm_cloud` in this order.
Fixes #632 

