### PR TITLE
Collect usage data for the circuit-knitting-toolbox

### DIFF
--- a/qiskit_ibm_runtime/api/session.py
+++ b/qiskit_ibm_runtime/api/session.py
@@ -63,6 +63,7 @@ def _get_client_header() -> str:
         "qiskit_machine_learning",
         "qiskit_optimization",
         "qiskit_finance",
+        "circuit_knitting_toolbox",
     ]
 
     pkg_versions = {"qiskit_ibm_runtime": f"qiskit_ibm_runtime-{ibm_runtime_version}"}
@@ -274,7 +275,7 @@ class RetrySession(Session):
         headers.update({"X-Qx-Client-Application": f"{CLIENT_APPLICATION}/qiskit"})
 
         # Use PurePath in order to support arbitrary path formats
-        callers = {PurePath("qiskit/"), "qiskit_"}
+        callers = {PurePath("qiskit/"), "qiskit_", "circuit_knitting_toolbox"}
 
         stack = inspect.stack()
         stack.reverse()


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This collects usage data for the [Circuit Knitting Toolbox](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox), building on the framework that was added in #733.

### Details and comments

I tested on the [entanglement forging tutorial](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/docs/entanglement_forging/tutorials/tutorial_1_getting_started.ipynb) provided with the circuit knitting toolbox.

Before:

```
qiskit-version-2/qiskit_ibm_runtime-0.9.5,qiskit_terra-0.24.0,qiskit_aer-0.12.0*,qiskit_nature-0.5.2*/qiskit-ibm-runtime~qiskit_ibm_runtime~qiskit_runtime_service.py
```

After:

```
qiskit-version-2/qiskit_ibm_runtime-0.9.5,qiskit_terra-0.24.0,qiskit_aer-0.12.0*,qiskit_nature-0.5.2*,circuit_knitting_toolbox-0.1.0*/circuit_knitting_toolbox~entanglement_forging~entanglement_forging_knitter.py
```

The stack location is much more descriptive in the latter.