### PR TITLE
Remove caching of results in RuntimeJob

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -787,6 +787,7 @@ class IBMBackend(Backend):
                 program_id=program_id,
                 session_id=session_id,
                 service=self.service,
+                tags=job_tags,
             )
             logger.debug("Job %s was successfully submitted.", job.job_id())
         except TypeError as err:

--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -122,7 +122,6 @@ class RuntimeJob(Job):
         """
         super().__init__(backend=backend, job_id=job_id)
         self._api_client = api_client
-        self._results: Optional[Any] = None
         self._interim_results: Optional[Any] = None
         self._params = params or {}
         self._creation_date = creation_date
@@ -212,25 +211,22 @@ class RuntimeJob(Job):
             RuntimeInvalidStateError: If the job was cancelled, and attempting to retrieve result.
         """
         _decoder = decoder or self._final_result_decoder
-        if self._results is None or (_decoder != self._final_result_decoder):
-            self.wait_for_final_state(timeout=timeout)
-            if self._status == JobStatus.ERROR:
-                error_message = self._reason if self._reason else self._error_message
-                if self._reason == "RAN TOO LONG":
-                    raise RuntimeJobMaxTimeoutError(error_message)
-                raise RuntimeJobFailureError(f"Unable to retrieve job result. {error_message}")
-            if self._status is JobStatus.CANCELLED:
-                raise RuntimeInvalidStateError(
-                    "Unable to retrieve result for job {}. "
-                    "Job was cancelled.".format(self.job_id())
-                )
-
-            result_raw = self._download_external_result(
-                self._api_client.job_results(job_id=self.job_id())
+        self.wait_for_final_state(timeout=timeout)
+        if self._status == JobStatus.ERROR:
+            error_message = self._reason if self._reason else self._error_message
+            if self._reason == "RAN TOO LONG":
+                raise RuntimeJobMaxTimeoutError(error_message)
+            raise RuntimeJobFailureError(f"Unable to retrieve job result. {error_message}")
+        if self._status is JobStatus.CANCELLED:
+            raise RuntimeInvalidStateError(
+                "Unable to retrieve result for job {}. " "Job was cancelled.".format(self.job_id())
             )
 
-            self._results = _decoder.decode(result_raw) if result_raw else None
-        return self._results
+        result_raw = self._download_external_result(
+            self._api_client.job_results(job_id=self.job_id())
+        )
+
+        return _decoder.decode(result_raw) if result_raw else None
 
     def cancel(self) -> None:
         """Cancel the job.

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -27,6 +27,7 @@ from ibm_cloud_sdk_core.authenticators import (  # pylint: disable=import-error
     IAMAuthenticator,
 )
 from ibm_platform_services import ResourceControllerV2  # pylint: disable=import-error
+from qiskit_ibm_runtime.exceptions import IBMInputValueError
 
 
 def validate_job_tags(job_tags: Optional[List[str]]) -> None:
@@ -36,12 +37,12 @@ def validate_job_tags(job_tags: Optional[List[str]]) -> None:
         job_tags: Job tags to be validated.
 
     Raises:
-        ValueError: If the job tags are invalid.
+        IBMInputValueError: If the job tags are invalid.
     """
     if job_tags and (
         not isinstance(job_tags, list) or not all(isinstance(tag, str) for tag in job_tags)
     ):
-        raise ValueError("job_tags needs to be a list of strings.")
+        raise IBMInputValueError("job_tags needs to be a list of strings.")
 
 
 def get_iam_api_url(cloud_url: str) -> str:

--- a/releasenotes/notes/no_cached_results-54d063390b9b0ae6.yaml
+++ b/releasenotes/notes/no_cached_results-54d063390b9b0ae6.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Removed storing result in ``RuntimeJob._results``. Instead retrieve results every time the 
+    ``results()`` method is called.

--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -286,9 +286,8 @@ class TestIBMJob(IBMIntegrationTestCase):
         )
         self.assertNotIn(job.job_id(), [rjob.job_id() for rjob in oldest_jobs])
 
