### PR TITLE
Add channel strategy instance validation

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -374,6 +374,14 @@ class RuntimeClient(BaseBackendClient):
         """
         return self._api.backends(hgp=hgp, channel_strategy=channel_strategy)["devices"]
 
+    def cloud_instance(self) -> bool:
+        """Returns a boolean of whether or not the instance has q-ctrl enabled.
+
+        Returns:
+            Boolean value.
+        """
+        return self._api.cloud_instance()
+
     def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
         """Return the configuration of the IBM backend.
 

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -36,6 +36,7 @@ class Runtime(RestAdapterBase):
         "programs": "/programs",
         "jobs": "/jobs",
         "backends": "/backends",
+        "cloud_instance": "/instance",
     }
 
     def program(self, program_id: str) -> "Program":
@@ -293,3 +294,12 @@ class Runtime(RestAdapterBase):
         if channel_strategy:
             params["channel_strategy"] = channel_strategy
         return self.session.get(url, params=params, timeout=timeout).json()
+
+    def cloud_instance(self) -> bool:
+        """Return boolean of whether or not the instance has q-ctrl enabled.
+
+        Returns:
+            Boolean value.
+        """
+        url = self.get_url("cloud_instance")
+        return self.session.get(url).json().get("qctrl_enabled")

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -204,6 +204,7 @@ class QiskitRuntimeService(Provider):
             # TODO: We can make the backend discovery lazy
             self._backends = self._discover_cloud_backends()
             QiskitRuntimeService.global_service = self
+            self._validate_channel_strategy()
             return
         else:
             auth_client = self._authenticate_ibm_quantum_account(self._client_params)
@@ -307,6 +308,18 @@ class QiskitRuntimeService(Provider):
         account.validate()
 
         return account
+
+    def _validate_channel_strategy(self) -> None:
+        """Raise an error if the passed in channel_strategy and
+        instance do not match.
+
+        """
+        if self._channel_strategy == "q-ctrl":
+            qctrl_enabled = self._api_client.cloud_instance()
+            if not qctrl_enabled:
+                raise IBMNotAuthorizedError(
+                    "This account is not authorized to use ``q-ctrl`` as a channel strategy."
+                )
 
     def _discover_cloud_backends(self) -> Dict[str, "ibm_backend.IBMBackend"]:
         """Return the remote backends available for this service instance.

--- a/releasenotes/notes/channel-strategy-instance-validate-639b18b8c5d44678.yaml
+++ b/releasenotes/notes/channel-strategy-instance-validate-639b18b8c5d44678.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    An error will be raised during initialization if ``q-ctrl`` is passsed in as the ``channel_strategy`` and
+    An error will be raised during initialization if ``q-ctrl`` is passed in as the ``channel_strategy`` and
     the account instance does not have ``q-ctrl`` enabled. 

--- a/releasenotes/notes/channel-strategy-instance-validate-639b18b8c5d44678.yaml
+++ b/releasenotes/notes/channel-strategy-instance-validate-639b18b8c5d44678.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    An error will be raised during initialization if ``q-ctrl`` is passsed in as the ``channel_strategy`` and
+    the account instance does not have ``q-ctrl`` enabled. 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If `q-ctrl` is passed in as the channel_strategy but the instance does not have it enabled, the following error will be raised: 

```
IBMNotAuthorizedError: 'This account is not authorized to use ``q-ctrl`` as a channel strategy.'
```

### Details and comments
Fixes #1176

