### PR TITLE
Remove old deprecations

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -46,7 +46,6 @@ from .exceptions import IBMError
 from .api.exceptions import RequestsApiError
 from .api.client_parameters import ClientParameters
 from .utils.utils import CallableStr
-from .utils.deprecation import issue_deprecation_msg
 
 logger = logging.getLogger(__name__)
 
@@ -388,11 +387,6 @@ class RuntimeJob(Job):
             IBMRuntimeError: If a network error occurred.
         """
         try:
-            issue_deprecation_msg(
-                msg="The 'bss.seconds' attribute is deprecated",
-                version="0.11.1",
-                remedy="Use the 'usage.seconds' attribute instead.",
-            )
             return self._api_client.job_metadata(self.job_id())
         except RequestsApiError as err:
             raise IBMRuntimeError(f"Failed to get job metadata: {err}") from None

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -24,8 +24,6 @@ from .runtime_job import RuntimeJob
 from .runtime_program import ParameterNamespace
 from .program.result_decoder import ResultDecoder
 from .ibm_backend import IBMBackend
-from .utils.deprecation import issue_deprecation_msg
-from .exceptions import IBMInputValueError
 
 
 def _active_session(func):  # type: ignore
@@ -144,36 +142,19 @@ class Session:
             inputs: Program input parameters. These input values are passed
                 to the runtime program.
             options: Runtime options that control the execution environment.
-                See :class:`qiskit_ibm_runtime.RuntimeOptions` for all available options,
-                EXCEPT ``backend``, which should be specified during session initialization.
+                See :class:`qiskit_ibm_runtime.RuntimeOptions` for all available options.
             callback: Callback function to be invoked for any interim results and final result.
 
         Returns:
             Submitted job.
-
-        Raises:
-            IBMInputValueError: If a backend is passed in through options that does not match
-                the current session backend.
         """
 
         options = options or {}
 
         if "instance" not in options:
             options["instance"] = self._instance
-        if "backend" in options:
-            issue_deprecation_msg(
-                "'backend' is no longer a supported option within a session",
-                "0.9",
-                "Instead, specify a backend when creating a Session instance.",
-                3,
-            )
-            if self._backend and options["backend"] != self._backend:
-                raise IBMInputValueError(
-                    f"The backend '{options['backend']}' is different from",
-                    f"the session backend '{self._backend}'",
-                )
-        else:
-            options["backend"] = self._backend
+
+        options["backend"] = self._backend
 
         if not self._session_id:
             # TODO: What happens if session max time != first job max time?

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock, patch
 
 from qiskit_ibm_runtime import Session
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
-from qiskit_ibm_runtime.exceptions import IBMInputValueError
 import qiskit_ibm_runtime.session as session_pkg
 from .mock.fake_runtime_service import FakeRuntimeService
 from ..ibm_test_case import IBMTestCase
@@ -80,14 +79,6 @@ class TestSession(IBMTestCase):
         with self.assertRaises(RuntimeError):
             session.run(program_id="program_id", inputs={})
 
-    def test_conflicting_backend(self):
-        """Test passing in different backend through options."""
-        service = MagicMock()
-        backend = "ibm_gotham"
-        session = Session(service=service, backend=backend)
-        with self.assertRaises(IBMInputValueError):
-            session.run(program_id="test", inputs={}, options={"backend": "different_backend"})
-
     def test_run(self):
         """Test the run method."""
         job = MagicMock()
@@ -114,7 +105,7 @@ class TestSession(IBMTestCase):
             _, kwargs = service.run.call_args
             self.assertEqual(kwargs["program_id"], program_id)
             self.assertDictEqual(kwargs["options"], {"backend": backend, **options})
-            self.assertDictContainsSubset({"session_time": 42}, kwargs["options"])
+            self.assertTrue({"session_time": 42}.items() <= kwargs["options"].items())
             self.assertDictEqual(kwargs["inputs"], inputs)
             self.assertEqual(kwargs["session_id"], session_ids[idx])
             self.assertEqual(kwargs["start_session"], start_sessions[idx])


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Removing bss.seconds deprecation warning, it's been 3 months
Removing passing in a backend into options, this was deprecated 9 months ago 

Also replaced `assertDictContainsSubset` because it was removed in python 3.11

### Details and comments
Fixes part of #784 

