### PR TITLE
Fix CouplingMap test

### DIFF
--- a/test/unit/test_options.py
+++ b/test/unit/test_options.py
@@ -193,10 +193,7 @@ class TestOptions(IBMTestCase):
         coupling_map = [[1, 0], [2, 1], [0, 1], [1, 2]]
         coupling_map_set = {tuple(cp) for cp in coupling_map}
         line_coupling_map_set = {tuple(cp) for cp in CouplingMap.from_line(3)}
-        options_types = [
-            coupling_map_set,
-            line_coupling_map_set
-        ]
+        options_types = [coupling_map_set, line_coupling_map_set]
         for opt in options_types:
             with self.subTest(opts_dict=opt):
                 options = Options()
@@ -204,7 +201,4 @@ class TestOptions(IBMTestCase):
                 inputs = Options._get_program_inputs(asdict(options))
                 input_coupling_map = inputs["transpilation_settings"]["coupling_map"]
                 inputs_set = {tuple(input) for input in input_coupling_map}
-                self.assertEqual(
-                    inputs_set, opt
-                )
-
+                self.assertEqual(inputs_set, opt)

--- a/test/unit/test_options.py
+++ b/test/unit/test_options.py
@@ -191,15 +191,20 @@ class TestOptions(IBMTestCase):
     def test_coupling_map_options(self):
         """Check that coupling_map is processed correctly"""
         coupling_map = [[1, 0], [2, 1], [0, 1], [1, 2]]
+        coupling_map_set = {tuple(cp) for cp in coupling_map}
+        line_coupling_map_set = {tuple(cp) for cp in CouplingMap.from_line(3)}
         options_types = [
-            coupling_map,
-            CouplingMap.from_line(3),
+            coupling_map_set,
+            line_coupling_map_set
         ]
         for opt in options_types:
             with self.subTest(opts_dict=opt):
                 options = Options()
                 options.simulator.coupling_map = opt
                 inputs = Options._get_program_inputs(asdict(options))
+                input_coupling_map = inputs["transpilation_settings"]["coupling_map"]
+                inputs_set = {tuple(input) for input in input_coupling_map}
                 self.assertEqual(
-                    inputs["transpilation_settings"]["coupling_map"], coupling_map
+                    inputs_set, opt
                 )
+


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`test_coupling_map_options` was failing because of different order of the couples in the list. 
Converted the lists to sets for the comparison.


### Details and comments
See also #877

