### PR TITLE
"Retrieve IBM Cloud token" link broken

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -40,7 +40,7 @@ You can access Qiskit Runtime from either IBM Quantum or IBM Cloud.
     # Save an IBM Cloud account.
     QiskitRuntimeService.save_account(channel="ibm_cloud", token="MY_IBM_CLOUD_API_KEY", instance="MY_IBM_CLOUD_CRN")
 
-`Retrieve IBM Cloud token <cloud/quickstart#credentials.html>`__
+`Retrieve IBM Cloud token <https://cloud.ibm.com/iam/apikeys>`__
 
 
 Test your setup


### PR DESCRIPTION
I received a report from IBM Quantum Marketing:

> [...] On [Getting Started](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/getting_started.html), the “Retrive IBM Cloud token should link here: https://cloud.ibm.com/iam/apikeys

![image (23)](https://user-images.githubusercontent.com/766693/231653550-5841e2a2-c721-4f60-ac5c-cc3dfb30282c.png)

The current link is 404ing.