### PR TITLE
use try-except block to guard against errors during json parsing. If the

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -172,6 +172,7 @@ class RuntimeJob(Job):
                 url = result_url_json["url"]
                 result_response = requests.get(url)
                 return result_response.content
+            return response
         except json.JSONDecodeError:
             return response
 

--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -166,14 +166,14 @@ class RuntimeJob(Job):
         Args:
             response: Response to check for url keyword, if available, download result from given URL
         """
-        if "url" in response:
+        try:
             result_url_json = json.loads(response)
             if "url" in result_url_json:
                 url = result_url_json["url"]
                 result_response = requests.get(url)
-                response = result_response.content
-
-        return response
+                return result_response.content
+        except json.JSONDecodeError:
+            return response
 
     def interim_results(self, decoder: Optional[Type[ResultDecoder]] = None) -> Any:
         """Return the interim results of the job.


### PR DESCRIPTION
### Summary

In some cases, error messages contain an external results URL, in other cases, they don't. This PR introduces a try-except block to catch JSONDecodeErrors. In that case, we'll return the raw result instead of trying to parse it.

### Details and comments
Fixes https://github.com/Qiskit/qiskit-ibm-provider/issues/554

