### PR TITLE
Adjusts default value for optimization_level

### DIFF
--- a/qiskit_ibm_runtime/utils/qctrl.py
+++ b/qiskit_ibm_runtime/utils/qctrl.py
@@ -57,7 +57,7 @@ def _raise_if_error_in_options(options: Dict[str, Any]) -> None:
         arguments={},
     )
 
-    optimization_level = options.get("optimization_level", 1)
+    optimization_level = options.get("optimization_level", 3)
     _check_argument(
         optimization_level > 0,
         description="Q-CTRL Primitives do not support optimization level 0. Please\


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Corrects default value for optimization level under q-ctrl strategy


### Details and comments
Fixes #
Corrects default value for optimization level under q-ctrl strategy, value should be 3, not 1


