### PR TITLE
Fix target_history date bug 

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -228,7 +228,7 @@ class IBMBackend(Backend):
         """Gets backend properties and decodes it"""
         if datetime:
             datetime = local_to_utc(datetime)
-        if not self._properties:
+        if datetime or not self._properties:
             api_properties = self._api_client.backend_properties(self.name, datetime=datetime)
             if api_properties:
                 backend_properties = properties_from_server_data(api_properties)
@@ -241,9 +241,9 @@ class IBMBackend(Backend):
             if api_defaults:
                 self._defaults = defaults_from_server_data(api_defaults)
 
-    def _convert_to_target(self) -> None:
+    def _convert_to_target(self, refresh: bool = False) -> None:
         """Converts backend configuration, properties and defaults to Target object"""
-        if not self._target:
+        if refresh or not self._target:
             self._target = convert_to_target(
                 configuration=self._configuration,
                 properties=self._properties,
@@ -327,7 +327,7 @@ class IBMBackend(Backend):
         """
         self._get_properties(datetime=datetime)
         self._get_defaults()
-        self._convert_to_target()
+        self._convert_to_target(refresh=True)
         return self._target
 
     def properties(

--- a/releasenotes/notes/target-history-date-bug-7d6dad84fc5b3d2e.yaml
+++ b/releasenotes/notes/target-history-date-bug-7d6dad84fc5b3d2e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :meth:`~qiskit_ibm_runtime.IBMBackend.target_history` where
+    the datetime parameter was not being used to retrieve backend properties from the 
+    specified date.

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -13,7 +13,7 @@
 """Tests for backend functions using real runtime service."""
 
 from unittest import SkipTest
-from datetime import datetime
+from datetime import datetime, timedelta
 import copy
 
 from qiskit.transpiler.target import Target
@@ -94,6 +94,14 @@ class TestIBMBackend(IBMIntegrationTestCase):
         with self.subTest(backend=backend.name):
             self.assertIsNotNone(backend.target)
             self.assertIsInstance(backend.target, Target)
+
+    @production_only
+    def test_backend_target_history(self):
+        """Check retrieving backend target_history."""
+        backend = self.backend
+        with self.subTest(backend=backend.name):
+            self.assertIsNotNone(backend.target_history())
+            self.assertIsNotNone(backend.target_history(datetime=datetime.now() - timedelta(30)))
 
     def test_backend_max_circuits(self):
         """Check if the max_circuits property is set."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was an issue where passing in a `datetime` to `target_history()` wouldn't actually use the backend properties from the specified date 

```python
dt1 = datetime(2023, 9, 25, 20, 55, 55, tzinfo=timezone.utc)
th1 = backend.target_history(dt1)

dt2 = datetime(2023, 10, 9, 20, 55, 55, tzinfo=timezone.utc)
th2 = backend.target_history(dt2) # should be different from th1
```

### Details and comments
Fixes #

