### PR TITLE
Error message upon unsupported values for max_execution_time

### DIFF
--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -89,6 +89,8 @@ class Options:
     _MAX_OPTIMIZATION_LEVEL = 3
     _MAX_RESILIENCE_LEVEL_ESTIMATOR = 3
     _MAX_RESILIENCE_LEVEL_SAMPLER = 1
+    _MIN_EXECUTION_TIME = 300
+    _MAX_EXECUTION_TIME = 8 * 60 * 60  # 8 hours for real device
 
     optimization_level: Optional[int] = None
     resilience_level: Optional[int] = None
@@ -165,6 +167,7 @@ class Options:
         """Validate that program inputs (options) are valid
         Raises:
             ValueError: if optimization_level is out of the allowed range.
+            ValueError: if max_execution_time is out of the allowed range.
         """
         if not options.get("optimization_level") in list(
             range(Options._MAX_OPTIMIZATION_LEVEL + 1)
@@ -177,6 +180,16 @@ class Options:
         TranspilationOptions.validate_transpilation_options(
             options.get("transpilation")
         )
+        execution_time = options.get("max_execution_time")
+        if (
+            execution_time < Options._MIN_EXECUTION_TIME
+            or execution_time > Options._MAX_EXECUTION_TIME
+        ):
+            raise ValueError(
+                f"max_execution_time must be between "
+                f"{Options._MIN_EXECUTION_TIME} and {Options._MAX_EXECUTION_TIME} seconds."
+            )
+
         EnvironmentOptions.validate_environment_options(options.get("environment"))
 
     @staticmethod

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -181,14 +181,15 @@ class Options:
             options.get("transpilation")
         )
         execution_time = options.get("max_execution_time")
-        if (
-            execution_time < Options._MIN_EXECUTION_TIME
-            or execution_time > Options._MAX_EXECUTION_TIME
-        ):
-            raise ValueError(
-                f"max_execution_time must be between "
-                f"{Options._MIN_EXECUTION_TIME} and {Options._MAX_EXECUTION_TIME} seconds."
-            )
+        if not execution_time is None:
+            if (
+                execution_time < Options._MIN_EXECUTION_TIME
+                or execution_time > Options._MAX_EXECUTION_TIME
+            ):
+                raise ValueError(
+                    f"max_execution_time must be between "
+                    f"{Options._MIN_EXECUTION_TIME} and {Options._MAX_EXECUTION_TIME} seconds."
+                )
 
         EnvironmentOptions.validate_environment_options(options.get("environment"))
 

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -166,8 +166,8 @@ class Options:
     def validate_options(options: dict) -> None:
         """Validate that program inputs (options) are valid
         Raises:
-            ValueError: if optimization_level is out of the allowed range.
-            ValueError: if max_execution_time is out of the allowed range.
+            ValueError: if optimization_level is outside the allowed range.
+            ValueError: if max_execution_time is outside the allowed range.
         """
         if not options.get("optimization_level") in list(
             range(Options._MAX_OPTIMIZATION_LEVEL + 1)

--- a/releasenotes/notes/error_msg_max_execution_time-e401d353ae2a7d86.yaml
+++ b/releasenotes/notes/error_msg_max_execution_time-e401d353ae2a7d86.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Added error messages in case the user defines unsupported values 
+    for 'max_execution_time'.
+    Previously, this validation was done on the server side.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added error message when max_execution_time is outside the allowed range. Previously, this gave an error on the server side.


### Details and comments
Related to  #851.
Should actually have been part of #781.

