### PR TITLE
Revert circuit/observable indicies removal

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -176,7 +176,9 @@ class Estimator(BasePrimitive, BaseEstimator):
         """
         inputs = {
             "circuits": circuits,
+            "circuit_indices": list(range(len(circuits))),
             "observables": observables,
+            "observable_indices": list(range(len(observables))),
             "parameters": [circ.parameters for circ in circuits],
             "parameter_values": parameter_values,
         }

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -146,6 +146,7 @@ class Sampler(BasePrimitive, BaseSampler):
         inputs = {
             "circuits": circuits,
             "parameters": [circ.parameters for circ in circuits],
+            "circuit_indices": list(range(len(circuits))),
             "parameter_values": parameter_values,
         }
         return self._run_primitive(

--- a/releasenotes/notes/remove-data-caching-code-b878a85c3987a947.yaml
+++ b/releasenotes/notes/remove-data-caching-code-b878a85c3987a947.yaml
@@ -1,6 +1,0 @@
----
-fixes:
-  - |
-    The ``circuit_indices`` and ``observable_indices`` run inputs for 
-    :class:`~qiskit_ibm_runtime.Estimator` and :class:`~qiskit_ibm_runtime.Sampler`
-    have been completely removed.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#971 should not have been merged (oops), we need to wait for qiskit-ibm-primitives issue 108 first 

The data caching code and related tests can still be removed, just not the `circuit_indicies` and `observable_indicies` inputs 

### Details and comments

