### PR TITLE
Revert `Session.from_id 0.15.0` changes  

### DIFF
--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -23,9 +23,8 @@ from .runtime_job import RuntimeJob
 from .runtime_program import ParameterNamespace
 from .program.result_decoder import ResultDecoder
 from .ibm_backend import IBMBackend
-from .exceptions import IBMInputValueError
-from .utils.deprecation import deprecate_arguments
 from .utils.default_session import set_cm_session
+from .utils.deprecation import deprecate_arguments
 
 
 def _active_session(func):  # type: ignore
@@ -284,44 +283,28 @@ class Session:
     def from_id(
         cls,
         session_id: str,
-        service: QiskitRuntimeService,
+        service: Optional[QiskitRuntimeService] = None,
         backend: Optional[Union[str, IBMBackend]] = None,
     ) -> "Session":
         """Construct a Session object with a given session_id
 
         Args:
-            session_id: the id of the session to be created. This must be an already
+            session_id: the id of the session to be created. This can be an already
                 existing session id.
             service: instance of the ``QiskitRuntimeService`` class.
             backend: instance of :class:`qiskit_ibm_runtime.IBMBackend` class or
                 string name of backend.
 
-        Raises:
-            IBMInputValueError: If given `session_id` does not exist. or the backend passed in does
-                not match the original session backend.
-
         Returns:
             A new Session with the given ``session_id``
-        """
 
+        """
         if backend:
             deprecate_arguments("backend", "0.15.0", "Sessions do not support multiple backends.")
-            if isinstance(backend, IBMBackend):
-                backend = backend.name
 
-        response = service._api_client.session_details(session_id)
-        if response:
-            session_backend = response.get("backend_name")
-            if backend and backend != session_backend:
-                raise IBMInputValueError(
-                    f"The session_id {session_id} was created with backend {session_backend}, "
-                    f"but backend {backend} was given."
-                )
-            session = cls(service, session_backend)
-            session._session_id = session_id
-            return session
-
-        raise IBMInputValueError(f"The session_id {session_id} does not exist.")
+        session = cls(service, backend)
+        session._session_id = session_id
+        return session
 
     def __enter__(self) -> "Session":
         set_cm_session(self)

--- a/releasenotes/notes/revert-from-id-9b87ea2d948251d6.yaml
+++ b/releasenotes/notes/revert-from-id-9b87ea2d948251d6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Reverting `0.15.0` changes to :meth:`~qiskit_ibm_runtime.Session.from_id` because it was
+    a breaking change without proper deprecation. 
+


### PR DESCRIPTION
This reverts commit 8fa0472e15ea36341acd6de67efa54a9815354e8. But keeps the `backend` parameter deprecation 

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Fixes #1228

