### PR TITLE
Add a circuit check to Estimator

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -427,3 +427,19 @@ class Estimator(BaseEstimator):
             **fields: The fields to update the options
         """
         self._options = Options._merge_options(self._options, fields)
+
+    @classmethod
+    def _validate_circuits(
+        cls,
+        circuits: Sequence[QuantumCircuit] | QuantumCircuit,
+    ) -> tuple[QuantumCircuit, ...]:
+        circuits = super()._validate_circuits(circuits)
+        for i, circuit in enumerate(circuits):
+            # Note: we need to remove the following check when Runtime Estimator
+            # supports dynamic circuits.
+            if circuit.num_clbits > 0:
+                raise ValueError(
+                    f"The {i}-th circuit has some classical bits. "
+                    "Estimator accepts quantum circuits without classical bits."
+                )
+        return circuits

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -439,7 +439,7 @@ class Estimator(BaseEstimator):
             # supports dynamic circuits.
             if circuit.num_clbits > 0:
                 raise ValueError(
-                    f"The {i}-th circuit has some classical bits. "
-                    "Estimator accepts quantum circuits without classical bits."
+                    f"The {i}-th circuit has {circuit.num_clbits} classical bits. "
+                    "Estimator only accepts quantum circuits without classical bits."
                 )
         return circuits

--- a/test/unit/test_ibm_primitives.py
+++ b/test/unit/test_ibm_primitives.py
@@ -48,7 +48,10 @@ class TestPrimitives(IBMTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.qx = ReferenceCircuits.bell()
+        cls.qx = {
+            Sampler: ReferenceCircuits.bell(),
+            Estimator: ReferenceCircuits.bell_no_measure(),
+        }
         cls.obs = SparsePauliOp.from_list([("IZ", 1)])
         return super().setUpClass()
 
@@ -144,7 +147,7 @@ class TestPrimitives(IBMTestCase):
             for opt in options:
                 with self.subTest(primitive=cls, options=opt):
                     inst = cls(session=session, options=opt)
-                    inst.run(self.qx, observables=self.obs)
+                    inst.run(self.qx[cls], observables=self.obs)
                     _, kwargs = session.run.call_args
                     run_options = kwargs["options"]
                     for key, val in opt.items():
@@ -165,7 +168,7 @@ class TestPrimitives(IBMTestCase):
                 with self.subTest(primitive=cls, env=env):
                     options = Options(environment=env)
                     inst = cls(session=session, options=options)
-                    inst.run(self.qx, observables=self.obs)
+                    inst.run(self.qx[cls], observables=self.obs)
                     if sys.version_info >= (3, 8):
                         run_options = session.run.call_args.kwargs["options"]
                     else:
@@ -294,7 +297,7 @@ class TestPrimitives(IBMTestCase):
             for options, expected in options_vars:
                 with self.subTest(primitive=cls, options=options):
                     inst = cls(session=session, options=options)
-                    inst.run(self.qx, observables=self.obs)
+                    inst.run(self.qx[cls], observables=self.obs)
                     if sys.version_info >= (3, 8):
                         inputs = session.run.call_args.kwargs["inputs"]
                     else:
@@ -310,7 +313,7 @@ class TestPrimitives(IBMTestCase):
             with self.subTest(primitive=cls):
                 inst = cls(session=session)
                 inst.set_options(resilience_level=1, optimization_level=2, shots=99)
-                inst.run(self.qx, observables=self.obs)
+                inst.run(self.qx[cls], observables=self.obs)
                 if sys.version_info >= (3, 8):
                     inputs = session.run.call_args.kwargs["inputs"]
                 else:
@@ -352,7 +355,7 @@ class TestPrimitives(IBMTestCase):
             for options, expected in options_vars:
                 with self.subTest(primitive=cls, options=options):
                     inst = cls(session=session)
-                    inst.run(self.qx, observables=self.obs, **options)
+                    inst.run(self.qx[cls], observables=self.obs, **options)
                     if sys.version_info >= (3, 8):
                         inputs = session.run.call_args.kwargs["inputs"]
                     else:
@@ -376,7 +379,7 @@ class TestPrimitives(IBMTestCase):
             for options in options_vars:
                 with self.subTest(primitive=cls, options=options):
                     inst = cls(session=session)
-                    inst.run(self.qx, observables=self.obs, **options)
+                    inst.run(self.qx[cls], observables=self.obs, **options)
                     if sys.version_info >= (3, 8):
                         rt_options = session.run.call_args.kwargs["options"]
                     else:
@@ -392,7 +395,7 @@ class TestPrimitives(IBMTestCase):
             with self.subTest(primitive=cls):
                 options = Options(foo="foo")  # pylint: disable=unexpected-keyword-arg
                 inst = cls(session=session, options=options)
-                inst.run(self.qx, observables=self.obs)
+                inst.run(self.qx[cls], observables=self.obs)
                 if sys.version_info >= (3, 8):
                     inputs = session.run.call_args.kwargs["inputs"]
                 else:
@@ -407,7 +410,7 @@ class TestPrimitives(IBMTestCase):
         for cls in primitives:
             with self.subTest(primitive=cls):
                 inst = cls(session=session)
-                inst.run(self.qx, observables=self.obs, foo="foo")
+                inst.run(self.qx[cls], observables=self.obs, foo="foo")
                 if sys.version_info >= (3, 8):
                     inputs = session.run.call_args.kwargs["inputs"]
                 else:
@@ -422,8 +425,8 @@ class TestPrimitives(IBMTestCase):
         for cls in primitives:
             with self.subTest(primitive=cls):
                 inst = cls(session=session)
-                inst.run(self.qx, observables=self.obs, shots=100)
-                inst.run(self.qx, observables=self.obs, shots=200)
+                inst.run(self.qx[cls], observables=self.obs, shots=100)
+                inst.run(self.qx[cls], observables=self.obs, shots=200)
                 kwargs_list = session.run.call_args_list
                 for idx, shots in zip([0, 1], [100, 200]):
                     self.assertEqual(
@@ -440,7 +443,7 @@ class TestPrimitives(IBMTestCase):
         for idx in range(num_runs):
             cls = primitives[idx % 2]
             inst = cls(session=session)
-            inst.run(self.qx, observables=self.obs)
+            inst.run(self.qx[cls], observables=self.obs)
         self.assertEqual(session.run.call_count, num_runs)
 
     @unittest.skip("Skip until data caching is reenabled.")

--- a/test/unit/test_runtime_ws.py
+++ b/test/unit/test_runtime_ws.py
@@ -90,7 +90,10 @@ class TestRuntimeWebsocketClient(IBMTestCase):
         service = MagicMock(spec=QiskitRuntimeService)
         service.run = _patched_run
 
-        circ = ReferenceCircuits.bell()
+        circ = {
+            Sampler: ReferenceCircuits.bell(),
+            Estimator: ReferenceCircuits.bell_no_measure(),
+        }
         obs = SparsePauliOp.from_list([("IZ", 1)])
         primitives = [Sampler, Estimator]
         sub_tests = [
@@ -103,7 +106,7 @@ class TestRuntimeWebsocketClient(IBMTestCase):
                 with self.subTest(primitive=cls, options=options, callback=callback):
                     results = []
                     inst = cls(session=Session(service=service), **options)
-                    job = inst.run(circ, observables=obs, **callback)
+                    job = inst.run(circ[cls], observables=obs, **callback)
                     time.sleep(JOB_PROGRESS_RESULT_COUNT + 2)
                     self.assertEqual(JOB_PROGRESS_RESULT_COUNT, len(results))
                     self.assertFalse(job._ws_client.connected)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Estimator is currently supposed to accept quantum circuits without classical bits.
This PR adds the check.

Same as https://github.com/Qiskit/qiskit-terra/pull/9692

### Details and comments
Fixes #

