### PR TITLE
Support external results whenever `.job_results()` is called

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -456,7 +456,9 @@ class RuntimeJob(Job):
             Error message.
         """
         status = response["state"]["status"].upper()
-        job_result_raw = self._api_client.job_results(job_id=self.job_id())
+        job_result_raw = self._download_external_result(
+            self._api_client.job_results(job_id=self.job_id())
+        )
         index = job_result_raw.rfind("Traceback")
         if index != -1:
             job_result_raw = job_result_raw[index:]


### PR DESCRIPTION
### Summary

There were cases where the check whether the result should be fetched from an external source was missing.

### Details and comments
Fixes #

