### PR TITLE
Fix error in simulator property of stabilizer simulator backends

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -243,7 +243,7 @@ class IBMBackend(Backend):
 
     def _convert_to_target(self, refresh: bool = False) -> None:
         """Converts backend configuration, properties and defaults to Target object"""
-        if refresh or not self._target:
+        if (refresh or not self._target) and self.name.split("_")[-1] != "stabilizer":
             self._target = convert_to_target(
                 configuration=self._configuration,
                 properties=self._properties,


### PR DESCRIPTION
Fixes #1136 

### Summary
This PR proposes a simple fix to an issue causing the stabilizer simulators to error out when their `simulator` boolean fields are queried.

There seems to be an issue with the coupling maps/properties held by the stabilizer backends internally. The following error is the result of querying whether a stabilizer simulator backend is a simulator (`backend.simulator`). The full steps to reproduce and error trace are included in #1136 :

```
TranspilerError: "The number of qubits for Instruction(name='cx', num_qubits=2, num_clbits=0, params=[]) does not match the number of qubits in the properties dictionary: (0,)"
```

This is a rudimentary "fix", and it very well may not be the ideal solution. I just wanted to submit this PR to get the ball rolling on a fix. I'm happy to fix this at a more fundamental level if someone has a specific idea :)


### Details and comments
This fix simply checks the simulator name, and if it is suffixed with "_stabilizer", the `convert_to_target` function is not called from within `self._convert_to_target`. This means that `convert_to_target` will never be called for stabilizer simulators from the internal `_convert_to_target` method.