### PR TITLE
Expose new session details 

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -345,6 +345,17 @@ class RuntimeClient(BaseBackendClient):
         """
         self._api.runtime_session(session_id=session_id).close()
 
+    def session_details(self, session_id: str) -> Dict[str, Any]:
+        """Get session details.
+
+        Args:
+            session_id: Session ID.
+
+        Returns:
+            Session details.
+        """
+        return self._api.runtime_session(session_id=session_id).details()
+
     def list_backends(
         self, hgp: Optional[str] = None, channel_strategy: Optional[str] = None
     ) -> List[str]:

--- a/qiskit_ibm_runtime/api/rest/base.py
+++ b/qiskit_ibm_runtime/api/rest/base.py
@@ -1,0 +1,57 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Base REST adapter."""
+
+from ..session import RetrySession
+
+
+class RestAdapterBase:
+    """Base class for REST adapters."""
+
+    URL_MAP = {}  # type: ignore[var-annotated]
+    """Mapping between the internal name of an endpoint and the actual URL."""
+
+    _HEADER_JSON_CONTENT = {"Content-Type": "application/json"}
+
+    def __init__(self, session: RetrySession, prefix_url: str = "") -> None:
+        """RestAdapterBase constructor.
+
+        Args:
+            session: Session to be used in the adapter.
+            prefix_url: String to be prepend to all URLs.
+        """
+        self.session = session
+        self.prefix_url = prefix_url
+
+    def get_url(self, identifier: str) -> str:
+        """Return the resolved URL for the specified identifier.
+
+        Args:
+            identifier: Internal identifier of the endpoint.
+
+        Returns:
+            The resolved URL of the endpoint (relative to the session base URL).
+        """
+        return "{}{}".format(self.prefix_url, self.URL_MAP[identifier])
+
+    def get_prefixed_url(self, prefix: str, identifier: str) -> str:
+        """Return an adjusted URL for the specified identifier.
+
+        Args:
+            prefix: string to be prepended to the URL.
+            identifier: Internal identifier of the endpoint.
+
+        Returns:
+            The resolved facade URL of the endpoint.
+        """
+        return "{}{}{}".format(prefix, self.prefix_url, self.URL_MAP[identifier])

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -19,9 +19,9 @@ import json
 
 from qiskit_ibm_provider.api.rest.base import RestAdapterBase
 from qiskit_ibm_provider.api.rest.program_job import ProgramJob
-from qiskit_ibm_provider.api.rest.runtime_session import RuntimeSession
 from qiskit_ibm_provider.utils import local_to_utc
 
+from .runtime_session import RuntimeSession
 from .program import Program
 from ...utils import RuntimeEncoder
 from .cloud_backend import CloudBackend

--- a/qiskit_ibm_runtime/api/rest/runtime_session.py
+++ b/qiskit_ibm_runtime/api/rest/runtime_session.py
@@ -13,7 +13,7 @@
 """Runtime Session REST adapter."""
 
 from typing import Dict, Any
-from qiskit_ibm_provider.api.rest.base import RestAdapterBase
+from .base import RestAdapterBase
 from ..session import RetrySession
 
 
@@ -43,7 +43,11 @@ class RuntimeSession(RestAdapterBase):
     def details(self) -> Dict[str, Any]:
         """Return the details of this session."""
         try:
-            return self.session.get(self.get_url("self")).json()
+            if "cloud" in self.session.base_url:
+                return self.session.get(self.get_url("self")).json()
+            else:
+                # TODO: remove this once "v2" is removed from the url path
+                return self.session.get(self.get_prefixed_url("/v2", "self")).json()
         # return None if API is not supported
         except:  # pylint: disable=bare-except
             return None

