### PR TITLE
Add sleep to test_job_logs

### DIFF
--- a/test/integration/test_job.py
+++ b/test/integration/test_job.py
@@ -278,6 +278,7 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
         with self.assertLogs("qiskit_ibm_runtime", "INFO"):
             job.logs()
         job.wait_for_final_state()
+        time.sleep(1)
         self.assertTrue(job.logs())
 
     @run_integration_test


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This testing is failing on cloud - I believe the db takes a second to update because the logs should always be returned and this change seems to fix it 

### Details and comments
Fixes #

