### PR TITLE
Charge for QR time only

### DIFF
--- a/docs/cloud/plans.rst
+++ b/docs/cloud/plans.rst
@@ -44,14 +44,13 @@ A pay-as-you-go plan for accessing IBM Quantum systems. Build your own programs 
 Pricing overview
 ----------------
 
-The Lite plan is free. The Standard plan charges you per *runtime second* when running on physical systems. The following diagram illustrates what is included in a runtime second. For this service, one runtime second includes quantum compute time. Any time spent waiting for results or in the queue for the quantum computer are excluded.
+The Lite plan is free. The Standard plan charges you per *runtime second* when running on physical systems. The following diagram illustrates what is included in a runtime second. For this service, one runtime second includes only quantum compute time. Any time spent waiting for results or in the queue for the quantum computer are excluded.
 
 .. figure:: ../images/Runtime_Accounting_Diagram.png
    :alt: This diagram shows that everything before the program starts (such as queuing) is free. After the job starts, it costs $1.60 per second.
 
    Runtime second accounting   
 
-The quantum and near-time classical compute times are grouped to deliver the best performance of quantum programs. The runtime environment uses near-time classical compute to host in-term hardware-dependent tasks like session management, circuit optimization, and (when supported) error mitigation to optimize the execution of quantum programs.
 
 Next steps
 ----------


### PR DESCRIPTION
### Summary
We only charge for QR time - remove mentions of classical time in the cost section


### Details and comments
Fixes #

