### PR TITLE
Fix decorators initialize service bug in testing suite 

### DIFF
--- a/test/decorators.py
+++ b/test/decorators.py
@@ -28,7 +28,7 @@ def production_only(func):
 
     @wraps(func)
     def _wrapper(self, *args, **kwargs):
-        if "dev" in self.dependencies.url:
+        if "dev" in self.dependencies.url or "test" in self.dependencies.url:
             raise SkipTest(f"Skipping integration test. {self} is not supported on staging.")
         func(self, *args, **kwargs)
 
@@ -127,6 +127,7 @@ def integration_test_setup(
             service = None
             if init_service:
                 service = QiskitRuntimeService(
+                    instance=instance,
                     channel=channel,
                     token=token,
                     url=url,

--- a/test/integration/test_job.py
+++ b/test/integration/test_job.py
@@ -68,6 +68,7 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
         job = self._run_program(service, backend="")
         self.assertTrue(job.backend(), f"Job {job.job_id()} has no backend.")
 
+    @production_only
     @run_integration_test
     def test_run_program_log_level(self, service):
         """Test running with a custom log level."""

--- a/test/integration/test_options.py
+++ b/test/integration/test_options.py
@@ -20,7 +20,7 @@ from qiskit_ibm_runtime import Session, Sampler, Options, Estimator
 from qiskit_ibm_runtime.exceptions import RuntimeJobFailureError
 
 from ..ibm_test_case import IBMIntegrationTestCase
-from ..decorators import run_integration_test
+from ..decorators import run_integration_test, production_only
 
 
 class TestIntegrationOptions(IBMIntegrationTestCase):
@@ -114,6 +114,7 @@ class TestIntegrationOptions(IBMIntegrationTestCase):
                 inst.run(circ, observables=obs)
             self.assertIn("a coupling map is required.", str(exc.exception))
 
+    @production_only
     @run_integration_test
     def test_all_resilience_levels(self, service):
         """Test that all resilience_levels are recognized correctly


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixing small bug introduced in https://github.com/Qiskit/qiskit-ibm-runtime/pull/979, cloud accounts still need the instance parameter. 

### Details and comments
Fixes #

