### PR TITLE
Set error levels to default when no backend is selected

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -322,6 +322,9 @@ class Estimator(BaseEstimator):
                 Options._DEFAULT_OPTIMIZATION_LEVEL,
                 Options._DEFAULT_RESILIENCE_LEVEL,
             )
+        else:
+            combined["optimization_level"] = Options._DEFAULT_OPTIMIZATION_LEVEL
+            combined["resilience_level"] = Options._DEFAULT_RESILIENCE_LEVEL
         logger.info("Submitting job using options %s", combined)
         inputs.update(Options._get_program_inputs(combined))
 

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -277,6 +277,9 @@ class Sampler(BaseSampler):
                 Options._DEFAULT_OPTIMIZATION_LEVEL,
                 Options._DEFAULT_RESILIENCE_LEVEL,
             )
+        else:
+            combined["optimization_level"] = Options._DEFAULT_OPTIMIZATION_LEVEL
+            combined["resilience_level"] = Options._DEFAULT_RESILIENCE_LEVEL
         logger.info("Submitting job using options %s", combined)
         inputs.update(Options._get_program_inputs(combined))
 

--- a/releasenotes/notes/error-lvl-defaults-no-backend-95fba0e99884314a.yaml
+++ b/releasenotes/notes/error-lvl-defaults-no-backend-95fba0e99884314a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue where if no backend was selected, ``optimization_level`` and ``resilience_level`` 
+    would default to ``None``, causing the job to fail.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As @merav-aharoni mentioned in https://github.com/Qiskit/qiskit-ibm-runtime/pull/748#issuecomment-1484110941, if `self._session.backend()` does not exist, the optimization and resilience levels will be set to `None` which would fail the job.

This could happen on cloud when no backend is selected, or when the sampler/estimator are used as sessions 

tests should be covered in https://github.com/Qiskit/qiskit-ibm-runtime/pull/748

### Details and comments
Fixes #

