### PR TITLE
Remove importing PauliSumOp, which is deprecated

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 import os
 from typing import Optional, Dict, Sequence, Any, Union
 import logging
+import typing
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.primitives import BaseEstimator
 
@@ -31,6 +31,9 @@ from .utils.qctrl import validate as qctrl_validate
 
 # pylint: disable=unused-import,cyclic-import
 from .session import Session
+
+if typing.TYPE_CHECKING:
+    from qiskit.opflow import PauliSumOp
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Partial fix to https://github.com/Qiskit/qiskit-ibm-runtime/issues/1057

Skip importing `PauliSumOp`, which is only used for type hinting. 