### PR TITLE
Fix broken link

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -40,7 +40,7 @@ You can access Qiskit Runtime from either IBM Quantum or IBM Cloud.
     # Save an IBM Cloud account.
     QiskitRuntimeService.save_account(channel="ibm_cloud", token="MY_IBM_CLOUD_API_KEY", instance="MY_IBM_CLOUD_CRN")
 
-`Retrieve IBM Cloud token <https://cloud.ibm.com/iam/apikeys>`__
+`Retrieve IBM Cloud token <https://cloud.ibm.com/iam/apikeys>`_
 
 
 Test your setup


### PR DESCRIPTION
An extra underscore was causing the external link to break. 





### Details and comments
Fixes #
https://github.ibm.com/IBM-Q-Software/ch-ux/issues/20
