### PR TITLE
Added error messages for unsupported values of optimization_level and resilience_level

### DIFF
--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -85,6 +85,8 @@ class Options:
     # in Sampler/Estimator
     _DEFAULT_OPTIMIZATION_LEVEL = 3
     _DEFAULT_RESILIENCE_LEVEL = 1
+    _MAX_OPTIMIZATION_LEVEL = 3
+    _MAX_RESILIENCE_LEVEL = 3
     optimization_level: Optional[int] = None
     resilience_level: Optional[int] = None
     max_execution_time: Optional[int] = None
@@ -113,10 +115,21 @@ class Options:
 
         Returns:
             Inputs acceptable by primitive programs.
+
+        Raises:
+            ValueError: if optimization_level is out of the allowed range.
+            ValueError: if resilience_level is out of the allowed range.
         """
         sim_options = options.get("simulator", {})
         inputs = {}
         inputs["transpilation_settings"] = options.get("transpilation", {})
+        if not options.get("optimization_level") in list(
+            range(Options._MAX_OPTIMIZATION_LEVEL)
+        ):
+            raise ValueError(
+                f"optimization_level can only take the values "
+                f"{list(range(Options._MAX_OPTIMIZATION_LEVEL))}"
+            )
         inputs["transpilation_settings"].update(
             {
                 "optimization_settings": {"level": options.get("optimization_level")},
@@ -124,7 +137,12 @@ class Options:
                 "basis_gates": sim_options.get("basis_gates", None),
             }
         )
-
+        if not options.get("resilience_level") in list(
+            range(Options._MAX_RESILIENCE_LEVEL)
+        ):
+            raise ValueError(
+                f"resilience_level can only take the values {list(range(Options._MAX_RESILIENCE_LEVEL))}"
+            )
         inputs["resilience_settings"] = options.get("resilience", {})
         inputs["resilience_settings"].update({"level": options.get("resilience_level")})
         inputs["run_options"] = options.get("execution")

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -114,6 +114,8 @@ class Sampler(BaseSampler):
 
             skip_transpilation (DEPRECATED): Transpilation is skipped if set to True. False by default.
                 Ignored if ``skip_transpilation`` is also specified in ``options``.
+        Raises:
+            ValueError: if resilience_level is out of the allowed range.
         """
         # `_options` in this class is an instance of qiskit_ibm_runtime.Options class.
         # The base class, however, uses a `_run_options` which is an instance of
@@ -171,6 +173,10 @@ class Sampler(BaseSampler):
         _options.transpilation.skip_transpilation = (  # type: ignore[union-attr]
             skip_transpilation
         )
+        if _options.resilience_level and not _options.resilience_level in [0, 1]:
+            raise ValueError(
+                "resilience level can only take the values [0, 1] in Sampler"
+            )
 
         if _options.optimization_level is None:
             if _options.simulator and (

--- a/releasenotes/notes/options-error-messages-10b3b978d874b807.yaml
+++ b/releasenotes/notes/options-error-messages-10b3b978d874b807.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Added error messages in case the user defines unsupported values for 'optimization_level' or for 'resilience_level'.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added error messages if the user defines unsupported values of `optimization_level` and `resilience_level`.


### Details and comments
Previously, if these options were out of range when initializing `Options`, an error message was raised from terra code, which is less legible. 
The `resilience_level` for `Sampler` is only supported for values [0, 1]. If a higher value was supplied, this was simply ignored, without notifying the user.
Fixes #641

