### PR TITLE
Only return channel strategy supported backends 

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -345,13 +345,19 @@ class RuntimeClient(BaseBackendClient):
         """
         self._api.runtime_session(session_id=session_id).close()
 
-    def list_backends(self, hgp: Optional[str] = None) -> List[str]:
+    def list_backends(
+        self, hgp: Optional[str] = None, channel_strategy: Optional[str] = None
+    ) -> List[str]:
         """Return IBM backends available for this service instance.
+
+        Args:
+            hgp: Filter by hub/group/project.
+            channel_strategy: Filter by channel strategy.
 
         Returns:
             IBM backends available for this service instance.
         """
-        return self._api.backends(hgp=hgp)["devices"]
+        return self._api.backends(hgp=hgp, channel_strategy=channel_strategy)["devices"]
 
     def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
         """Return the configuration of the IBM backend.

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -271,17 +271,25 @@ class Runtime(RestAdapterBase):
         return CloudBackend(self.session, backend_name)
 
     def backends(
-        self, hgp: Optional[str] = None, timeout: Optional[float] = None
+        self,
+        hgp: Optional[str] = None,
+        timeout: Optional[float] = None,
+        channel_strategy: Optional[str] = None,
     ) -> Dict[str, List[str]]:
         """Return a list of IBM backends.
 
         Args:
+            hgp: The service instance to use, only for ``ibm_quantum`` channel, in h/g/p format.
             timeout: Number of seconds to wait for the request.
+            channel_strategy: Error mitigation strategy.
 
         Returns:
             JSON response.
         """
         url = self.get_url("backends")
+        params = {}
         if hgp:
-            return self.session.get(url, params={"provider": hgp}).json()
-        return self.session.get(url, timeout=timeout).json()
+            params["provider"] = hgp
+        if channel_strategy:
+            params["channel_strategy"] = channel_strategy
+        return self.session.get(url, params=params, timeout=timeout).json()

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -315,7 +315,7 @@ class QiskitRuntimeService(Provider):
             A dict of the remote backend instances, keyed by backend name.
         """
         ret = OrderedDict()  # type: ignore[var-annotated]
-        backends_list = self._api_client.list_backends()
+        backends_list = self._api_client.list_backends(channel_strategy=self._channel_strategy)
         for backend_name in backends_list:
             raw_config = self._api_client.backend_configuration(backend_name=backend_name)
             config = configuration_from_server_data(

--- a/releasenotes/notes/channel-strategy-backend-filter-a4fe5248d9aea9c1.yaml
+++ b/releasenotes/notes/channel-strategy-backend-filter-a4fe5248d9aea9c1.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    If using a ``channel_strategy``, only backends that support that ``channel_strategy``
+    will be accessible to the user.
+

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -514,7 +514,10 @@ class BaseFakeRuntimeClient:
             raise RequestsApiError("Job not found", status_code=404)
         return self._jobs[job_id]
 
-    def list_backends(self, hgp: Optional[str] = None) -> List[str]:
+    # pylint: disable=unused-argument
+    def list_backends(
+        self, hgp: Optional[str] = None, channel_strategy: Optional[str] = None
+    ) -> List[str]:
         """Return IBM backends available for this service instance."""
         return [back.name for back in self._backends if back.has_access(hgp)]
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If a channel strategy is passed in during initialization, only backends supporting that channel strategy will be returned. 
We can add a test when we can test the full Q-CTRL path.

### Details and comments
Fixes #1058

