### PR TITLE
Migrate fake provider base classes from Qiskit

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py
@@ -15,7 +15,7 @@ Fake Almaden device (20 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeAlmadenV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
@@ -15,7 +15,7 @@ Fake Armonk device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeArmonkV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py
@@ -15,7 +15,7 @@ Fake Athens device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeAthensV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py
@@ -16,7 +16,7 @@ Fake Auckland device (27 qubits).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakeAuckland(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py
@@ -15,7 +15,7 @@ Fake Belem device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeBelemV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py
@@ -15,7 +15,7 @@ Fake Boeblingen device (20 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeBoeblingenV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py
@@ -15,7 +15,7 @@ Fake Bogota device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeBogotaV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py
@@ -15,7 +15,7 @@ Fake Brooklyn device (65 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeBrooklynV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py
@@ -15,7 +15,7 @@ Fake Burlington device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeBurlingtonV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py
@@ -15,7 +15,7 @@ Fake Cairo device (27 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeCairoV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
@@ -15,7 +15,7 @@ Fake Cambridge device (20 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeCambridgeV2(fake_backend.FakeBackendV2):
@@ -68,5 +68,5 @@ class FakeCambridgeAlternativeBasis(FakeCambridge):
     props_filename = "props_cambridge_alt.json"  # type: ignore
 
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__()  # type: ignore
         self._configuration.basis_gates = ["u", "sx", "p", "cx", "id"]

--- a/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py
@@ -15,7 +15,7 @@ Fake Casablanca device (7 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeCasablancaV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py
@@ -15,7 +15,7 @@ Fake Essex device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeEssexV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py
@@ -16,7 +16,7 @@ Fake Geneva device (27 qubits).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakeGeneva(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
@@ -16,7 +16,7 @@ Fake Guadalupe device (5 qubit).
 
 import os
 
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeGuadalupeV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py
@@ -15,7 +15,7 @@ Fake Hanoi device (27 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeHanoiV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py
@@ -15,7 +15,7 @@ Fake Jakarta device (7 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeJakartaV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py
@@ -15,7 +15,7 @@ Fake Johannesburg device (20 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeJohannesburgV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py
@@ -15,7 +15,7 @@ Fake Kolkata device (27 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeKolkataV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py
@@ -15,7 +15,7 @@ Fake Lagos device (7 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeLagosV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py
@@ -15,7 +15,7 @@ Fake Lima device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeLimaV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py
@@ -15,7 +15,7 @@ Fake London device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeLondonV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py
@@ -15,7 +15,7 @@ Fake Manhattan device (65 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeManhattanV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py
@@ -15,7 +15,7 @@ Fake Manila device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeManilaV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
@@ -23,7 +23,7 @@ from qiskit.providers.models import (
     BackendProperties,
 )
 from qiskit.providers.fake_provider.fake_backend import FakeBackend
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakeMelbourneV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py
@@ -15,7 +15,7 @@ Fake Montreal device (27 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeMontrealV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py
@@ -15,7 +15,7 @@ Fake Mumbai device (27 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeMumbaiV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py
@@ -15,7 +15,7 @@ Fake Nairobi device (7 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeNairobiV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py
@@ -16,7 +16,7 @@ Fake Oslo device (7 qubits).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakeOslo(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py
@@ -15,7 +15,7 @@ Fake Ourense device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeOurenseV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
@@ -15,7 +15,7 @@ Fake Paris device (20 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeParisV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py
@@ -16,7 +16,7 @@ Fake Perth device (7 qubits).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakePerth(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py
@@ -23,7 +23,7 @@ from qiskit.providers.models import (
     BackendProperties,
 )
 from qiskit.providers.fake_provider.fake_backend import FakeBackend
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakePoughkeepsieV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py
@@ -16,7 +16,7 @@ Fake Prague device (33 qubits).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakePrague(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py
@@ -15,7 +15,7 @@ Fake Quito device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeQuitoV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py
@@ -15,7 +15,7 @@ Fake Rochester device (53 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeRochesterV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py
@@ -15,7 +15,7 @@ Fake Rome device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeRomeV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py
@@ -15,7 +15,7 @@ Fake Santiago device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeSantiagoV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py
@@ -15,7 +15,7 @@ Fake Sherbrooke device (127 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakeSherbrooke(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py
@@ -15,7 +15,7 @@ Fake Singapore device (20 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeSingaporeV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py
@@ -15,7 +15,7 @@ Fake Sydney device (27 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeSydneyV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py
@@ -15,7 +15,7 @@ Fake Toronto device (27 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeTorontoV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py
@@ -15,7 +15,7 @@ Fake Valencia device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeValenciaV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py
@@ -15,7 +15,7 @@ Fake Vigo device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeVigoV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py
@@ -15,7 +15,7 @@ Fake Washington device (127 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_pulse_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_pulse_backend, fake_backend
 
 
 class FakeWashingtonV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py
@@ -15,7 +15,7 @@ Fake Yorktown device (5 qubit).
 """
 
 import os
-from qiskit.providers.fake_provider import fake_qasm_backend, fake_backend
+from qiskit_ibm_runtime.fake_provider import fake_qasm_backend, fake_backend
 
 
 class FakeYorktownV2(fake_backend.FakeBackendV2):

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -1,0 +1,570 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=no-name-in-module
+"""
+Base class for dummy backends.
+"""
+
+import warnings
+import collections
+import json
+import os
+import re
+
+from typing import List, Iterable
+
+from qiskit import circuit
+from qiskit.providers.models import BackendProperties, BackendConfiguration, PulseDefaults
+from qiskit.providers import BackendV2, BackendV1
+from qiskit import pulse
+from qiskit.exceptions import QiskitError
+from qiskit.utils import optionals as _optionals
+from qiskit.providers import basicaer
+from qiskit.transpiler import Target
+from qiskit.providers import Options
+from qiskit.providers.backend_compat import convert_to_target
+from qiskit.providers.fake_provider.utils.json_decoder import (
+    decode_backend_configuration,
+    decode_backend_properties,
+    decode_pulse_defaults,
+)
+
+
+class _Credentials:
+    def __init__(self, token: str = "123456", url: str = "https://") -> None:
+        self.token = token
+        self.url = url
+        self.hub = "hub"
+        self.group = "group"
+        self.project = "project"
+
+
+class FakeBackendV2(BackendV2):
+    """A fake backend class for testing and noisy simulation using real backend
+    snapshots.
+
+    The class inherits :class:`~qiskit.providers.BackendV2` class. This version
+    differs from earlier :class:`~qiskit.providers.fake_provider.FakeBackend` (V1) class in a
+    few aspects. Firstly, configuration attribute no longer exsists. Instead,
+    attributes exposing equivalent required immutable properties of the backend
+    device are added. For example ``fake_backend.configuration().n_qubits`` is
+    accessible from ``fake_backend.num_qubits`` now. Secondly, this version
+    removes extra abstractions :class:`~qiskit.providers.fake_provider.FakeQasmBackend` and
+    :class:`~qiskit.providers.fake_provider.FakePulseBackend` that were present in V1.
+    """
+
+    # directory and file names for real backend snapshots.
+    dirname = None
+    conf_filename = None
+    props_filename = None
+    defs_filename = None
+    backend_name = None
+
+    def __init__(self) -> None:
+        """FakeBackendV2 initializer."""
+        self._conf_dict = self._get_conf_dict_from_json()
+        self._props_dict = None
+        self._defs_dict = None
+        super().__init__(
+            provider=None,
+            name=self._conf_dict.get("backend_name"),
+            description=self._conf_dict.get("description"),
+            online_date=self._conf_dict.get("online_date"),
+            backend_version=self._conf_dict.get("backend_version"),
+        )
+        self._target = None
+        self.sim = None
+
+        if "channels" in self._conf_dict:
+            self._parse_channels(self._conf_dict["channels"])
+
+    def _parse_channels(self, channels: dict) -> None:
+        type_map = {
+            "acquire": pulse.AcquireChannel,
+            "drive": pulse.DriveChannel,
+            "measure": pulse.MeasureChannel,
+            "control": pulse.ControlChannel,
+        }
+        identifier_pattern = re.compile(r"\D+(?P<index>\d+)")
+
+        channels_map = {  # type: ignore
+            "acquire": collections.defaultdict(list),
+            "drive": collections.defaultdict(list),
+            "measure": collections.defaultdict(list),
+            "control": collections.defaultdict(list),
+        }
+        for identifier, spec in channels.items():
+            channel_type = spec["type"]
+            out = re.match(identifier_pattern, identifier)
+            if out is None:
+                # Identifier is not a valid channel name format
+                continue
+            channel_index = int(out.groupdict()["index"])
+            qubit_index = tuple(spec["operates"]["qubits"])
+            chan_obj = type_map[channel_type](channel_index)
+            channels_map[channel_type][qubit_index].append(chan_obj)
+        setattr(self, "channels_map", channels_map)
+
+    def _setup_sim(self) -> None:
+        if _optionals.HAS_AER:
+            from qiskit_aer import AerSimulator  # pylint: disable=import-outside-toplevel
+
+            self.sim = AerSimulator()
+            if self.target and self._props_dict:
+                noise_model = self._get_noise_model_from_backend_v2()  # type: ignore
+                self.sim.set_options(noise_model=noise_model)
+                # Update fake backend default too to avoid overwriting
+                # it when run() is called
+                self.set_options(noise_model=noise_model)
+
+        else:
+            self.sim = basicaer.QasmSimulatorPy()
+
+    def _get_conf_dict_from_json(self) -> dict:
+        if not self.conf_filename:
+            return None
+        conf_dict = self._load_json(self.conf_filename)  # type: ignore
+        decode_backend_configuration(conf_dict)
+        conf_dict["backend_name"] = self.backend_name
+        return conf_dict
+
+    def _set_props_dict_from_json(self) -> None:
+        if self.props_filename:
+            props_dict = self._load_json(self.props_filename)  # type: ignore
+            decode_backend_properties(props_dict)
+            self._props_dict = props_dict
+
+    def _set_defs_dict_from_json(self) -> None:
+        if self.defs_filename:
+            defs_dict = self._load_json(self.defs_filename)  # type: ignore
+            decode_pulse_defaults(defs_dict)
+            self._defs_dict = defs_dict
+
+    def _load_json(self, filename: str) -> dict:
+        with open(  # pylint: disable=unspecified-encoding
+            os.path.join(self.dirname, filename)
+        ) as f_json:
+            the_json = json.load(f_json)
+        return the_json
+
+    @property
+    def target(self) -> Target:
+        """A :class:`qiskit.transpiler.Target` object for the backend.
+
+        :rtype: Target
+        """
+        if self._target is None:
+            self._get_conf_dict_from_json()
+            if self._props_dict is None:
+                self._set_props_dict_from_json()
+            if self._defs_dict is None:
+                self._set_defs_dict_from_json()
+            conf = BackendConfiguration.from_dict(self._conf_dict)
+            props = None
+            if self._props_dict is not None:
+                props = BackendProperties.from_dict(self._props_dict)  # type: ignore
+            defaults = None
+            if self._defs_dict is not None:
+                defaults = PulseDefaults.from_dict(self._defs_dict)  # type: ignore
+
+            self._target = convert_to_target(
+                conf, props, defaults, add_delay=True, filter_faulty=True
+            )
+
+        return self._target
+
+    @property
+    def max_circuits(self) -> None:
+        return None
+
+    @classmethod
+    def _default_options(cls) -> Options:
+        """Return the default options
+
+        This method will return a :class:`qiskit.providers.Options`
+        subclass object that will be used for the default options. These
+        should be the default parameters to use for the options of the
+        backend.
+
+        Returns:
+            qiskit.providers.Options: A options object with
+                default values set
+        """
+        if _optionals.HAS_AER:
+            from qiskit_aer import AerSimulator  # pylint: disable=import-outside-toplevel
+
+            return AerSimulator._default_options()
+        else:
+            return basicaer.QasmSimulatorPy._default_options()
+
+    @property
+    def dtm(self) -> float:
+        """Return the system time resolution of output signals
+
+        Returns:
+            The output signal timestep in seconds.
+        """
+        dtm = self._conf_dict.get("dtm")
+        if dtm is not None:
+            # converting `dtm` in nanoseconds in configuration file to seconds
+            return dtm * 1e-9
+        else:
+            return None
+
+    @property
+    def meas_map(self) -> List[List[int]]:
+        """Return the grouping of measurements which are multiplexed
+        This is required to be implemented if the backend supports Pulse
+        scheduling.
+
+        Returns:
+            The grouping of measurements which are multiplexed
+        """
+        return self._conf_dict.get("meas_map")
+
+    def drive_channel(self, qubit: int):  # type: ignore
+        """Return the drive channel for the given qubit.
+
+        This is required to be implemented if the backend supports Pulse
+        scheduling.
+
+        Returns:
+            DriveChannel: The Qubit drive channel
+        """
+        drive_channels_map = getattr(self, "channels_map", {}).get("drive", {})
+        qubits = (qubit,)
+        if qubits in drive_channels_map:
+            return drive_channels_map[qubits][0]
+        return None
+
+    def measure_channel(self, qubit: int):  # type: ignore
+        """Return the measure stimulus channel for the given qubit.
+
+        This is required to be implemented if the backend supports Pulse
+        scheduling.
+
+        Returns:
+            MeasureChannel: The Qubit measurement stimulus line
+        """
+        measure_channels_map = getattr(self, "channels_map", {}).get("measure", {})
+        qubits = (qubit,)
+        if qubits in measure_channels_map:
+            return measure_channels_map[qubits][0]
+        return None
+
+    def acquire_channel(self, qubit: int):  # type: ignore
+        """Return the acquisition channel for the given qubit.
+
+        This is required to be implemented if the backend supports Pulse
+        scheduling.
+
+        Returns:
+            AcquireChannel: The Qubit measurement acquisition line.
+        """
+        acquire_channels_map = getattr(self, "channels_map", {}).get("acquire", {})
+        qubits = (qubit,)
+        if qubits in acquire_channels_map:
+            return acquire_channels_map[qubits][0]
+        return None
+
+    def control_channel(self, qubits: Iterable[int]):  # type: ignore
+        """Return the secondary drive channel for the given qubit
+
+        This is typically utilized for controlling multiqubit interactions.
+        This channel is derived from other channels.
+
+        This is required to be implemented if the backend supports Pulse
+        scheduling.
+
+        Args:
+            qubits: Tuple or list of qubits of the form
+                ``(control_qubit, target_qubit)``.
+
+        Returns:
+            List[ControlChannel]: The multi qubit control line.
+        """
+        control_channels_map = getattr(self, "channels_map", {}).get("control", {})
+        qubits = tuple(qubits)
+        if qubits in control_channels_map:
+            return control_channels_map[qubits]
+        return []
+
+    def run(self, run_input, **options):  # type: ignore
+        """Run on the fake backend using a simulator.
+
+        This method runs circuit jobs (an individual or a list of QuantumCircuit
+        ) and pulse jobs (an individual or a list of Schedule or ScheduleBlock)
+        using BasicAer or Aer simulator and returns a
+        :class:`~qiskit.providers.Job` object.
+
+        If qiskit-aer is installed, jobs will be run using AerSimulator with
+        noise model of the fake backend. Otherwise, jobs will be run using
+        BasicAer simulator without noise.
+
+        Currently noisy simulation of a pulse job is not supported yet in
+        FakeBackendV2.
+
+        Args:
+            run_input (QuantumCircuit or Schedule or ScheduleBlock or list): An
+                individual or a list of
+                :class:`~qiskit.circuit.QuantumCircuit`,
+                :class:`~qiskit.pulse.ScheduleBlock`, or
+                :class:`~qiskit.pulse.Schedule` objects to run on the backend.
+            options: Any kwarg options to pass to the backend for running the
+                config. If a key is also present in the options
+                attribute/object then the expectation is that the value
+                specified will be used instead of what's set in the options
+                object.
+
+        Returns:
+            Job: The job object for the run
+
+        Raises:
+            QiskitError: If a pulse job is supplied and qiskit-aer is not installed.
+        """
+        circuits = run_input
+        pulse_job = None
+        if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):
+            pulse_job = True
+        elif isinstance(circuits, circuit.QuantumCircuit):
+            pulse_job = False
+        elif isinstance(circuits, list):
+            if circuits:
+                if all(isinstance(x, (pulse.Schedule, pulse.ScheduleBlock)) for x in circuits):
+                    pulse_job = True
+                elif all(isinstance(x, circuit.QuantumCircuit) for x in circuits):
+                    pulse_job = False
+        if pulse_job is None:  # submitted job is invalid
+            raise QiskitError(
+                "Invalid input object %s, must be either a "
+                "QuantumCircuit, Schedule, or a list of either" % circuits
+            )
+        if pulse_job:  # pulse job
+            raise QiskitError("Pulse simulation is currently not supported for V2 fake backends.")
+        # circuit job
+        if not _optionals.HAS_AER:
+            warnings.warn("Aer not found using BasicAer and no noise", RuntimeWarning)
+        if self.sim is None:
+            self._setup_sim()
+        self.sim._options = self._options
+        job = self.sim.run(circuits, **options)
+        return job
+
+    def _get_noise_model_from_backend_v2(  # type: ignore
+        self,
+        gate_error=True,
+        readout_error=True,
+        thermal_relaxation=True,
+        temperature=0,
+        gate_lengths=None,
+        gate_length_units="ns",
+    ):
+        """Build noise model from BackendV2.
+
+        This is a temporary fix until qiskit-aer supports building noise model
+        from a BackendV2 object.
+        """
+
+        from qiskit.circuit import Delay  # pylint: disable=import-outside-toplevel
+        from qiskit.providers.exceptions import (  # pylint: disable=import-outside-toplevel
+            BackendPropertyError,
+        )
+        from qiskit_aer.noise import NoiseModel  # pylint: disable=import-outside-toplevel
+        from qiskit_aer.noise.device.models import (  # pylint: disable=import-outside-toplevel
+            _excited_population,
+            basic_device_gate_errors,
+            basic_device_readout_errors,
+        )
+        from qiskit_aer.noise.passes import (  # pylint: disable=import-outside-toplevel
+            RelaxationNoisePass,
+        )
+
+        if self._props_dict is None:
+            self._set_props_dict_from_json()
+
+        properties = BackendProperties.from_dict(self._props_dict)
+        basis_gates = self.operation_names
+        num_qubits = self.num_qubits
+        dt = self.dt  # pylint: disable=invalid-name
+
+        noise_model = NoiseModel(basis_gates=basis_gates)
+
+        # Add single-qubit readout errors
+        if readout_error:
+            for qubits, error in basic_device_readout_errors(properties):
+                noise_model.add_readout_error(error, qubits)
+
+        # Add gate errors
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                module="qiskit_aer.noise.device.models",
+            )
+            gate_errors = basic_device_gate_errors(
+                properties,
+                gate_error=gate_error,
+                thermal_relaxation=thermal_relaxation,
+                gate_lengths=gate_lengths,
+                gate_length_units=gate_length_units,
+                temperature=temperature,
+            )
+        for name, qubits, error in gate_errors:
+            noise_model.add_quantum_error(error, name, qubits)
+
+        if thermal_relaxation:
+            # Add delay errors via RelaxationNiose pass
+            try:
+                excited_state_populations = [
+                    _excited_population(freq=properties.frequency(q), temperature=temperature)
+                    for q in range(num_qubits)
+                ]
+            except BackendPropertyError:
+                excited_state_populations = None
+            try:
+                delay_pass = RelaxationNoisePass(
+                    t1s=[properties.t1(q) for q in range(num_qubits)],
+                    t2s=[properties.t2(q) for q in range(num_qubits)],
+                    dt=dt,
+                    op_types=Delay,
+                    excited_state_populations=excited_state_populations,
+                )
+                noise_model._custom_noise_passes.append(delay_pass)
+            except BackendPropertyError:
+                # Device does not have the required T1 or T2 information
+                # in its properties
+                pass
+
+        return noise_model
+
+
+class FakeBackend(BackendV1):
+    """This is a dummy backend just for testing purposes."""
+
+    def __init__(self, configuration, time_alive=10):  # type: ignore
+        """FakeBackend initializer.
+
+        Args:
+            configuration (BackendConfiguration): backend configuration
+            time_alive (int): time to wait before returning result
+        """
+        super().__init__(configuration)
+        self.time_alive = time_alive
+        self._credentials = _Credentials()
+        self.sim = None
+
+    def _setup_sim(self) -> None:
+        if _optionals.HAS_AER:
+            from qiskit_aer import AerSimulator  # pylint: disable=import-outside-toplevel
+            from qiskit_aer.noise import NoiseModel  # pylint: disable=import-outside-toplevel
+
+            self.sim = AerSimulator()
+            if self.properties():
+                noise_model = NoiseModel.from_backend(self)
+                self.sim.set_options(noise_model=noise_model)
+                # Update fake backend default options too to avoid overwriting
+                # it when run() is called
+                self.set_options(noise_model=noise_model)
+        else:
+            self.sim = basicaer.QasmSimulatorPy()
+
+    def properties(self) -> BackendProperties:
+        """Return backend properties"""
+        coupling_map = self.configuration().coupling_map
+        if coupling_map is None:
+            return None
+        unique_qubits = list(set().union(*coupling_map))
+
+        properties = {
+            "backend_name": self.name(),
+            "backend_version": self.configuration().backend_version,
+            "last_update_date": "2000-01-01 00:00:00Z",
+            "qubits": [
+                [
+                    {"date": "2000-01-01 00:00:00Z", "name": "T1", "unit": "\u00b5s", "value": 0.0},
+                    {"date": "2000-01-01 00:00:00Z", "name": "T2", "unit": "\u00b5s", "value": 0.0},
+                    {
+                        "date": "2000-01-01 00:00:00Z",
+                        "name": "frequency",
+                        "unit": "GHz",
+                        "value": 0.0,
+                    },
+                    {
+                        "date": "2000-01-01 00:00:00Z",
+                        "name": "readout_error",
+                        "unit": "",
+                        "value": 0.0,
+                    },
+                    {"date": "2000-01-01 00:00:00Z", "name": "operational", "unit": "", "value": 1},
+                ]
+                for _ in range(len(unique_qubits))
+            ],
+            "gates": [
+                {
+                    "gate": "cx",
+                    "name": "CX" + str(pair[0]) + "_" + str(pair[1]),
+                    "parameters": [
+                        {
+                            "date": "2000-01-01 00:00:00Z",
+                            "name": "gate_error",
+                            "unit": "",
+                            "value": 0.0,
+                        }
+                    ],
+                    "qubits": [pair[0], pair[1]],
+                }
+                for pair in coupling_map
+            ],
+            "general": [],
+        }
+
+        return BackendProperties.from_dict(properties)
+
+    @classmethod
+    def _default_options(cls) -> Options:
+        if _optionals.HAS_AER:
+            from qiskit_aer import QasmSimulator  # pylint: disable=import-outside-toplevel
+
+            return QasmSimulator._default_options()
+        else:
+            return basicaer.QasmSimulatorPy._default_options()
+
+    def run(self, run_input, **kwargs):  # type: ignore
+        """Main job in simulator"""
+        circuits = run_input
+        pulse_job = None
+        if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):
+            pulse_job = True
+        elif isinstance(circuits, circuit.QuantumCircuit):
+            pulse_job = False
+        elif isinstance(circuits, list):
+            if circuits:
+                if all(isinstance(x, (pulse.Schedule, pulse.ScheduleBlock)) for x in circuits):
+                    pulse_job = True
+                elif all(isinstance(x, circuit.QuantumCircuit) for x in circuits):
+                    pulse_job = False
+        if pulse_job is None:
+            raise QiskitError(
+                "Invalid input object %s, must be either a "
+                "QuantumCircuit, Schedule, or a list of either" % circuits
+            )
+        if pulse_job:  # pulse job
+            raise QiskitError("Pulse simulation is currently not supported for V1 fake backends.")
+
+        if self.sim is None:
+            self._setup_sim()
+        if not _optionals.HAS_AER:
+            warnings.warn("Aer not found using BasicAer and no noise", RuntimeWarning)
+        self.sim._options = self._options
+        job = self.sim.run(circuits, **kwargs)
+
+        return job

--- a/qiskit_ibm_runtime/fake_provider/fake_provider.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_provider.py
@@ -69,7 +69,10 @@ class FakeProviderForBackendV2(ProviderV1):
     available in the :mod:`qiskit_ibm_runtime.fake_provider`.
     """
 
-    def get_backend(self, name=None, **kwargs):  # type: ignore
+    def backend(self, name=None, **kwargs):  # type: ignore
+        """
+        Filter backends in provider by name.
+        """
         backend = self._backends[0]
         if name:
             filtered_backends = [backend for backend in self._backends if backend.name() == name]

--- a/qiskit_ibm_runtime/fake_provider/fake_pulse_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_pulse_backend.py
@@ -1,0 +1,43 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Fake backend abstract class for mock backends supporting OpenPulse.
+"""
+
+from qiskit.exceptions import QiskitError
+from qiskit.providers.models import PulseBackendConfiguration, PulseDefaults
+
+from qiskit.providers.fake_provider.utils.json_decoder import decode_pulse_defaults
+from .fake_qasm_backend import FakeQasmBackend
+
+
+class FakePulseBackend(FakeQasmBackend):
+    """A fake pulse backend."""
+
+    defs_filename = None
+
+    def defaults(self) -> PulseDefaults:
+        """Returns a snapshot of device defaults"""
+        if not self._defaults:
+            self._set_defaults_from_json()
+        return self._defaults
+
+    def _set_defaults_from_json(self) -> None:
+        if not self.props_filename:
+            raise QiskitError("No properties file has been defined")
+        defs = self._load_json(self.defs_filename)  # type: ignore
+        decode_pulse_defaults(defs)
+        self._defaults = PulseDefaults.from_dict(defs)
+
+    def _get_config_from_dict(self, conf: dict) -> PulseBackendConfiguration:
+        return PulseBackendConfiguration.from_dict(conf)

--- a/qiskit_ibm_runtime/fake_provider/fake_qasm_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_qasm_backend.py
@@ -1,0 +1,74 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Fake backend abstract class for mock backends.
+"""
+
+import json
+import os
+
+from qiskit.exceptions import QiskitError
+from qiskit.providers.models import BackendProperties, QasmBackendConfiguration
+
+from qiskit.providers.fake_provider.utils.json_decoder import (
+    decode_backend_configuration,
+    decode_backend_properties,
+)
+from .fake_backend import FakeBackend
+
+
+class FakeQasmBackend(FakeBackend):
+    """A fake OpenQASM backend."""
+
+    dirname = None
+    conf_filename = None
+    props_filename = None
+    backend_name = None
+
+    def __init__(self):  # type: ignore
+        configuration = self._get_conf_from_json()
+        self._defaults = None
+        self._properties = None
+        super().__init__(configuration)
+
+    def properties(self) -> BackendProperties:
+        """Returns a snapshot of device properties"""
+        if not self._properties:
+            self._set_props_from_json()
+        return self._properties
+
+    def _get_conf_from_json(self) -> QasmBackendConfiguration:
+        if not self.conf_filename:
+            raise QiskitError("No configuration file has been defined")
+        conf = self._load_json(self.conf_filename)  # type: ignore
+        decode_backend_configuration(conf)
+        configuration = self._get_config_from_dict(conf)
+        configuration.backend_name = self.backend_name
+        return configuration
+
+    def _set_props_from_json(self) -> None:
+        if not self.props_filename:
+            raise QiskitError("No properties file has been defined")
+        props = self._load_json(self.props_filename)  # type: ignore
+        decode_backend_properties(props)
+        self._properties = BackendProperties.from_dict(props)
+
+    def _load_json(self, filename: str) -> dict:
+        with open(  # pylint: disable=unspecified-encoding
+            os.path.join(self.dirname, filename)
+        ) as f_json:
+            the_json = json.load(f_json)
+        return the_json
+
+    def _get_config_from_dict(self, conf: dict) -> QasmBackendConfiguration:
+        return QasmBackendConfiguration.from_dict(conf)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR migrates the fake backend base classes from Qiskit:

- `FakeBackend`
- `FakeBackendV2`
- `FakeQasmBackend`
- `FakePulseBackend`

and updates the backend snapshot to inherit from the new `qiskit-ibm-runtime`-based classes.
The motivations behind this move are:

- decoupling the fake provider in `qiskit_ibm_runtime` from the deprecations taking place in the `qiskit` fake provider
- setting the stage for a future change of base classes of the fake backends in `qiskit_ibm_runtime`, as indicated in https://github.com/Qiskit/qiskit/issues/9553

### Details and comments

- This PR performs a history-preserving copy of the files. To preserve the history, the commits shouldn't be squashed before merging. If preserving the history is not a priority then they can just be squashed as it's usually done.
- This PR additionally changes the V2 fake provider's `get_backend` method to `backend` as indicated in #85, but I can revert it if you prefer it to be in a separate PR.
- I am not sure how much of this change should be documented in a release note, in principle users should not be interacting with these classes directly, the initial idea was to even make them private.
