### PR TITLE
Fix bad CI config for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,8 +17,8 @@ on:
   # allow everyone with write access to the repository to trigger the workflow run manually
   workflow_dispatch:
 jobs:
-  if: github.repository_owner == 'Qiskit'
   e2e-tests:
+    if: github.repository_owner == 'Qiskit'
     name: Run e2e tests - ${{ matrix.environment }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes https://github.com/Qiskit/qiskit-ibm-runtime/pull/824. 

This did not cause the PR CI to fail because the tests happen on a cron schedule.

