### PR TITLE
Removing primitive program (and link to near time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ session. You are encouraged to start a session as a context manager, to ensure t
 
 ## Primitives
 
-**Primitives** are a simplified interface for defining near-time quantum-classical workloads required to efficiently build and customize applications. The initial release of Qiskit Runtime includes two primitives: ``Estimator`` and ``Sampler``. They perform foundational quantum computing tasks and act as an entry point to the Qiskit Runtime service.
+**Primitives** are a simplified interface for defining `near-time quantum-classical workloads <https://research.ibm.com/blog/near-real-time-quantum-compute>`_ required to efficiently build and customize applications. The initial release of Qiskit Runtime includes two primitives: ``Estimator`` and ``Sampler``. They perform foundational quantum computing tasks and act as an entry point to the Qiskit Runtime service.
 
 There are several different options you can specify when calling the primitives. See [`qiskit_ibm_runtime.Options`](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/options.py#L103) class for more information.
 

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ session. You are encouraged to start a session as a context manager, to ensure t
 
 ## Primitives
 
-**Primitives** are prebuilt programs that provide a simplified interface for defining near-time quantum-classical workloads required to efficiently build and customize applications. The initial release of Qiskit Runtime includes two primitives: ``Estimator`` and ``Sampler``. They perform foundational quantum computing tasks and act as an entry point to the Qiskit Runtime service.
+**Primitives** are a simplified interface for defining near-time quantum-classical workloads required to efficiently build and customize applications. The initial release of Qiskit Runtime includes two primitives: ``Estimator`` and ``Sampler``. They perform foundational quantum computing tasks and act as an entry point to the Qiskit Runtime service.
 
-There are several different options you can specify when calling the primitive programs. See [`qiskit_ibm_runtime.Options`](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/options.py#L103) class for more information.
+There are several different options you can specify when calling the primitives. See [`qiskit_ibm_runtime.Options`](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/options.py#L103) class for more information.
 
 ### Sampler
 
-This is a program that takes a list of user circuits as an input and generates an error-mitigated readout of quasi-probabilities. This provides users a way to better evaluate shot results using error mitigation and enables them to more efficiently evaluate the possibility of multiple relevant data points in the context of destructive interference.
+This is a primitive that takes a list of user circuits as an input and generates an error-mitigated readout of quasi-probabilities. This provides users a way to better evaluate shot results using error mitigation and enables them to more efficiently evaluate the possibility of multiple relevant data points in the context of destructive interference.
 
 To invoke the `Sampler` primitive within a session:
 
@@ -146,7 +146,7 @@ with Session(service=service, backend="ibmq_qasm_simulator") as session:
 
 ### Estimator
 
-This is a program that takes circuits and observables to evaluate expectation values and variances for a given parameter input. This primitive allows users to efficiently calculate and interpret expectation values of quantum operators required for many algorithms.
+This is a primitive that takes circuits and observables to evaluate expectation values and variances for a given parameter input. This primitive allows users to efficiently calculate and interpret expectation values of quantum operators required for many algorithms.
 
 To invoke the `Estimator` primitive within a session:
 

--- a/docs/cloud/quickstart.rst
+++ b/docs/cloud/quickstart.rst
@@ -32,7 +32,7 @@ If you already created a Qiskit Runtime service instance or were invited to one 
 Install or update Qiskit packages
 -----------------------------------
 
-Install or update the following packages in your development environment. They let you create circuits and work with primitive programs with Qiskit Runtime. For detailed instructions, refer to the `Qiskit textbook <https://qiskit.org/textbook/ch-appendix/qiskit.html>`__. Periodically check the `Qiskit release notes <https://qiskit.org/documentation/release_notes.html>`__ (or rerun these commands) so that you always have the latest version.
+Install or update the following packages in your development environment. They let you create circuits and work with primitives with Qiskit Runtime. For detailed instructions, refer to the `Qiskit textbook <https://qiskit.org/textbook/ch-appendix/qiskit.html>`__. Periodically check the `Qiskit release notes <https://qiskit.org/documentation/release_notes.html>`__ (or rerun these commands) so that you always have the latest version.
 
  .. note::
 
@@ -92,45 +92,12 @@ If you save your credentials to disk, you can use ``QiskitRuntimeService()`` in 
 
 If you need to update your saved credentials, run ``save_account`` again, passing in ``overwrite=True``  and the updated credentials. For more information about managing your account, see the `account management topic <how_to/account-management.html>`__.
 
-Test your setup
--------------------
 
-Run the Hello World program to ensure that your environment is set up properly.
-
-.. note::
-   If you are running on real backends, Hello World incurs a cost. See `Manage costs <cost.html>`__ for cost information.
-
-If you did not save your credentials to disk, specify ``QiskitRuntimeService(channel="ibm_cloud", token=<IBM Cloud API key>, instance=<IBM Cloud CRN>)``
-instead of ``QiskitRuntimeService()`` in the following code.
-
-.. code-block:: python
-
-   from qiskit_ibm_runtime import QiskitRuntimeService
-
-   service = QiskitRuntimeService()
-   program_inputs = {'iterations': 1}
-   options = {"backend": ""}
-   job = service.run(program_id="hello-world",
-                  options=options,
-                  inputs=program_inputs
-                 )
-   print(f"job id: {job.job_id()}")
-   result = job.result()
-   print(result)
+Choose a primitive to run
+-------------------------
 
 
-Result:
-
-.. code-block::
-
-       Hello world!
-
-
-Choose a program to run
-----------------------------------
-
-
-Qiskit Runtime uses primitive programs to interface with quantum computers. The following programs are publicly available. Choose the appropriate link to continue learning how to run a program.
+Qiskit Runtime uses primitives to interface with quantum computers and they are publicly available. Choose the appropriate link to continue learning how to run a primitive.
 
 `Getting started with Sampler <https://qiskit.org/documentation/partners/qiskit_ibm_runtime/tutorials/how-to-getting-started-with-sampler.html>`__
 

--- a/docs/compare.rst
+++ b/docs/compare.rst
@@ -22,7 +22,7 @@ Using Qiskit Runtime
 
 Qiskit Runtime offers advantages in workload performance. Variational
 algorithms can run on classical compute resources that are colocated
-with the QPUs through the Estimator primitive program. This allows users
+with the QPUs through the Estimator primitive. This allows users
 to run iterative algorithm circuits back to back. In addition, sessions
 can drive a sequence of jobs without having to re-queue each job,
 avoiding latencies of queue wait times after the session is actively

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -5,7 +5,7 @@ Getting started
 Install Qiskit packages
 ========================
 
-Install these packages. They let you create circuits and work with primitive programs
+Install these packages. They let you create circuits and work with primitives
 through Qiskit Runtime.
 
 .. code-block:: bash

--- a/docs/how_to/options.rst
+++ b/docs/how_to/options.rst
@@ -1,5 +1,5 @@
-Configure primitive program options
-========================================
+Configure primitive options
+===========================
 
 When calling the primitives, you can pass in options, as shown in the line ``estimator = Estimator(options=options)`` in the following code example:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Key concepts
 
 **Primitives**
 
-Primitives are core functions that provide a simplified interface for defining near-time quantum-classical workloads required to efficiently build and customize applications. The initial release of Qiskit Runtime includes two primitives: Estimator and Sampler. They perform foundational quantum computing tasks and act as an entry point to the Qiskit Runtime service.
+Primitives are core functions that provide a simplified interface for defining `near-time quantum-classical workloads <https://research.ibm.com/blog/near-real-time-quantum-compute>`_  required to efficiently build and customize applications. The initial release of Qiskit Runtime includes two primitives: Estimator and Sampler. They perform foundational quantum computing tasks and act as an entry point to the Qiskit Runtime service.
 
 
 **Estimator**

--- a/docs/migrate/migrate-guide.rst
+++ b/docs/migrate/migrate-guide.rst
@@ -122,7 +122,7 @@ Key:
 
 **Simplified interface**:
 
-Use primitive programs to write code more efficiently.  For details, see the examples topics, such as `Using Estimator to design an algorithm <migrate-estimator>`__.
+Use primitives to write code more efficiently.  For details, see the examples topics, such as `Using Estimator to design an algorithm <migrate-estimator>`__.
 
   .. figure:: ../images/compare-code.png
    :scale: 50 %

--- a/docs/primitives.rst
+++ b/docs/primitives.rst
@@ -58,7 +58,7 @@ The following primitives are available:
 How to use primitives
 ---------------------
 
-Primitive program interfaces vary based on the type of task that you want to run on the quantum computer and the corresponding data that you want returned as a result. After identifying the appropriate primitive for your program, you can use Qiskit to prepare inputs, such as circuits, observables (for Estimator), and customizable options to optimize your job. For more information, see the appropriate topic:
+Primitive interfaces vary based on the type of task that you want to run on the quantum computer and the corresponding data that you want returned as a result. After identifying the appropriate primitive for your program, you can use Qiskit to prepare inputs, such as circuits, observables (for Estimator), and customizable options to optimize your job. For more information, see the appropriate topic:
 
 * `Getting started with Estimator <./tutorials/how-to-getting-started-with-estimator.ipynb>`__
 * `Getting started with Sampler <./tutorials/how-to-getting-started-with-sampler.ipynb>`__

--- a/docs/tutorials/grover_with_sampler.ipynb
+++ b/docs/tutorials/grover_with_sampler.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Database search with Grover's using Sampler\n",
     "\n",
-    "In this tutorial, you will solve a small database search problem using Grover's algorithm with the Sampler primitive Qiskit Runtime program."
+    "In this tutorial, you will solve a small database search problem using Grover's algorithm with the Sampler primitive in Qiskit Runtime."
    ]
   },
   {
@@ -48,7 +48,7 @@
     "In this tutorial, you are going to look for the owner of a small phone book using Grover's algorithm following these steps:\n",
     "\n",
     "1. Create Grover's circuit for the phone book search problem.\n",
-    "2. Submit the circuits to a quantum computer on the cloud using Qiskit Runtime service and the Sampler primitive program.\n",
+    "2. Submit the circuits to a quantum computer on the cloud using Qiskit Runtime service and the Sampler primitive.\n",
     "3. Analyze the results and identify the owner of the phone number."
    ]
   },
@@ -232,7 +232,7 @@
    "source": [
     "## Step 2: Submit the circuits to a quantum computer on the cloud\n",
     "\n",
-    "Now that the Grover's circuits are created, let's submit them to a quantum computer on the cloud by using the Sampler program."
+    "Now that the Grover's circuits are created, let's submit them to a quantum computer on the cloud by using the Sampler primitive."
    ]
   },
   {
@@ -281,9 +281,9 @@
    "id": "17d8307f-f3ff-4371-9286-611def049a8b",
    "metadata": {},
    "source": [
-    "Grover's algorithm determines the correct answer based on the highest probability of measurement outcomes. The `Sampler` primitive program is perfect for getting probabilities, so you will use that. In the following cell, you create an instance of the `Sampler` program, and start a Runtime session using the context manager (`with ...:`), which automatically opens and closes the session for you. \n",
+    "Grover's algorithm determines the correct answer based on the highest probability of measurement outcomes. The `Sampler` primitive is perfect for getting probabilities, so you will use that. In the following cell, you create an instance of the `Sampler` primitive, and start a Runtime session using the context manager (`with ...:`), which automatically opens and closes the session for you. \n",
     "\n",
-    "The `Sampler` program allows a batch submission of circuits in a job. Here you are passing a list of two circuits (Grover with 1 iteration and 2 iterations) to the Sampler but only one call is needed to sample the probability of measurement outcomes of both circuits."
+    "The `Sampler` primitive allows a batch submission of circuits in a job. Here you are passing a list of two circuits (Grover with 1 iteration and 2 iterations) to the Sampler but only one call is needed to sample the probability of measurement outcomes of both circuits."
    ]
   },
   {
@@ -436,7 +436,7 @@
    "source": [
     "## Summary\n",
     "\n",
-    "In this tutorial, you have solved a small database search problem using a quantum computer. You have constructed Grover's circuits by defining a phone book search problem using the `AmplificationProblem` class in Qiskit and then submitted the circuits to run using the Sampler primitive program through Qiskit Runtime service. "
+    "In this tutorial, you have solved a small database search problem using a quantum computer. You have constructed Grover's circuits by defining a phone book search problem using the `AmplificationProblem` class in Qiskit and then submitted the circuits to run using the Sampler primitive through Qiskit Runtime service. "
    ]
   },
   {

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -26,7 +26,7 @@ execute significantly faster within its improved hybrid quantum/classical proces
 Primitives and sessions
 -----------------------
 
-Qiskit Runtime has two predefined primitive programs: ``Sampler`` and ``Estimator``.
+Qiskit Runtime has two predefined primitives: ``Sampler`` and ``Estimator``.
 These primitives provide a simplified interface for performing foundational quantum
 computing tasks while also accounting for the latest developments in
 quantum hardware and software.
@@ -97,7 +97,7 @@ Supplementary Information
    :animate: fade-in-slide-down
 
     When you use the ``run()`` method of the :class:`Sampler` or :class:`Estimator`
-    to invoke the primitive program, a
+    to invoke the primitive, a
     :class:`RuntimeJob` instance is returned. This class has all the basic job
     methods, such as :meth:`RuntimeJob.status`, :meth:`RuntimeJob.result`, and
     :meth:`RuntimeJob.cancel`.

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -49,7 +49,7 @@ class Estimator(BaseEstimator):
     to the Estimator primitive.
 
     You are encouraged to use :class:`~qiskit_ibm_runtime.Session` to open a session,
-    during which you can invoke one or more primitive programs. Jobs submitted within a session
+    during which you can invoke one or more primitives. Jobs submitted within a session
     are prioritized by the scheduler, and data is cached for efficiency.
 
     Example::
@@ -154,7 +154,7 @@ class Estimator(BaseEstimator):
         parameter_values: Sequence[float] | Sequence[Sequence[float]] | None = None,
         **kwargs: Any,
     ) -> RuntimeJob:
