### PR TITLE
Use date on max_execution_time change

### DIFF
--- a/docs/faqs/max_execution_time.rst
+++ b/docs/faqs/max_execution_time.rst
@@ -13,7 +13,7 @@ a job exceeds this time limit, it is forcibly cancelled and a ``RuntimeJobMaxTim
 exception is raised.
 
 .. note::
-   As of ``qiskit-ibm-runtime`` 0.12.0, the ``max_execution_time`` value is based on quantum
+   As of August 7, 2023, the ``max_execution_time`` value is now based on quantum
    time instead of wall clock time. Quantum time represents the time that the QPU
    complex (including control software, control electronics, QPU, and so on) is engaged in
    processing the job.

--- a/docs/faqs/max_execution_time.rst
+++ b/docs/faqs/max_execution_time.rst
@@ -13,7 +13,7 @@ a job exceeds this time limit, it is forcibly cancelled and a ``RuntimeJobMaxTim
 exception is raised.
 
 .. note::
-   As of August 7, 2023, the ``max_execution_time`` value is now based on quantum
+   As of August 7, 2023, the ``max_execution_time`` value is based on quantum
    time instead of wall clock time. Quantum time represents the time that the QPU
    complex (including control software, control electronics, QPU, and so on) is engaged in
    processing the job.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Use date on max_execution_time change since it's not related to qiskit-ibm-runtime release. 

### Details and comments
Fixes #

