### PR TITLE
fix typo in tutorial code

### DIFF
--- a/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
+++ b/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
@@ -278,7 +278,7 @@
     "    for _ in range(i):\n",
     "        trotter_circuit = trotter_circuit.compose(trotter_layer)\n",
     "    trotter_circuit_list.append(trotter_circuit)\n",
-    "    print(f\"Trotter circuit with {i} Trotter steps\")\n",
+    "    print(\"Trotter circuit with {} Trotter steps\".format(i))\n",
     "    display(trotter_circuit.draw(fold=-1))\n",
     "\n",
     "obs = SparsePauliOp(\"Z\"*qubits)\n",

--- a/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
+++ b/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
@@ -278,7 +278,7 @@
     "    for _ in range(i):\n",
     "        trotter_circuit = trotter_circuit.compose(trotter_layer)\n",
     "    trotter_circuit_list.append(trotter_circuit)\n",
-    "    print(\"Trotter circuit with {} Trotter steps\".format(i))\n",
+    "    print(f\"Trotter circuit with {i} Trotter steps\")\n",
     "    display(trotter_circuit.draw(fold=-1))\n",
     "\n",
     "obs = SparsePauliOp(\"Z\"*qubits)\n",

--- a/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
+++ b/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
@@ -281,8 +281,8 @@
     "    print(f\"Trotter circuit with {i} Trotter steps\")\n",
     "    display(trotter_circuit.draw(fold=-1))\n",
     "\n",
-    "obs = SparsePauliOp(\"Z\"*qubits)\n",
-    "obs_list = [obs]*len(trotter_circuit_list)\n"
+    "obs = SparsePauliOp(\"Z\" * qubits)\n",
+    "obs_list = [obs] * len(trotter_circuit_list)"
    ]
   },
   {

--- a/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
+++ b/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
@@ -278,7 +278,7 @@
     "    for _ in range(i):\n",
     "        trotter_circuit = trotter_circuit.compose(trotter_layer)\n",
     "    trotter_circuit_list.append(trotter_circuit)\n",
-    "    print(f'Trotter circuit with {i} Trotter steps`)\n",
+    "    print(f'Trotter circuit with {i} Trotter steps')\n",
     "    display(trotter_circuit.draw(fold=-1))\n",
     "\n",
     "obs = SparsePauliOp(\"Z\"*qubits)\n",

--- a/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
+++ b/docs/tutorials/Error-Suppression-and-Error-Mitigation.ipynb
@@ -278,7 +278,7 @@
     "    for _ in range(i):\n",
     "        trotter_circuit = trotter_circuit.compose(trotter_layer)\n",
     "    trotter_circuit_list.append(trotter_circuit)\n",
-    "    print(f'Trotter circuit with {i} Trotter steps')\n",
+    "    print(f\"Trotter circuit with {i} Trotter steps\")\n",
     "    display(trotter_circuit.draw(fold=-1))\n",
     "\n",
     "obs = SparsePauliOp(\"Z\"*qubits)\n",


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A simple typo is fixed in the code.
` -> '

Due to mistyped grave accent ` instead of apostrophe ', the code used to give out SyntaxError: unterminated string literal 


### Details and comments
Fixes #