-        """Submit a request to the estimator primitive program.
+        """Submit a request to the estimator primitive.
 
         Args:
             circuits: a (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or
@@ -190,7 +190,7 @@ class Estimator(BaseEstimator):
         parameter_values: Sequence[Sequence[float]],
         **kwargs: Any,
     ) -> RuntimeJob:
-        """Submit a request to the estimator primitive program.
+        """Submit a request to the estimator primitive.
 
         Args:
             circuits: a (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or

--- a/qiskit_ibm_runtime/options/__init__.py
+++ b/qiskit_ibm_runtime/options/__init__.py
@@ -17,10 +17,10 @@ Primitive options (:mod:`qiskit_ibm_runtime.options`)
 
 .. currentmodule:: qiskit_ibm_runtime.options
 
-Options that can be passed to the primitive programs.
+Options that can be passed to the primitives.
 
 The :class:`Options` class encapsulates all the options you can specify
-when invoking a primitive program. It includes frequestly used options,
+when invoking a primitive. It includes frequestly used options,
 such as ``optimization_level`` and ``resilience_level`` as well as
 sub-categories, such as ``transpilation`` and ``execution``.
 You can use auto-complete to easily find the options inside each

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -30,7 +30,7 @@ from ..utils.deprecation import issue_deprecation_msg
 @_flexible
 @dataclass
 class Options:
-    """Options for the primitive programs.
+    """Options for the primitives.
 
     Args:
         optimization_level: How much optimization to perform on the circuits.
@@ -118,7 +118,7 @@ class Options:
         """Convert the input options to program compatible inputs.
 
         Returns:
-            Inputs acceptable by primitive programs.
+            Inputs acceptable by primitives.
         """
         sim_options = options.get("simulator", {})
         inputs = {}

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -46,7 +46,7 @@ class Sampler(BaseSampler):
     The :meth:`run` method can be used to submit circuits and parameters to the Sampler primitive.
 
     You are encouraged to use :class:`~qiskit_ibm_runtime.Session` to open a session,
-    during which you can invoke one or more primitive programs. Jobs submitted within a session
+    during which you can invoke one or more primitives. Jobs submitted within a session
     are prioritized by the scheduler, and data is cached for efficiency.
 
     Example::
@@ -134,7 +134,7 @@ class Sampler(BaseSampler):
         parameter_values: Sequence[float] | Sequence[Sequence[float]] | None = None,
         **kwargs: Any,
     ) -> RuntimeJob:
-        """Submit a request to the sampler primitive program.
+        """Submit a request to the sampler primitive.
 
         Args:
             circuits: A (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or
@@ -164,7 +164,7 @@ class Sampler(BaseSampler):
         parameter_values: Sequence[Sequence[float]],
         **kwargs: Any,
     ) -> RuntimeJob:
-        """Submit a request to the sampler primitive program.
+        """Submit a request to the sampler primitive.
 
         Args:
             circuits: A (parameterized) :class:`~qiskit.circuit.QuantumCircuit` or


### PR DESCRIPTION
Converting "primitive program" into "primitive" (as a noun). For context, see https://qubit-social.xyz/@blakejohnson/110338831690761969

Additionally,
 * I removed the `Hello World` example in the README, assuming it is on its way out. Not fully sure.
 * link to https://research.ibm.com/blog/near-real-time-quantum-compute for "near-time"