### PR TITLE
Filter backends by instance when given in QiskitRuntimeService constructor

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -358,6 +358,7 @@ class QiskitRuntimeService(Provider):
         Raises:
             IBMInputValueError: If the URL specified is not a valid IBM Quantum authentication URL.
             IBMAccountError: If no hub/group/project could be found for this account.
+            IBMInputValueError: If instance parameter is not found in hgps.
 
         Returns:
             The hub/group/projects for this account.

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -169,7 +169,6 @@ class QiskitRuntimeService(Provider):
             IBMInputValueError: If an input is invalid.
         """
         super().__init__()
-
         self._account = self._discover_account(
             token=token,
             url=url,
@@ -409,9 +408,8 @@ class QiskitRuntimeService(Provider):
                 # Move user selected hgp to front of the list
                 hgps.move_to_end(default_hgp, last=False)
             else:
-                warnings.warn(
-                    f"Default hub/group/project {default_hgp} not "
-                    "found for the account and is ignored."
+                raise IBMInputValueError(
+                    f"Hub/group/project {default_hgp} could not be found for this account."
                 )
         return hgps
 

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -538,6 +538,7 @@ class QiskitRuntimeService(Provider):
         """
         # TODO filter out input_allowed not having runtime
         backends: List[IBMBackend] = []
+        instance_filter = instance if instance else self._account.instance
         if self._channel == "ibm_quantum":
             if name:
                 if name not in self._backends:
@@ -550,16 +551,16 @@ class QiskitRuntimeService(Provider):
                     )
                 if self._backends[name]:
                     backends.append(self._backends[name])
-            elif instance:
-                hgp = self._get_hgp(instance=instance)
+            elif instance_filter is not None:
+                hgp = self._get_hgp(instance=instance_filter)
                 for backend_name in hgp.backends:
                     if (
                         not self._backends[backend_name]
-                        or instance != self._backends[backend_name]._instance
+                        or instance_filter != self._backends[backend_name]._instance
                     ):
-                        self._set_backend_config(backend_name, instance)
+                        self._set_backend_config(backend_name, instance_filter)
                         self._backends[backend_name] = self._create_backend_obj(
-                            self._backend_configs[backend_name], instance
+                            self._backend_configs[backend_name], instance_filter
                         )
                     if self._backends[backend_name]:
                         backends.append(self._backends[backend_name])

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -169,6 +169,7 @@ class QiskitRuntimeService(Provider):
             IBMInputValueError: If an input is invalid.
         """
         super().__init__()
+
         self._account = self._discover_account(
             token=token,
             url=url,
@@ -550,7 +551,7 @@ class QiskitRuntimeService(Provider):
                     )
                 if self._backends[name]:
                     backends.append(self._backends[name])
-            elif instance_filter is not None:
+            elif instance_filter:
                 hgp = self._get_hgp(instance=instance_filter)
                 for backend_name in hgp.backends:
                     if (

--- a/releasenotes/notes/filter_instance-a7203041b5ab85d9.yaml
+++ b/releasenotes/notes/filter_instance-a7203041b5ab85d9.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    If ''instance'' is provided as parameter to 
+    :meth:`QiskitRuntimeService.__init__`,
+    then this is used as a filter in :meth:`QiskitRuntimeService.backends()`.
+    If ''instance'' is not recognized as one of the provider instances,
+    an exception will be raised. Previously, we only issued a warning.

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -127,7 +127,7 @@ def integration_test_setup(
             service = None
             if init_service:
                 service = QiskitRuntimeService(
-                    channel=channel, token=token, url=url, instance=instance
+                    channel=channel, token=token, url=url,
                 )
             dependencies = IntegrationTestDependencies(
                 channel=channel,

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -54,9 +54,7 @@ def run_quantum_and_cloud_fake(func):
 
     @wraps(func)
     def _wrapper(self, *args, **kwargs):
-        ibm_quantum_service = FakeRuntimeService(
-            channel="ibm_quantum", token="my_token", instance="h/g/p"
-        )
+        ibm_quantum_service = FakeRuntimeService(channel="ibm_quantum", token="my_token")
         cloud_service = FakeRuntimeService(
             channel="ibm_cloud",
             token="my_token",

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -127,7 +127,9 @@ def integration_test_setup(
             service = None
             if init_service:
                 service = QiskitRuntimeService(
-                    channel=channel, token=token, url=url,
+                    channel=channel,
+                    token=token,
+                    url=url,
                 )
             dependencies = IntegrationTestDependencies(
                 channel=channel,

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -203,7 +203,6 @@ class TestBackendFilters(IBMTestCase):
         ibm_quantum_service = FakeRuntimeService(
             channel="ibm_quantum",
             token="my_token",
-            instance="h/g/p",
             backend_specs=fake_backend_specs,
         )
         cloud_service = FakeRuntimeService(

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -55,6 +55,17 @@ class TestBackendFilters(IBMTestCase):
                 for back in backends:
                     self.assertEqual(back._instance, hgp)
 
+    def test_filter_by_service_instance_ibm_quantum(self):
+        """Test filtering by QiskitRuntimeService._account.instance (works only on ibm_quantum)."""
+        for hgp in FakeRuntimeService.DEFAULT_HGPS:
+            service = FakeRuntimeService(channel="ibm_quantum", token="my_token", instance=hgp)
+            with self.subTest(hgp=hgp):
+                backends = service.backends()
+                backend_name = [back.name for back in backends]
+                self.assertEqual(len(backend_name), 2)
+                for back in backends:
+                    self.assertEqual(back._instance, hgp)
+
     def test_filter_config_properties(self):
         """Test filtering by configuration properties."""
         n_qubits = 5


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
When `QiskitRuntimeService()` is initialised with `instance`, filter the backends according to the `instance`.


### Details and comments
Previously, the backends were filtered by `instance` only when it was given as parameter to `QiskitRuntimeService.backends()`.
In addition, we now raise an exception if the `instance` parameter to `QiskitRuntimeService` is not supported. Previously, we only  gave a warning.
Fixes #938.

