### PR TITLE
[WIP] Accept all hierarchical options if given flatly

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -180,11 +180,11 @@ class Estimator(BaseEstimator):
                     version="0.7",
                     remedy="Please pass the backend when opening a session.",
                 )
-            skip_transpilation = options.get("transpilation", {}).get(
-                "skip_transpilation", False
-            )
             default_options = asdict(Options())
             _options = Options._merge_options(default_options, options_copy)
+            skip_transpilation = _options.get("transpilation", {}).get(
+                "skip_transpilation", False
+            )
 
         _options["transpilation"][
             "skip_transpilation"

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -140,7 +140,7 @@ class Estimator(BaseEstimator):
             skip_transpilation: (DEPRECATED) Transpilation is skipped if set to True. False by default.
                 Ignored ``skip_transpilation`` is also specified in ``options``.
         """
-        # `_options` in this class is an instance of qiskit_ibm_runtime.Options class.
+        # `_options` in this class is a Dict.
         # The base class, however, uses a `_run_options` which is an instance of
         # qiskit.providers.Options. We largely ignore this _run_options because we use
         # a nested dictionary to categorize options.
@@ -165,12 +165,12 @@ class Estimator(BaseEstimator):
         self._session: Session = None
 
         if options is None:
-            _options = Options()
+            _options = asdict(Options())
         elif isinstance(options, Options):
-            _options = copy.deepcopy(options)
             skip_transpilation = (
-                _options.transpilation.skip_transpilation  # type: ignore[union-attr]
+                options.transpilation.skip_transpilation  # type: ignore[union-attr]
             )
+            _options = asdict(copy.deepcopy(options))
         else:
             options_copy = copy.deepcopy(options)
             backend = options_copy.pop("backend", None)
@@ -183,39 +183,32 @@ class Estimator(BaseEstimator):
             skip_transpilation = options.get("transpilation", {}).get(
                 "skip_transpilation", False
             )
-            log_level = options_copy.pop("log_level", None)
-            _options = Options(**options_copy)
-            if log_level:
-                issue_deprecation_msg(
-                    msg="The 'log_level' option has been moved to the 'environment' category",
-                    version="0.7",
-                    remedy="Please specify 'environment':{'log_level': log_level} instead.",
-                )
-                _options.environment.log_level = log_level  # type: ignore[union-attr]
+            default_options = asdict(Options())
+            _options = Options._merge_options(default_options, options_copy)
 
-        _options.transpilation.skip_transpilation = (  # type: ignore[union-attr]
-            skip_transpilation
-        )
+        _options["transpilation"][
+            "skip_transpilation"
+        ] = skip_transpilation  # type: ignore[union-attr]
 
-        if _options.optimization_level is None:
-            if _options.simulator and (
-                not hasattr(_options.simulator, "noise_model")
-                or asdict(_options.simulator)["noise_model"] is None
+        if _options["optimization_level"] is None:
+            if _options["simulator"] and (
+                not hasattr(_options["simulator"], "noise_model")
+                or _options["simulator"]["noise_model"] is None
             ):
-                _options.optimization_level = 1
+                _options["optimization_level"] = 1
             else:
-                _options.optimization_level = Options._DEFAULT_OPTIMIZATION_LEVEL
+                _options["optimization_level"] = Options._DEFAULT_OPTIMIZATION_LEVEL
 
-        if _options.resilience_level is None:
-            if _options.simulator and (
-                not hasattr(_options.simulator, "noise_model")
-                or asdict(_options.simulator)["noise_model"] is None
+        if _options["resilience_level"] is None:
+            if _options["simulator"] and (
+                not hasattr(_options["simulator"], "noise_model")
+                or _options["simulator"]["noise_model"] is None
             ):
-                _options.resilience_level = 0
+                _options["resilience_level"] = 0
             else:
-                _options.resilience_level = Options._DEFAULT_RESILIENCE_LEVEL
+                _options["resilience_level"] = Options._DEFAULT_RESILIENCE_LEVEL
 
-        self._options: dict = asdict(_options)
+        self._options: dict = _options
 
         self._initial_inputs = {
             "circuits": circuits,

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -115,7 +115,7 @@ class Sampler(BaseSampler):
             skip_transpilation (DEPRECATED): Transpilation is skipped if set to True. False by default.
                 Ignored if ``skip_transpilation`` is also specified in ``options``.
         """
-        # `_options` in this class is an instance of qiskit_ibm_runtime.Options class.
+        # `_options` in this class is a Dict.
         # The base class, however, uses a `_run_options` which is an instance of
         # qiskit.providers.Options. We largely ignore this _run_options because we use
         # a nested dictionary to categorize options.
@@ -142,13 +142,12 @@ class Sampler(BaseSampler):
         if options is None:
             _options = asdict(Options())
         elif isinstance(options, Options):
-            _options = asdict(copy.deepcopy(options))
             skip_transpilation = (
                 options.transpilation.skip_transpilation  # type: ignore[union-attr]
             )
+            _options = asdict(copy.deepcopy(options))
         else:
             options_copy = copy.deepcopy(options)
-            #print("options_copy = "+str(options_copy))
             backend = options_copy.pop("backend", None)
             if backend is not None:
                 issue_deprecation_msg(
@@ -156,29 +155,15 @@ class Sampler(BaseSampler):
                     version="0.7",
                     remedy="Please pass the backend when opening a session.",
                 )
-            log_level = options_copy.pop("log_level", None)
-            #print("log level" + str(log_level))
-            if log_level:
-                issue_deprecation_msg(
-                    msg="The 'log_level' option has been moved to the 'environment' category",
-                    version="0.7",
-                    remedy="Please specify 'environment':{'log_level': log_level} instead.",
-                )
-
-            default_options = asdict(Options())
-            #print("default_options = " + str(default_options))
-            _options = Options._merge_options(default_options, options_copy)
-            #print("_options = " + str(_options))
-            if log_level:
-                _options["environment"]["log_level"] = log_level  # type: ignore[union-attr]
-
-            skip_transpilation = _options.get("transpilation", {}).get(
+            skip_transpilation = options.get("transpilation", {}).get(
                 "skip_transpilation", False
             )
+            default_options = asdict(Options())
+            _options = Options._merge_options(default_options, options_copy)
 
-        _options["transpilation"]["skip_transpilation"] = (  # type: ignore[union-attr]
-                skip_transpilation
-        )
+        _options["transpilation"][
+            "skip_transpilation"
+        ] = skip_transpilation  # type: ignore[union-attr]
 
         if _options["optimization_level"] is None:
             if _options["simulator"] and (
@@ -199,7 +184,6 @@ class Sampler(BaseSampler):
                 _options["resilience_level"] = Options._DEFAULT_RESILIENCE_LEVEL
 
         self._options: dict = _options
-
 
         self._initial_inputs = {"circuits": circuits, "parameters": parameters}
         if isinstance(session, Session):

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -155,12 +155,11 @@ class Sampler(BaseSampler):
                     version="0.7",
                     remedy="Please pass the backend when opening a session.",
                 )
-            skip_transpilation = options.get("transpilation", {}).get(
-                "skip_transpilation", False
-            )
             default_options = asdict(Options())
             _options = Options._merge_options(default_options, options_copy)
-
+            skip_transpilation = _options.get("transpilation", {}).get(
+                "skip_transpilation", False
+            )
         _options["transpilation"][
             "skip_transpilation"
         ] = skip_transpilation  # type: ignore[union-attr]


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Accept all options on given on level 1 and assign them to the appropriate hierarchical option type.


### Details and comments
For example, if the user defines `options = "shots": 1024}` as input to one of the primitives, we translate it to `options = {"execution": {"shots": 1024}}`.
Fixes #755.

