### PR TITLE
Add default `channel_strategy` option

### DIFF
--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -165,10 +165,11 @@ class Account:
     def _assert_valid_channel_strategy(channel_strategy: str) -> None:
         """Assert that the channel strategy is valid."""
         # add more strategies as they are implemented
-        if channel_strategy and channel_strategy not in ["q-ctrl"]:
+        strategies = ["q-ctrl", "default"]
+        if channel_strategy and channel_strategy not in strategies:
             raise InvalidAccountError(
                 f"Invalid `channel_strategy` value. Expected one of "
-                f"{['q-ctrl']}, got '{channel_strategy}'."
+                f"{strategies}, got '{channel_strategy}'."
             )
 
     @staticmethod

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -241,7 +241,7 @@ class QiskitRuntimeService(Provider):
         account = None
         verify_ = verify or True
         if channel_strategy:
-            if channel_strategy not in ["q-ctrl"]:
+            if channel_strategy not in ["q-ctrl", "default"]:
                 raise ValueError(f"{channel_strategy} is not a valid channel strategy.")
             if channel and channel != "ibm_cloud":
                 raise ValueError(
@@ -1023,7 +1023,9 @@ class QiskitRuntimeService(Provider):
                 max_execution_time=qrt_options.max_execution_time,
                 start_session=start_session,
                 session_time=qrt_options.session_time,
-                channel_strategy=self._channel_strategy,
+                channel_strategy=None
+                if self._channel_strategy == "default"
+                else self._channel_strategy,
             )
         except RequestsApiError as ex:
             if ex.status_code == 404:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adding to #1017 - adding a "default" option to `channel_strategy` so users can have an account configured with the `q-ctrl` strategy but switch to the default strategy by reinitializing the service with `channel_strategy = 'default'`.

### Details and comments
Fixes #