-    @skip("how do we support refresh")
     def test_refresh_job_result(self):
-        """Test re-retrieving job result via refresh."""
+        """Test re-retrieving job result."""
         result = self.sim_job.result()
 
         # Save original cached results.
@@ -300,8 +299,8 @@ class TestIBMJob(IBMIntegrationTestCase):
         self.assertNotEqual(cached_result, result.to_dict())
         self.assertEqual(result.results[0].header.name, "modified_result")
 
-        # Re-retrieve result via refresh.
-        result = self.sim_job.result(refresh=True)
+        # Re-retrieve result.
+        result = self.sim_job.result()
         self.assertDictEqual(cached_result, result.to_dict())
         self.assertNotEqual(result.results[0].header.name, "modified_result")
 

--- a/test/integration/test_ibm_job_attributes.py
+++ b/test/integration/test_ibm_job_attributes.py
@@ -25,12 +25,11 @@ from qiskit import QuantumCircuit
 from qiskit.test.reference_circuits import ReferenceCircuits
 
 from qiskit_ibm_provider.api.clients.runtime import RuntimeClient
-from qiskit_ibm_provider.exceptions import (
-    IBMBackendValueError,
-)
+from qiskit_ibm_provider.exceptions import IBMBackendValueError
 from qiskit_ibm_provider.job.exceptions import IBMJobFailureError
 
 from qiskit_ibm_runtime import IBMBackend, RuntimeJob
+from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from ..decorators import (
     IntegrationTestDependencies,
     integration_test_setup,
@@ -224,7 +223,7 @@ class TestIBMJobAttributes(IBMTestCase):
         cancel_job_safe(job, self.log)
 
     def test_esp_readout_not_enabled(self):
-        """Test that an error is thrown is ESP readout is used and the backend does not support it."""
+        """Test that an error is thrown if ESP readout is used and the backend does not support it."""
         # sim backend does not have ``measure_esp_enabled`` flag: defaults to ``False``
         with self.assertRaises(IBMBackendValueError) as context_manager:
             self.sim_backend.run(self.bell, use_measure_esp=True)
@@ -283,10 +282,8 @@ class TestIBMJobAttributes(IBMTestCase):
                     len(rjobs), 1, "Expected job {}, got {}".format(job.job_id(), rjobs)
                 )
                 self.assertEqual(rjobs[0].job_id(), job.job_id())
-                # TODO check why this sometimes fails
-                # self.assertEqual(set(rjobs[0].tags()), set(job_tags))
+                self.assertEqual(set(rjobs[0].tags), set(job_tags))
 
-    @skip("refresh supported in provider but not in runtime")
     def test_job_tags_replace(self):
         """Test updating job tags by replacing a job's existing tags."""
         initial_job_tags = [uuid.uuid4().hex[:16]]
@@ -304,15 +301,13 @@ class TestIBMJobAttributes(IBMTestCase):
 
                 # Wait a bit so we don't get cached results.
                 time.sleep(2)
-                job.refresh()
-
-                self.assertEqual(set(tags_to_replace), set(job.tags()))
+                self.assertEqual(set(tags_to_replace), set(job.tags))
 
     def test_invalid_job_tags(self):
         """Test using job tags with an and operator."""
-        self.assertRaises(IBMBackendValueError, self.sim_backend.run, self.bell, job_tags={"foo"})
+        self.assertRaises(IBMInputValueError, self.sim_backend.run, self.bell, job_tags={"foo"})
         self.assertRaises(
-            IBMBackendValueError,
+            IBMInputValueError,
             self.service.jobs,
             job_tags=[1, 2, 3],
         )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Removed the `RuntimeJob._results` member, and don't store the results every time they are retrieved. Instead, retrieve the results from the server every time.
Also fixed several related tests.
Noticed `job_tags` was not passed as a parameter when creating a new `RuntimeJob`, so added it.


### Details and comments
Fixes #1159 