--- a/qiskit_ibm_runtime/api/rest/runtime_session.py
+++ b/qiskit_ibm_runtime/api/rest/runtime_session.py
@@ -1,0 +1,45 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Runtime Session REST adapter."""
+
+from typing import Dict, Any
+from qiskit_ibm_provider.api.rest.base import RestAdapterBase
+from ..session import RetrySession
+
+
+class RuntimeSession(RestAdapterBase):
+    """Rest adapter for session related endpoints."""
+
+    URL_MAP = {
+        "self": "",
+        "close": "/close",
+    }
+
+    def __init__(self, session: RetrySession, session_id: str, url_prefix: str = "") -> None:
+        """Job constructor.
+
+        Args:
+            session: RetrySession to be used in the adapter.
+            session_id: Job ID of the first job in a runtime session.
+            url_prefix: Prefix to use in the URL.
+        """
+        super().__init__(session, "{}/sessions/{}".format(url_prefix, session_id))
+
+    def close(self) -> None:
+        """Close this session."""
+        url = self.get_url("close")
+        self.session.delete(url)
+
+    def details(self) -> Dict[str, Any]:
+        """Return the details of this session."""
+        return self.session.get(self.get_url("self")).json()

--- a/qiskit_ibm_runtime/api/rest/runtime_session.py
+++ b/qiskit_ibm_runtime/api/rest/runtime_session.py
@@ -42,4 +42,8 @@ class RuntimeSession(RestAdapterBase):
 
     def details(self) -> Dict[str, Any]:
         """Return the details of this session."""
-        return self.session.get(self.get_url("self")).json()
+        try:
+            return self.session.get(self.get_url("self")).json()
+        # return None if API is not supported
+        except:  # pylint: disable=bare-except
+            return None

--- a/qiskit_ibm_runtime/api/rest/runtime_session.py
+++ b/qiskit_ibm_runtime/api/rest/runtime_session.py
@@ -43,11 +43,7 @@ class RuntimeSession(RestAdapterBase):
     def details(self) -> Dict[str, Any]:
         """Return the details of this session."""
         try:
-            if "cloud" in self.session.base_url:
-                return self.session.get(self.get_url("self")).json()
-            else:
-                # TODO: remove this once "v2" is removed from the url path
-                return self.session.get(self.get_prefixed_url("/v2", "self")).json()
+            return self.session.get(self.get_url("self")).json()
         # return None if API is not supported
         except:  # pylint: disable=bare-except
             return None

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -197,7 +197,7 @@ class Session:
         """Return current session status.
 
         Returns:
-            The current status of the session, including:
+            The current status of the session, including the following.
             Pending: Session is created but not active. It will become active when
                 the next job of this session is dequeued.
             In progress, accepting new jobs: session is active and accepting new jobs.
@@ -223,7 +223,7 @@ class Session:
         """Return session details.
 
         Returns:
-            A dictionary with session details, including:
+            A dictionary with the following sessions details.
             id: id of the session.
             backend_name: backend used for the session.
             interactive_timeout: The maximum idle time (in seconds) between jobs that

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -205,23 +205,16 @@ class Session:
             if response:
                 return {
                     "id": response.get("id"),
-                    "backend_name": response.get("backend_name") or response.get("backend"),
-                    "interactive_timeout": response.get("interactive_ttl")
-                    or response.get("interactiveSessionTTL"),
-                    "max_time": response.get("max_ttl") or response.get("maxSessionTTL"),
-                    "active_ttl": response.get("active_ttl") or response.get("activeTTL"),
+                    "backend_name": response.get("backend_name"),
+                    "interactive_timeout": response.get("interactive_ttl"),
+                    "max_time": response.get("max_ttl"),
+                    "active_ttl": response.get("active_ttl"),
                     "state": response.get("state"),
-                    "accepting_jobs": response.get("accepting_jobs")
-                    or response.get("acceptingJobs"),
-                    "root_job": response.get("rootJob"),
-                    "root_job_started": response.get("rootJobStarted"),
-                    "last_job": response.get("lastJob"),
-                    "last_job_started": response.get("lastJobStarted")
-                    or response.get("last_job_started"),
-                    "last_job_completed": response.get("lastJobCompleted")
-                    or response.get("last_job_completed"),
-                    "activated_at": response.get("activatedAt") or response.get("started_at"),
-                    "closed_at": response.get("closedAt") or response.get("closed_at"),
+                    "accepting_jobs": response.get("accepting_jobs"),
+                    "last_job_started": response.get("last_job_started"),
+                    "last_job_completed": response.get("last_job_completed"),
+                    "started_at": response.get("started_at"),
+                    "closed_at": response.get("closed_at"),
                 }
         return None
 

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -12,7 +12,7 @@
 
 """Qiskit Runtime flexible session."""
 
-from typing import Dict, Optional, Type, Union, Callable
+from typing import Dict, Optional, Type, Union, Callable, Any
 from types import TracebackType
 from functools import wraps
 from contextvars import ContextVar
@@ -192,6 +192,12 @@ class Session:
             Backend for this session. None if unknown.
         """
         return self._backend
