### PR TITLE
Exceptions should inherit from Terra where suitable

### DIFF
--- a/qiskit_ibm_runtime/exceptions.py
+++ b/qiskit_ibm_runtime/exceptions.py
@@ -13,7 +13,7 @@
 """Exceptions related to the IBM Runtime service."""
 
 from qiskit.exceptions import QiskitError
-from qiskit.providers.exceptions import JobTimeoutError
+from qiskit.providers.exceptions import JobTimeoutError, JobError
 
 
 class IBMError(QiskitError):
@@ -70,7 +70,7 @@ class RuntimeProgramNotFound(IBMRuntimeError):
     pass
 
 
-class RuntimeJobFailureError(IBMRuntimeError):
+class RuntimeJobFailureError(JobError):
     """Error raised when a runtime job failed."""
 
     pass

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -20,6 +20,8 @@ from datetime import timezone, datetime as python_datetime
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Dict, Any, List
 
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
+
 from qiskit_ibm_provider.utils.hgp import from_instance_format
 from qiskit_ibm_runtime.api.exceptions import RequestsApiError
 from qiskit_ibm_runtime.utils import RuntimeEncoder
@@ -543,4 +545,4 @@ class BaseFakeRuntimeClient:
         for back in self._backends:
             if back.name == backend_name:
                 return back
-        raise ValueError(f"Backend {backend_name} not found")
+        raise QiskitBackendNotFoundError(f"Backend {backend_name} not found")


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
I only identified one such exception - as @jyu00 pointed out - `RuntimeJobFailureError` should inherit `JobError`.
While reviewing the exceptions, I changed the exception type in the `fake_runtime_client`. I thought `QiskitBackendNotFoundError` was more suitable here.
Fixes #1118
See also https://github.com/Qiskit/qiskit-ibm-provider/pull/741.
