### PR TITLE
Remove opflow and algorithms from serialization tests

### DIFF
--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -101,12 +101,12 @@ class TestDataSerialization(IBMTestCase):
             warnings.filterwarnings(
                 "ignore", category=DeprecationWarning, module=r"qiskit\.opflow\."
             )
-            from qiskit.opflow import PauliSumOp
+            from qiskit.opflow import PauliSumOp # pylint: disable=import-outside-toplevel
 
         # catch warnings triggered by opflow use
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as w_log:
             deprecated_op = PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[2]))
-            self.assertTrue(len(w) > 0)
+            self.assertTrue(len(w_log) > 0)
 
         coeff_x = Parameter("x")
         coeff_y = coeff_x + 1

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -24,12 +24,10 @@ import numpy as np
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.test.reference_circuits import ReferenceCircuits
 from qiskit.circuit.library import EfficientSU2, CXGate, PhaseGate, U2Gate
-
 from qiskit.providers.fake_provider import FakeNairobi
 from qiskit.quantum_info import SparsePauliOp, Pauli, Statevector
 from qiskit.result import Result
 from qiskit_aer.noise import NoiseModel
-
 from qiskit_ibm_runtime.utils import RuntimeEncoder, RuntimeDecoder
 from .mock.fake_runtime_client import CustomResultRuntimeJob
 from .mock.fake_runtime_service import FakeRuntimeService
@@ -101,7 +99,7 @@ class TestDataSerialization(IBMTestCase):
             warnings.filterwarnings(
                 "ignore", category=DeprecationWarning, module=r"qiskit\.opflow\."
             )
-            from qiskit.opflow import PauliSumOp # pylint: disable=import-outside-toplevel
+            from qiskit.opflow import PauliSumOp  # pylint: disable=import-outside-toplevel
 
         # catch warnings triggered by opflow use
         with warnings.catch_warnings(record=True) as w_log:

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,41 +20,11 @@ import warnings
 from datetime import datetime
 
 import numpy as np
-import scipy.sparse
-from qiskit.algorithms.optimizers import (
-    ADAM,
-    GSLS,
-    SPSA,
-    QNSPSA,
-    L_BFGS_B,
-    NELDER_MEAD,
-)
+
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.test.reference_circuits import ReferenceCircuits
 from qiskit.circuit.library import EfficientSU2, CXGate, PhaseGate, U2Gate
-from qiskit.opflow import (
-    PauliSumOp,
-    MatrixOp,
-    PauliOp,
-    CircuitOp,
-    EvolvedOp,
-    TaperedPauliSumOp,
-    Z2Symmetries,
-    I,
-    X,
-    Y,
-    Z,
-    StateFn,
-    CircuitStateFn,
-    DictStateFn,
-    VectorStateFn,
-    OperatorStateFn,
-    SparseVectorStateFn,
-    CVaRMeasurement,
-    ComposedOp,
-    SummedOp,
-    TensoredOp,
-)
+
 from qiskit.providers.fake_provider import FakeNairobi
 from qiskit.quantum_info import SparsePauliOp, Pauli, Statevector
 from qiskit.result import Result
@@ -122,76 +92,6 @@ class TestDataSerialization(IBMTestCase):
                 if not isinstance(circ, list):
                     decoded = [decoded]
                 self.assertTrue(all(isinstance(item, QuantumCircuit) for item in decoded))
