### PR TITLE
Skip unit tests until provider/736 is merged 

### DIFF
--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 import tempfile
 import warnings
+from unittest import skip
 from datetime import datetime
 
 import numpy as np
@@ -91,6 +92,7 @@ class TestDataSerialization(IBMTestCase):
                     decoded = [decoded]
                 self.assertTrue(all(isinstance(item, QuantumCircuit) for item in decoded))
 
+    @skip("Skip until qiskit-ibm-provider/736 is merged")
     def test_coder_operators(self):
         """Test runtime encoder and decoder for operators."""
 
@@ -165,6 +167,7 @@ class TestDataSerialization(IBMTestCase):
             decoded = json.loads(encoded, cls=RuntimeDecoder)
             self.assertTrue(np.array_equal(decoded["ndarray"], obj["ndarray"]))
 
+    @skip("Skip until qiskit-ibm-provider/736 is merged")
     def test_encoder_instruction(self):
         """Test encoding and decoding instructions"""
         subtests = (


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Skipping failing unit tests, they will be fixed by https://github.com/Qiskit/qiskit-ibm-provider/pull/736 which can't be merged until qiskit is updated on the server side. 

### Details and comments
Fixes #

