### PR TITLE
Add instances method 

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -1498,6 +1498,16 @@ class QiskitRuntimeService(Provider):
             raise QiskitBackendNotFoundError("No backend matches the criteria.")
         return min(candidates, key=lambda b: b.status().pending_jobs)
 
+    def instances(self) -> List[str]:
+        """Return the IBM Quantum instances list currently in use for the session.
+
+        Returns:
+            A list with instances currently in the session.
+        """
+        if self._channel == "ibm_quantum":
+            return list(self._hgps.keys())
+        return []
+
     @property
     def auth(self) -> str:
         """Return the authentication type used.

--- a/releasenotes/notes/instances-method-02fda1de98638e59.yaml
+++ b/releasenotes/notes/instances-method-02fda1de98638e59.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a new method, :meth:`qiskit_ibm_runtime.QiskitRuntimeService.instances` that returns
+    all instances(hub/group/project) the user is in. This is only for the ``ibm_quantum`` channel
+    since the ``ibm_cloud`` channel does not have multiple instances.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

To be consistent with `qiskit-ibm-provider`, there should be an `instances()` method that returns all instances the user is in (quantum channel only). 

### Details and comments
Fixes #