-
-    def test_coder_operators(self):
-        """Test runtime encoder and decoder for operators."""
-        coeff_x = Parameter("x")
-        coeff_y = coeff_x + 1
-        quantum_circuit = QuantumCircuit(1)
-        quantum_circuit.h(0)
-        operator = 2.0 * I ^ I
-        z2_symmetries = Z2Symmetries(
-            [Pauli("IIZI"), Pauli("ZIII")],
-            [Pauli("IIXI"), Pauli("XIII")],
-            [1, 3],
-            [-1, 1],
-        )
-        isqrt2 = 1 / np.sqrt(2)
-        sparse = scipy.sparse.csr_matrix([[0, isqrt2, 0, isqrt2]])
-
-        subtests = (
-            PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[2]), coeff=3),
-            PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[1]), coeff=coeff_y),
-            PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[1 + 2j]), coeff=3 - 2j),
-            PauliSumOp.from_list([("II", -1.052373245772859), ("IZ", 0.39793742484318045)]),
-            MatrixOp(primitive=np.array([[0, -1j], [1j, 0]]), coeff=coeff_x),
-            PauliOp(primitive=Pauli("Y"), coeff=coeff_x),
-            CircuitOp(quantum_circuit, coeff=coeff_x),
-            EvolvedOp(operator, coeff=coeff_x),
-            TaperedPauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[2]), z2_symmetries),
-            StateFn(quantum_circuit, coeff=coeff_x),
-            CircuitStateFn(quantum_circuit, is_measurement=True),
-            DictStateFn("1" * 3, is_measurement=True),
-            VectorStateFn(np.ones(2**3, dtype=complex)),
-            OperatorStateFn(CircuitOp(QuantumCircuit(1))),
-            SparseVectorStateFn(sparse),
-            Statevector([1, 0]),
-            CVaRMeasurement(Z, 0.2),
-            ComposedOp([(X ^ Y ^ Z), (Z ^ X ^ Y ^ Z).to_matrix_op()]),
-            SummedOp([X ^ X * 2, Y ^ Y], 2),
-            TensoredOp([(X ^ Y), (Z ^ I)]),
-            (Z ^ Z) ^ (I ^ 2),
-        )
-        for operator in subtests:
-            with self.subTest(operator=operator):
-                encoded = json.dumps(operator, cls=RuntimeEncoder)
-                self.assertIsInstance(encoded, str)
-                decoded = json.loads(encoded, cls=RuntimeDecoder)
-                self.assertEqual(operator, decoded)
-
-    def test_coder_optimizers(self):
-        """Test runtime encoder and decoder for optimizers."""
-        subtests = (
-            (ADAM, {"maxiter": 100, "amsgrad": True}),
-            (GSLS, {"maxiter": 50, "min_step_size": 0.01}),
-            (SPSA, {"maxiter": 10, "learning_rate": 0.01, "perturbation": 0.1}),
-            (QNSPSA, {"fidelity": 123, "maxiter": 25, "resamplings": {1: 100, 2: 50}}),
-            # some SciPy optimizers only work with default arguments due to Qiskit/qiskit-terra#6682
-            (L_BFGS_B, {}),
-            (NELDER_MEAD, {}),
-            # Enable when https://github.com/scikit-quant/scikit-quant/issues/24 is fixed
-            # (IMFIL, {"maxiter": 20}),
-            # (SNOBFIT, {"maxiter": 200, "maxfail": 20}),
-        )
-        for opt_cls, settings in subtests:
-            with self.subTest(opt_cls=opt_cls):
-                optimizer = opt_cls(**settings)
-                encoded = json.dumps(optimizer, cls=RuntimeEncoder)
-                self.assertIsInstance(encoded, str)
-                decoded = json.loads(encoded, cls=RuntimeDecoder)
-                self.assertTrue(isinstance(decoded, opt_cls))
-                for key, value in settings.items():
-                    self.assertEqual(decoded.settings[key], value)
 
     def test_coder_noise_model(self):
         """Test encoding and decoding a noise model."""
@@ -268,8 +168,7 @@ if __name__ == '__main__':
         temp_fp.close()
 
         subtests = (
-            PauliSumOp(SparsePauliOp(Pauli("XYZX"), coeffs=[2]), coeff=3),
-            DictStateFn("1" * 3, is_measurement=True),
+            SparsePauliOp(Pauli("XYZX"), coeffs=[2]),
             Statevector([1, 0]),
         )
         for operator in subtests:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I started looking into the unit tests which trigger `qiskit.opflow` and `qiskit.algorithms` deprecation warnings (see https://github.com/Qiskit/qiskit-ibm-runtime/issues/1057) to see what is the best way to address these, and I think that:

1. the optimizer tests can directly be removed
2. the operator tests don't need to test any opflow class beyond PauliSumOp (which is the only one documented as being supported)

Let me know if I missed anything, but from what I see, these tests are not really actionable unit tests. They are an integration test of sorts to check that common inputs/outputs to the encoder/decoder “work”. However, all the encoder does is call whatever object’s `.to_json` method, which is not runtime’s “responsibility” to fix. I guess that a selection of “common” inputs was picked when the tests were designed, and this selection included, for example, the optimizers in `qiskit.algorithms` (which I imagine lead to some edge cases that you wanted to cover). But I think that there is no strict reason why runtime should be checking the optimizers ability to serialize to json, especially now that the classes are deprecated and **not used by the primitives**. At first, I even removed the `PauliSumOp` test, but decided to add it back to be on the safe side, as this is still a documented input type.

### Details and comments
Could be a fix for #1057 @1ucian0 

Note: I also don't think these tests should be moved to, for example, `qiskit_algorithms`, because we never mention that these are json-serializable.