+
+    def details(self) -> Optional[Dict[str, Any]]:
+        """Return session details."""
+        if self._session_id:
+            return self._service._api_client.session_details(self._session_id)
+        return None
 
     @property
     def session_id(self) -> str:

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -195,8 +195,19 @@ class Session:
 
     def status(self) -> Optional[str]:
         """Return current session status."""
-        # TODO implement this when API changes are done
-        pass
+        details = self.details()
+        if details:
+            state = details["state"]
+            accepting_jobs = details["accepting_jobs"]
+            if state == "open":
+                return "Pending"
+            if state == "active" and accepting_jobs:
+                return "In progress, accepting new jobs"
+            if state == "active" and not accepting_jobs:
+                return "In progress, not accepting new jobs"
+            return state.capitalize()
+
+        return None
 
     def details(self) -> Optional[Dict[str, Any]]:
         """Return session details."""
@@ -208,7 +219,7 @@ class Session:
                     "backend_name": response.get("backend_name"),
                     "interactive_timeout": response.get("interactive_ttl"),
                     "max_time": response.get("max_ttl"),
-                    "active_ttl": response.get("active_ttl"),
+                    "active_timeout": response.get("active_ttl"),
                     "state": response.get("state"),
                     "accepting_jobs": response.get("accepting_jobs"),
                     "last_job_started": response.get("last_job_started"),

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -194,7 +194,11 @@ class Session:
         return self._backend
 
     def status(self) -> Optional[str]:
-        """Return current session status."""
+        """Return current session status.
+
+        Returns:
+            A string describing the current status of the session.
+        """
         details = self.details()
         if details:
             state = details["state"]
@@ -210,7 +214,11 @@ class Session:
         return None
 
     def details(self) -> Optional[Dict[str, Any]]:
-        """Return session details."""
+        """Return session details.
+
+        Returns:
+            A dictionary with information about the session.
+        """
         if self._session_id:
             response = self._service._api_client.session_details(self._session_id)
             if response:

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -227,7 +227,7 @@ class Session:
             id: id of the session.
             backend_name: backend used for the session.
             interactive_timeout: The maximum idle time (in seconds) between jobs that
-                is allowed to occur before the session is deactivated.
+            is allowed to occur before the session is deactivated.
             max_time: Maximum allowed time (in seconds) for the session, subject to plan limits.
             active_timeout: The maximum time (in seconds) a session can stay active.
             state: State of the session - open, active, inactive, or closed.

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -198,8 +198,8 @@ class Session:
 
         Returns:
             The current status of the session, including the following.
-            Pending: Session is created but not active. It will become active when
-                the next job of this session is dequeued.
+            Pending: Session is created but not active.
+                It will become active when the next job of this session is dequeued.
             In progress, accepting new jobs: session is active and accepting new jobs.
             In progress, not accepting new jobs: session is active and not accepting new jobs.
             Closed: max_time expired or session was explicitly closed.

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -198,8 +198,8 @@ class Session:
 
         Returns:
             The current status of the session, including:
-            Pending: Session is created but no jobs have been dequeued, or
-                the interactive_timeout expired before more jobs were available
+            Pending: Session is created but not active. It will become active when
+                the next job of this session is dequeued.
             In progress, accepting new jobs: session is active and accepting new jobs
             In progress, not accepting new jobs: session is active and not accepting new jobs
             Closed: max_time expired or session was explicitly closed
@@ -226,11 +226,10 @@ class Session:
             A dictionary with session details, including:
             id: id of the session
             backned_name: backend used for the session
-            interactive_timeout: The max time (in seconds) between jobs that
-                is allowed to occur to keep the session active
-            max_time: Max allowed time for the session to run in seconds, subject to plan limits
-            active_timeout: The remaining time (in seconds) for the session to
-                be in the active state whilst jobs are running
+            interactive_timeout: The maximum idle time (in seconds) between jobs that
+                is allowed to occur before the session is deactivated.
+            max_time: Maximum allowed time (in seconds) for the session, subject to plan limits
+            active_timeout: The maximum time (in seconds) a session can stay active.
             state: State of the session - open, active, inactive, or closed
             accepting_jobs: Whether or not the session is accepting jobs
             last_job_started: Timestamp of when the last job in the session started

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -200,10 +200,10 @@ class Session:
             The current status of the session, including:
             Pending: Session is created but not active. It will become active when
                 the next job of this session is dequeued.
-            In progress, accepting new jobs: session is active and accepting new jobs
-            In progress, not accepting new jobs: session is active and not accepting new jobs
-            Closed: max_time expired or session was explicitly closed
-            None: status details are not available
+            In progress, accepting new jobs: session is active and accepting new jobs.
+            In progress, not accepting new jobs: session is active and not accepting new jobs.
+            Closed: max_time expired or session was explicitly closed.
+            None: status details are not available.
         """
         details = self.details()
         if details:
@@ -224,18 +224,18 @@ class Session:
 
         Returns:
             A dictionary with session details, including:
-            id: id of the session
-            backned_name: backend used for the session
+            id: id of the session.
+            backned_name: backend used for the session.
             interactive_timeout: The maximum idle time (in seconds) between jobs that
                 is allowed to occur before the session is deactivated.
-            max_time: Maximum allowed time (in seconds) for the session, subject to plan limits
+            max_time: Maximum allowed time (in seconds) for the session, subject to plan limits.
             active_timeout: The maximum time (in seconds) a session can stay active.
-            state: State of the session - open, active, inactive, or closed
-            accepting_jobs: Whether or not the session is accepting jobs
-            last_job_started: Timestamp of when the last job in the session started
-            last_job_completed: Timestamp of when the last job in the session completed
-            started_at: Timestamp of when the session was started
-            closed_at: Timestamp of when the session was closed
+            state: State of the session - open, active, inactive, or closed.
+            accepting_jobs: Whether or not the session is accepting jobs.
+            last_job_started: Timestamp of when the last job in the session started.
+            last_job_completed: Timestamp of when the last job in the session completed.
+            started_at: Timestamp of when the session was started.
+            closed_at: Timestamp of when the session was closed.
 
         """
         if self._session_id:

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -193,10 +193,40 @@ class Session:
         """
         return self._backend
 
+    def status(self) -> Optional[str]:
+        """Return current session status."""
+        # TODO Check/match statuses with IQP, return enum
+        details = self.details()
+        if details:
+            return (
+                f"Current status: {details['state']}, accepting jobs: {details['accepting_jobs']}"
+            )
+        return None
+
     def details(self) -> Optional[Dict[str, Any]]:
         """Return session details."""
         if self._session_id:
-            return self._service._api_client.session_details(self._session_id)
+            response = self._service._api_client.session_details(self._session_id)
+            if response:
+                return {
+                    "id": response.get("id"),
+                    "backend_name": response.get("backend_name") or response.get("backend"),
+                    "interactive_timeout": response.get("interactive_ttl")
+                    or response.get("interactiveSessionTTL"),
+                    "max_time": response.get("max_ttl") or response.get("maxSessionTTL"),
+                    "active_ttl": response.get("active_ttl") or response.get("activeTTL"),
+                    "state": response.get("state"),
+                    "accepting_jobs": response.get("accepting_jobs")
+                    or response.get("acceptingJobs"),
+                    # Note the following fields are only returned in the quantum channel
+                    "root_job": response.get("rootJob"),
+                    "root_job_started": response.get("rootJobStarted"),
+                    "last_job": response.get("lastJob"),
+                    "last_job_started": response.get("lastJobStarted"),
+                    "last_job_completed": response.get("lastJobCompleted"),
+                    "activated_at": response.get("activatedAt"),
+                    "closed_at": response.get("closedAt"),
+                }
         return None
 
     @property

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -197,13 +197,19 @@ class Session:
         """Return current session status.
 
         Returns:
-            A string describing the current status of the session.
+            The current status of the session, including:
+                Pending: Session is created but no jobs have been dequeued, or
+                    the ``interactive_timeout`` expired before more jobs were available
+                In progress, accepting new jobs: session is active and accepting new jobs
+                In progress, not accepting new jobs: session is active and not accepting new jobs
+                Closed: ``max_time`` expired or session was explicitly closed
+                None: status details are not available
         """
         details = self.details()
         if details:
             state = details["state"]
             accepting_jobs = details["accepting_jobs"]
-            if state == "open":
+            if state in ["open", "inactive"]:
                 return "Pending"
             if state == "active" and accepting_jobs:
                 return "In progress, accepting new jobs"
@@ -217,7 +223,21 @@ class Session:
         """Return session details.
 
         Returns:
-            A dictionary with information about the session.
+            A dictionary with session details, including:
+                id: id of the session
+                backned_name: backend used for the session
+                interactive_timeout: The max time (in seconds) between jobs that
+                    is allowed to occur to keep the session active
+                max_time: Max allowed time for the session to run in seconds, subject to plan limits
+                active_timeout: The remaining time (in seconds) for the session to
+                    be in the active state whilst jobs are running
+                state: State of the session - open, active, inactive, or closed
+                accepting_jobs: Whether or not the session is accepting jobs
+                last_job_started: Timestamp of when the last job in the session started
+                last_job_completed: Timestamp of when the last job in the session completed
+                started_at: Timestamp of when the session was started
+                closed_at: Timestamp of when the session was closed
+
         """
         if self._session_id:
             response = self._service._api_client.session_details(self._session_id)

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -198,12 +198,12 @@ class Session:
 
         Returns:
             The current status of the session, including:
-                Pending: Session is created but no jobs have been dequeued, or
-                    the ``interactive_timeout`` expired before more jobs were available
-                In progress, accepting new jobs: session is active and accepting new jobs
-                In progress, not accepting new jobs: session is active and not accepting new jobs
-                Closed: ``max_time`` expired or session was explicitly closed
-                None: status details are not available
+            Pending: Session is created but no jobs have been dequeued, or
+                the interactive_timeout expired before more jobs were available
+            In progress, accepting new jobs: session is active and accepting new jobs
+            In progress, not accepting new jobs: session is active and not accepting new jobs
+            Closed: max_time expired or session was explicitly closed
+            None: status details are not available
         """
         details = self.details()
         if details:
@@ -224,19 +224,19 @@ class Session:
 
         Returns:
             A dictionary with session details, including:
-                id: id of the session
-                backned_name: backend used for the session
-                interactive_timeout: The max time (in seconds) between jobs that
-                    is allowed to occur to keep the session active
-                max_time: Max allowed time for the session to run in seconds, subject to plan limits
-                active_timeout: The remaining time (in seconds) for the session to
-                    be in the active state whilst jobs are running
-                state: State of the session - open, active, inactive, or closed
-                accepting_jobs: Whether or not the session is accepting jobs
-                last_job_started: Timestamp of when the last job in the session started
-                last_job_completed: Timestamp of when the last job in the session completed
-                started_at: Timestamp of when the session was started
-                closed_at: Timestamp of when the session was closed
+            id: id of the session
+            backned_name: backend used for the session
+            interactive_timeout: The max time (in seconds) between jobs that
+                is allowed to occur to keep the session active
+            max_time: Max allowed time for the session to run in seconds, subject to plan limits
+            active_timeout: The remaining time (in seconds) for the session to
+                be in the active state whilst jobs are running
+            state: State of the session - open, active, inactive, or closed
+            accepting_jobs: Whether or not the session is accepting jobs
+            last_job_started: Timestamp of when the last job in the session started
+            last_job_completed: Timestamp of when the last job in the session completed
+            started_at: Timestamp of when the session was started
+            closed_at: Timestamp of when the session was closed
 
         """
         if self._session_id:

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -197,9 +197,9 @@ class Session:
         """Return current session status.
 
         Returns:
-            The current status of the session, including the following.
+            The current status of the session, including:
             Pending: Session is created but not active.
-                It will become active when the next job of this session is dequeued.
+            It will become active when the next job of this session is dequeued.
             In progress, accepting new jobs: session is active and accepting new jobs.
             In progress, not accepting new jobs: session is active and not accepting new jobs.
             Closed: max_time expired or session was explicitly closed.
@@ -223,7 +223,7 @@ class Session:
         """Return session details.
 
         Returns:
-            A dictionary with the following sessions details.
+            A dictionary with the sessions details, including:
             id: id of the session.
             backend_name: backend used for the session.
             interactive_timeout: The maximum idle time (in seconds) between jobs that

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -225,7 +225,7 @@ class Session:
         Returns:
             A dictionary with session details, including:
             id: id of the session.
-            backned_name: backend used for the session.
+            backend_name: backend used for the session.
             interactive_timeout: The maximum idle time (in seconds) between jobs that
                 is allowed to occur before the session is deactivated.
             max_time: Maximum allowed time (in seconds) for the session, subject to plan limits.
@@ -236,7 +236,6 @@ class Session:
             last_job_completed: Timestamp of when the last job in the session completed.
             started_at: Timestamp of when the session was started.
             closed_at: Timestamp of when the session was closed.
-
         """
         if self._session_id:
             response = self._service._api_client.session_details(self._session_id)

--- a/releasenotes/notes/expose-session-details-c4a44316d30dad33.yaml
+++ b/releasenotes/notes/expose-session-details-c4a44316d30dad33.yaml
@@ -5,3 +5,6 @@ features:
     about a session, including: maximum session time, active time remaining, the current state, 
     and whether or not the session is accepting jobs.
 
+    Also added :meth:`~qiskit_ibm_runtime.Session.status`, which returns the current status of 
+    the session.
+

--- a/releasenotes/notes/expose-session-details-c4a44316d30dad33.yaml
+++ b/releasenotes/notes/expose-session-details-c4a44316d30dad33.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new method, :meth:`~qiskit_ibm_runtime.Session.details` that returns information
+    about a session, including: maximum session time, active time remaining, the current state, 
+    and whether or not the session is accepting jobs.
+


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adding a new `session.details()` method that returns the following:

Both channels will return these 11 fields:
```python
{
'id': 'cki5d18m3kt305s4pndg',
 'backend_name': 'ibm_algiers',
 'interactive_timeout': 300,
 'max_time': 28800,
 'active_ttl': 28800,
 'state': 'closed',
 'accepting_jobs': True,
 'last_job_started': '2023-10-09T19:37:42.004Z',
 'last_job_completed': '2023-10-09T19:38:10.064Z',
 'started_at': '2023-10-09T19:37:42.004Z',
 'closed_at': '2023-10-09T19:38:39.406Z'
}

```

Also added `runtime_session.py` and `base.py` back to this repo since we are eventually merging qiskit-ibm-provider back here anyway.

### Details and comments
Fixes #887 

~~Also, open to different options on how we want these new details exposed. Do we want just a method that returns all the information, or maybe specific properties added to the `Session` class?~~
