### PR TITLE
Make `test_backend_wrong_instance` IQP only 

### DIFF
--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -46,6 +46,7 @@ class TestIntegrationBackend(IBMIntegrationTestCase):
         )
 
     @run_integration_test
+    @quantum_only
     def test_backend_wrong_instance(self, service):
         """Test getting a backend with wrong instance."""
         hgps = list(service._hgps.keys())


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Cloud channel does not have hgps

### Details and comments
Fixes #

