### PR TITLE
Fix failing integration test due to case-sensitivity change

### DIFF
--- a/test/integration/test_estimator.py
+++ b/test/integration/test_estimator.py
@@ -197,9 +197,9 @@ class TestIntegrationEstimator(IBMIntegrationTestCase):
             job = estimator.run(circuits=circuit, observables="II")
             with self.assertRaises(RuntimeJobFailureError) as err:
                 job.result()
-            self.assertIn("REGISTER NAME", str(err.exception))
+            self.assertIn("register name", str(err.exception))
             self.assertFalse("python -m uvicorn server.main" in str(err.exception))
-            self.assertIn("REGISTER NAME", str(job.error_message()))
+            self.assertIn("register name", str(job.error_message()))
 
     @run_integration_test
     def test_estimator_no_session(self, service):

--- a/test/integration/test_sampler.py
+++ b/test/integration/test_sampler.py
@@ -166,9 +166,9 @@ class TestIntegrationIBMSampler(IBMIntegrationTestCase):
             job = sampler.run(circuits=circuit)
             with self.assertRaises(RuntimeJobFailureError) as err:
                 job.result()
-            self.assertIn("NO COUNTS FOR EXPERIMENT", str(err.exception))
+            self.assertIn("No counts for experiment", str(err.exception))
             self.assertFalse("python -m uvicorn server.main" in err.exception.message)
-            self.assertIn("NO COUNTS FOR EXPERIMENT", str(job.error_message()))
+            self.assertIn("No counts for experiment", str(job.error_message()))
 
     @run_integration_test
     def test_sampler_no_session(self, service):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Integration tests currently fail as the expected message changed (case-sensitivity change). This PR should fix it.

Example build exhibiting the error: https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/6096856126/job/16543305033#step:5:1424


### Details and comments

As can be seen in the output below, there were some subtle changes in the message we expect in the integration test:
* `REGISTER NAME` (old) vs `register name` (new)
* `NO COUNTS FOR EXPERIMENT` (old) vs `No counts for experiment` (new)

```
======================================================================
ERROR: test_all_resilience_levels (test.integration.test_options.TestIntegrationOptions) (service=<QiskitRuntimeService>)
Test that all resilience_levels are recognized correctly
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/decorators.py", line 91, in _wrapper
    func(self, *args, **kwargs)
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/integration/test_options.py", line 141, in test_all_resilience_levels
    result = inst.run(
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/qiskit_ibm_runtime/runtime_job.py", line 224, in result
    raise RuntimeJobFailureError(f"Unable to retrieve job result. {error_message}")
qiskit_ibm_runtime.exceptions.RuntimeJobFailureError: "Unable to retrieve job result. Invalid option fields: [\\'extrapolator\\', \\'noise_amplifier\\', \\'noise_factors\\']"

======================================================================
FAIL: test_estimator_error_messages (test.integration.test_estimator.TestIntegrationEstimator) (service=<QiskitRuntimeService>)
Test that the correct error message is displayed
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/decorators.py", line 91, in _wrapper
    func(self, *args, **kwargs)
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/integration/test_estimator.py", line 200, in test_estimator_error_messages
    self.assertIn("REGISTER NAME", str(err.exception))
AssertionError: 'REGISTER NAME' not found in '\'Unable to retrieve job result. CircuitError: \\\'register name "c" already exists\''

======================================================================
FAIL: test_sampler_error_messages (test.integration.test_sampler.TestIntegrationIBMSampler) (service=<QiskitRuntimeService>)
Test that the correct error message is displayed
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/decorators.py", line 91, in _wrapper
    func(self, *args, **kwargs)
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/integration/test_sampler.py", line 169, in test_sampler_error_messages
    self.assertIn("NO COUNTS FOR EXPERIMENT", str(err.exception))
AssertionError: 'NO COUNTS FOR EXPERIMENT' not found in '\'Unable to retrieve job result. QiskitError: \\\'No counts for experiment "0\''

----------------------------------------------------------------------
Ran 123 tests in 156.298s

FAILED (failures=2, errors=1, skipped=59)
make: *** [Makefile:30: integration-test] Error 1
Error: Process completed with exit code 2.
```
