### PR TITLE
Logging instance test is IQP channel only

### DIFF
--- a/test/integration/test_account.py
+++ b/test/integration/test_account.py
@@ -83,6 +83,9 @@ class TestIntegrationAccount(IBMIntegrationTestCase):
 
     def test_logging_instance_at_init(self):
         """Test instance is logged at initialization if instance not passed in."""
+        if self.dependencies.channel == "ibm_cloud":
+            self.skipTest("Not supported on ibm_cloud")
+
         with self.assertLogs("qiskit_ibm_runtime", "INFO") as logs:
             QiskitRuntimeService(
                 channel="ibm_quantum",


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`test_logging_instance_at_init` should only be tested on the quantum channel, not cloud 

### Details and comments
Fixes #

