### PR TITLE
remove deploy documentation to /documentation

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # This code is part of Qiskit.
@@ -31,6 +30,3 @@ pwd
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to qiskit.org/ecosystem"
 rclone sync --progress --exclude locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/ecosystem/ibm-runtime
-
-# Push to qiskit.org/documentation
-rclone sync --progress --exclude locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/partners/qiskit_ibm_runtime


### PR DESCRIPTION
Follow up on https://github.com/Qiskit/qiskit-ibm-runtime/pull/759

The documentation is correctly deployed in https://qiskit.org/ecosystem/ibm-runtime/ and the redirect https://qiskit.org/documentation/partners/qiskit_ibm_runtime is working. So, no need to upload to /documentation anymore.