### PR TITLE
Log instance on initialization and when running a job

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -219,8 +219,10 @@ class QiskitRuntimeService(Provider):
                 for backend_name in hgp.backends:
                     if backend_name not in self._backends:
                         self._backends[backend_name] = None
-            if not self._account.instance:
-                logger.info(f"Default Instance: {self._get_hgp().name}")
+            self._default_instance = self._account.instance
+            if not self._default_instance:
+                self._default_instance = self._get_hgp().name
+                logger.info("Default instance: %s", self._default_instance)
         QiskitRuntimeService.global_service = self
 
         # TODO - it'd be nice to allow some kind of autocomplete, but `service.ibmq_foo`
@@ -990,8 +992,9 @@ class QiskitRuntimeService(Provider):
             # Find the right hgp
             hgp = self._get_hgp(instance=qrt_options.instance, backend_name=qrt_options.backend)
             hgp_name = hgp.name
-            if hgp_name != self._get_hgp().name:
-                logger.info(f"Instance selected: {hgp_name}")
+            if hgp_name != self._default_instance:
+                self._default_instance = hgp_name
+                logger.info("Instance selected: %s", self._default_instance)
         backend = self.backend(name=qrt_options.backend, instance=hgp_name)
         status = backend.status()
         if status.operational is True and status.status_msg != "active":

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -219,10 +219,10 @@ class QiskitRuntimeService(Provider):
                 for backend_name in hgp.backends:
                     if backend_name not in self._backends:
                         self._backends[backend_name] = None
-            self._default_instance = self._account.instance
-            if not self._default_instance:
-                self._default_instance = self._get_hgp().name
-                logger.info("Default instance: %s", self._default_instance)
+            self._current_instance = self._account.instance
+            if not self._current_instance:
+                self._current_instance = self._get_hgp().name
+                logger.info("Default instance: %s", self._current_instance)
         QiskitRuntimeService.global_service = self
 
         # TODO - it'd be nice to allow some kind of autocomplete, but `service.ibmq_foo`
@@ -992,9 +992,9 @@ class QiskitRuntimeService(Provider):
             # Find the right hgp
             hgp = self._get_hgp(instance=qrt_options.instance, backend_name=qrt_options.backend)
             hgp_name = hgp.name
-            if hgp_name != self._default_instance:
-                self._default_instance = hgp_name
-                logger.info("Instance selected: %s", self._default_instance)
+            if hgp_name != self._current_instance:
+                self._current_instance = hgp_name
+                logger.info("Instance selected: %s", self._current_instance)
         backend = self.backend(name=qrt_options.backend, instance=hgp_name)
         status = backend.status()
         if status.operational is True and status.status_msg != "active":

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -219,6 +219,8 @@ class QiskitRuntimeService(Provider):
                 for backend_name in hgp.backends:
                     if backend_name not in self._backends:
                         self._backends[backend_name] = None
+            if not self._account.instance:
+                logger.info(f"Default Instance: {self._get_hgp().name}")
         QiskitRuntimeService.global_service = self
 
         # TODO - it'd be nice to allow some kind of autocomplete, but `service.ibmq_foo`
@@ -988,6 +990,8 @@ class QiskitRuntimeService(Provider):
             # Find the right hgp
             hgp = self._get_hgp(instance=qrt_options.instance, backend_name=qrt_options.backend)
             hgp_name = hgp.name
+            if hgp_name != self._get_hgp().name:
+                logger.info(f"Instance selected: {hgp_name}")
         backend = self.backend(name=qrt_options.backend, instance=hgp_name)
         status = backend.status()
         if status.operational is True and status.status_msg != "active":

--- a/releasenotes/notes/log-instance-selected-a18c4791418b5e0d.yaml
+++ b/releasenotes/notes/log-instance-selected-a18c4791418b5e0d.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    At initialization, if not passed in directly, the default ``instance`` selected by the provider 
+    will be logged at the "INFO" level. When running a job, if the backend selected is not in 
+    the default instance but in a different instance the user also has access to, that instance 
+    will also be logged. 

--- a/test/integration/test_account.py
+++ b/test/integration/test_account.py
@@ -80,3 +80,13 @@ class TestIntegrationAccount(IBMIntegrationTestCase):
                 token=self.dependencies.token,
                 instance=service_instance_name,
             )
+
+    def test_logging_instance_at_init(self):
+        """Test instance is logged at initialization if instance not passed in."""
+        with self.assertLogs("qiskit_ibm_runtime", "INFO") as logs:
+            QiskitRuntimeService(
+                channel="ibm_quantum",
+                url=self.dependencies.url,
+                token=self.dependencies.token,
+            )
+        self.assertIn("instance", logs.output[0])


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

At initialization, if not passed in directly, the default `instance` selected by the provider 
will be logged at the "INFO" level. When running a job, if the backend selected is not in 
the default instance but in a different instance the user also has access to, that instance 
will also be logged.

### Details and comments
Fixes #1126

