### PR TITLE
Revert "Don't block for the first job in a session (#1170)"

### DIFF
--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -23,7 +23,6 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from .runtime_job import RuntimeJob
 from .utils.result_decoder import ResultDecoder
 from .ibm_backend import IBMBackend
-from .exceptions import RuntimeJobTimeoutError
 from .utils.default_session import set_cm_session
 from .utils.deprecation import deprecate_arguments
 
@@ -181,10 +180,7 @@ class Session:
                 self._setup_lock.release()
 
         if self._backend is None:
-            try:
-                self._backend = job.backend(0).name
-            except RuntimeJobTimeoutError:
-                self._backend = None
+            self._backend = job.backend().name
 
         return job
 

--- a/releasenotes/notes/backend-blocking-job-70ebcf44855cbdfd.yaml
+++ b/releasenotes/notes/backend-blocking-job-70ebcf44855cbdfd.yaml
@@ -1,8 +1,0 @@
----
-fixes:
-  - |
-    Fixed an issue where the first job in a cloud channel session without a backend passed 
-    in would block other jobs from starting. This would happen because the first job would
-    attempt to retrieve the backend from the job which required the job to be in a 
-    completed state. 
-

--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -101,19 +101,6 @@ class TestIntegrationSession(IBMIntegrationTestCase):
         job = sampler.run(ReferenceCircuits.bell(), shots=400)
         self.assertEqual(session_id, job.session_id)
 
-    @run_integration_test
-    def test_session_no_backend(self, service):
-        """Test session without passing in backend."""
-        if self.dependencies.channel == "ibm_quantum":
-            self.skipTest("Not supported on ibm_quantum")
-        with Session(service) as session:
-            sampler = Sampler(session=session)
-            job1 = sampler.run(ReferenceCircuits.bell(), shots=400)
-            job2 = sampler.run(ReferenceCircuits.bell(), shots=400)
-        self.assertTrue(job1.backend())
-        self.assertTrue(job2.backend())
-        self.assertEqual(job1.backend().name, job2.backend().name)
-
 
 class TestBackendRunInSession(IBMIntegrationTestCase):
     """Integration tests for Backend.run in Session."""


### PR DESCRIPTION
This reverts commit f2e24e49829360af4381cb0ffc46f62e343054fa.

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Reverting this changes because it resulted in multiple backends within a single session. 

### Details and comments
Fixes #

