### PR TITLE
Remove additional decomposition of BlueprintCircuit in JSON encode

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -52,7 +52,6 @@ from qiskit.circuit import (
     QuantumCircuit,
     QuantumRegister,
 )
-from qiskit.circuit.library import BlueprintCircuit
 from qiskit.circuit.parametertable import ParameterView
 from qiskit.result import Result
 from qiskit.version import __version__ as _terra_version_string
@@ -219,9 +218,6 @@ class RuntimeEncoder(json.JSONEncoder):
         if hasattr(obj, "to_json"):
             return {"__type__": "to_json", "__value__": obj.to_json()}
         if isinstance(obj, QuantumCircuit):
-            # TODO Remove the decompose when terra 6713 is released.
-            if isinstance(obj, BlueprintCircuit):
-                obj = obj.decompose()
             value = _serialize_and_encode(
                 data=obj,
                 serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]

--- a/releasenotes/notes/remove-blueprint-decompose-e40327f8a1d7fc7a.yaml
+++ b/releasenotes/notes/remove-blueprint-decompose-e40327f8a1d7fc7a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Removed additional decomposition of ``BlueprintCircuit``\s in the JSON encoder. This was
+    introduced as a bugfix, but has since been fixed. Still doing the decomposition led to
+    possible problems if the decomposed circuit was not in the correct basis set of the backend
+    anymore.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Credit goes to @Cryoris https://github.com/Qiskit/qiskit-ibm-provider/pull/549

### Details and comments
Fixes #

