### PR TITLE
Add pointer to qiskit/documentation issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Non-API docs issues
     url: https://github.com/Qiskit/documentation/issues/new/choose
-    about: Open an issue about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections (non-API documentation)
+    about: Open an issue about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections of docs.quantum.ibm.com (non-API documentation)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Non-API docs issues
+    url: https://github.com/Qiskit/documentation/issues/new/choose
+    about: Open an issue about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections (non-API documentation)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ contributing to qiskit-ibm-runtime, these are documented below.
 
 ### Open an issue
 
-* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit-ibm-runtime repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of https://docs.quantum.ibm.com, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit-ibm-runtime repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
 * For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference.
 
 ### Pull request checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,10 @@ https://qiskit.org/documentation/contributing_to_qiskit.html
 In addition to the general guidelines there are specific details for
 contributing to qiskit-ibm-runtime, these are documented below.
 
+### Open an issue
+
+* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit-ibm-runtime repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference.
 
 ### Pull request checklist
 


### PR DESCRIPTION


### Summary

With the unification of the qiskit-ibm-runtime docs and IBM Quantum Platform docs, we want to make it clear where to open an issue, depending on what page you're on when you identify a problem/suggestion to report.

### Details and comments

Issues about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections should be opened here: https://github.com/Qiskit/documentation/issues/new/choose



