### PR TITLE
Remove circuit & observable indices run inputs

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -176,9 +176,7 @@ class Estimator(BasePrimitive, BaseEstimator):
         """
         inputs = {
             "circuits": circuits,
-            "circuit_indices": list(range(len(circuits))),
             "observables": observables,
-            "observable_indices": list(range(len(observables))),
             "parameters": [circ.parameters for circ in circuits],
             "parameter_values": parameter_values,
         }

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -143,7 +143,6 @@ class Sampler(BasePrimitive, BaseSampler):
         inputs = {
             "circuits": circuits,
             "parameters": [circ.parameters for circ in circuits],
-            "circuit_indices": list(range(len(circuits))),
             "parameter_values": parameter_values,
         }
         return self._run_primitive(

--- a/releasenotes/notes/remove-circuit-indicies-e8af9da213e463e9.yaml
+++ b/releasenotes/notes/remove-circuit-indicies-e8af9da213e463e9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``circuit_indices`` and ``observable_indices`` run inputs for 
+    :class:`~qiskit_ibm_runtime.Estimator` and :class:`~qiskit_ibm_runtime.Sampler`
+    have been completely removed.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This was reverted in https://github.com/Qiskit/qiskit-ibm-runtime/pull/999 but is now needed for q-ctrl. 
These inputs are no longer passed in on the server side pending `qiskit-ibm-primitives/134`

### Details and comments
Fixes #

