### PR TITLE
Fixed bug when defining shots as int64

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -207,6 +207,8 @@ class RuntimeEncoder(json.JSONEncoder):
                 return {"__type__": "ndarray", "__value__": obj.tolist()}
             value = _serialize_and_encode(obj, np.save, allow_pickle=False)
             return {"__type__": "ndarray", "__value__": value}
+        if isinstance(obj, np.int64):
+            return obj.item()
         if isinstance(obj, set):
             return {"__type__": "set", "__value__": list(obj)}
         if isinstance(obj, Result):

--- a/releasenotes/notes/fix_np_int64-864b605a88f57419.yaml
+++ b/releasenotes/notes/fix_np_int64-864b605a88f57419.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug where ``shots`` passed in as a numpy type were not being
+    serialized correctly.

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -186,6 +186,13 @@ class TestDataSerialization(IBMTestCase):
             decoded = json.loads(encoded, cls=RuntimeDecoder)
             self.assertEqual(decoded, obj)
 
+    def test_encoder_np_number(self):
+        """Test encoding and decoding instructions"""
+        encoded = json.dumps(np.int64(100), cls=RuntimeEncoder)
+        self.assertIsInstance(encoded, str)
+        decoded = json.loads(encoded, cls=RuntimeDecoder)
+        self.assertEqual(decoded, 100)
+
     def test_encoder_callable(self):
         """Test encoding a callable."""
         with warnings.catch_warnings(record=True) as warn_cm:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added support for `numpy.int64` in the `RuntimeEncoder`.


### Details and comments
Fixes - same as https://github.com/Qiskit/qiskit-ibm-provider/issues/743 for Runtime repo.

