### PR TITLE
Issue warning when given an unsupported option

### DIFF
--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -15,6 +15,7 @@
 from typing import Optional, Union, ClassVar
 from dataclasses import dataclass, fields, field
 import copy
+import warnings
 
 from .utils import _flexible, Dict
 from .environment_options import EnvironmentOptions
@@ -148,6 +149,9 @@ class Options:
         # Add additional unknown keys.
         for key in options.keys():
             if key not in known_keys:
+                warnings.warn(
+                    f"Key {key} not in available options. It will be ignored."
+                )
                 inputs[key] = options[key]
         return inputs
 

--- a/releasenotes/notes/warning_on_unsupported_options-9a96d7f32a487d00.yaml
+++ b/releasenotes/notes/warning_on_unsupported_options-9a96d7f32a487d00.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Added a user warning when the user passes an option that is not supported
+    in Options.

--- a/test/unit/test_options.py
+++ b/test/unit/test_options.py
@@ -13,6 +13,7 @@
 """Tests for Options class."""
 
 from dataclasses import asdict
+import warnings
 
 from qiskit_aer.noise import NoiseModel
 from qiskit.providers.fake_provider import FakeNairobiV2
@@ -131,9 +132,14 @@ class TestOptions(IBMTestCase):
             simulator={"noise_model": noise_model},
             resilience={"noise_amplifier": "GlobalFoldingAmplifier"},
             foo="foo",
+            bar="bar",
         )
 
-        inputs = Options._get_program_inputs(asdict(options))
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always")
+            inputs = Options._get_program_inputs(asdict(options))
+            self.assertEqual(len(warn), 2)
+
         expected = {
             "run_options": {"shots": 100, "noise_model": noise_model},
             "transpilation_settings": {


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Issue a user warning when given an unsupported option in Options.


### Details and comments
The warning is issued in `Options._get_program_inputs()`.
Fixes #754 .

