### PR TITLE
Deprecated QiskitRuntimeService.get_backend()

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ bell.cx(0, 1)
 bell.measure_all()
 
 # 3. Execute using the Sampler primitive
-backend = service.get_backend('ibmq_qasm_simulator')
+backend = service.backend('ibmq_qasm_simulator')
 sampler = Sampler(backend=backend, options=options)
 job = sampler.run(circuits=bell)
 print(f"Job ID is {job.job_id()}")
@@ -180,7 +180,7 @@ for x in range(points):
     theta1.append(theta)
 
 # 3. Execute using the Estimator primitive
-backend = service.get_backend('ibmq_qasm_simulator')
+backend = service.backend('ibmq_qasm_simulator')
 estimator = Estimator(backend, options=options)
 job = estimator.run(circuits=[qc_example]*points, observables=[M1]*points, parameter_values=theta1)
 print(f"Job ID is {job.job_id()}")

--- a/qiskit_ibm_runtime/fake_provider/__init__.py
+++ b/qiskit_ibm_runtime/fake_provider/__init__.py
@@ -75,7 +75,7 @@ Here is an example of using a fake backend for transpilation and simulation.
 
         # get a real backend from the runtime service
         service = QiskitRuntimeService()
-        backend = service.get_backend('ibmq_manila')
+        backend = service.backend('ibmq_manila')
 
         # generate a simulator that mimics the real quantum system with the latest calibration results
         backend_sim = AerSimulator.from_backend(backend)

--- a/qiskit_ibm_runtime/fake_provider/fake_provider.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_provider.py
@@ -69,7 +69,7 @@ class FakeProviderForBackendV2(ProviderV1):
     available in the :mod:`qiskit_ibm_runtime.fake_provider`.
     """
 
-    def get_backend(self, name=None, **kwargs):  # type: ignore
+    def backend(self, name=None, **kwargs):  # type: ignore
         backend = self._backends[0]
         if name:
             filtered_backends = [backend for backend in self._backends if backend.name() == name]
@@ -143,7 +143,7 @@ class FakeProvider(ProviderV1):
     available in the :mod:`qiskit_ibm_runtime.fake_provider`.
     """
 
-    def get_backend(self, name=None, **kwargs):  # type: ignore
+    def backend(self, name=None, **kwargs):  # type: ignore
         backend = self._backends[0]
         if name:
             filtered_backends = [backend for backend in self._backends if backend.name() == name]

--- a/qiskit_ibm_runtime/fake_provider/fake_provider.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_provider.py
@@ -70,6 +70,7 @@ class FakeProviderForBackendV2(ProviderV1):
     """
 
     def backend(self, name=None, **kwargs):  # type: ignore
+        """Return FakeBackend with name 'name', and obeying additional filters as defined in kwargs"""
         backend = self._backends[0]
         if name:
             filtered_backends = [backend for backend in self._backends if backend.name() == name]
@@ -144,6 +145,7 @@ class FakeProvider(ProviderV1):
     """
 
     def backend(self, name=None, **kwargs):  # type: ignore
+        """Return FakeBackend with name 'name', and obeying additional filters as defined in kwargs"""
         backend = self._backends[0]
         if name:
             filtered_backends = [backend for backend in self._backends if backend.name() == name]

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -34,6 +34,7 @@ from qiskit_ibm_provider.utils.hgp import to_instance_format, from_instance_form
 from qiskit_ibm_provider.utils.backend_decoder import configuration_from_server_data
 from qiskit_ibm_runtime import ibm_backend
 
+from qiskit_ibm_runtime.utils.deprecation import issue_deprecation_msg
 from .utils.utils import validate_job_tags
 from .accounts import AccountManager, Account, ChannelType
 from .api.clients import AuthClient, VersionClient
@@ -53,6 +54,7 @@ from .utils import RuntimeDecoder, to_python_identifier
 from .api.client_parameters import ClientParameters
 from .runtime_options import RuntimeOptions
 from .ibm_backend import IBMBackend
+
 
 logger = logging.getLogger(__name__)
 
@@ -827,6 +829,11 @@ class QiskitRuntimeService(Provider):
         return backends[0]
 
     def get_backend(self, name: str = None, **kwargs: Any) -> Backend:
+        issue_deprecation_msg(
+            msg="QiskitRuntimeService.get_backend() is deprecated.",
+            version="0.17.0",
+            remedy="use QiskitRuntimeService.backend() instead"
+        )
         return self.backend(name, **kwargs)
 
     def run(

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -832,7 +832,7 @@ class QiskitRuntimeService(Provider):
         issue_deprecation_msg(
             msg="QiskitRuntimeService.get_backend() is deprecated.",
             version="0.17.0",
-            remedy="use QiskitRuntimeService.backend() instead"
+            remedy="use QiskitRuntimeService.backend() instead",
         )
         return self.backend(name, **kwargs)
 

--- a/releasenotes/notes/deprecate_get_backend-4cf253c053f23bc2.yaml
+++ b/releasenotes/notes/deprecate_get_backend-4cf253c053f23bc2.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    ``QiskitRuntimeService.get_backend()`` has been deprecated, use ``QiskitRuntimeService.backend()`` instead.
+

--- a/test/ibm_test_case.py
+++ b/test/ibm_test_case.py
@@ -175,7 +175,7 @@ class IBMIntegrationJobTestCase(IBMIntegrationTestCase):
             "max_execution_time": max_execution_time,
         }
         if pid == "sampler":
-            backend = service.get_backend(backend_name)
+            backend = service.backend(backend_name)
             options = Options()
             if log_level:
                 options.environment.log_level = log_level

--- a/test/integration/test_ibm_qasm_simulator.py
+++ b/test/integration/test_ibm_qasm_simulator.py
@@ -27,7 +27,7 @@ class TestIBMQasmSimulator(IBMIntegrationTestCase):
 
     def test_execute_one_circuit_simulator_online(self):
         """Test execute_one_circuit_simulator_online."""
-        backend = self.service.get_backend("ibmq_qasm_simulator")
+        backend = self.service.backend("ibmq_qasm_simulator")
         quantum_register = QuantumRegister(1)
         classical_register = ClassicalRegister(1)
         quantum_circuit = QuantumCircuit(quantum_register, classical_register, name="qc")
@@ -44,7 +44,7 @@ class TestIBMQasmSimulator(IBMIntegrationTestCase):
 
     def test_execute_several_circuits_simulator_online(self):
         """Test execute_several_circuits_simulator_online."""
-        backend = self.service.get_backend("ibmq_qasm_simulator")
+        backend = self.service.backend("ibmq_qasm_simulator")
         quantum_register = QuantumRegister(2)
         classical_register = ClassicalRegister(2)
         qcr1 = QuantumCircuit(quantum_register, classical_register, name="qc1")
@@ -70,7 +70,7 @@ class TestIBMQasmSimulator(IBMIntegrationTestCase):
 
     def test_online_qasm_simulator_two_registers(self):
         """Test online_qasm_simulator_two_registers."""
-        backend = self.service.get_backend("ibmq_qasm_simulator")
+        backend = self.service.backend("ibmq_qasm_simulator")
         qr1 = QuantumRegister(2)
         cr1 = ClassicalRegister(2)
         qr2 = QuantumRegister(2)

--- a/test/integration/test_options.py
+++ b/test/integration/test_options.py
@@ -31,7 +31,7 @@ class TestIntegrationOptions(IBMIntegrationTestCase):
     @run_integration_test
     def test_noise_model(self, service):
         """Test running with noise model."""
-        backend = service.get_backend("ibmq_qasm_simulator")
+        backend = service.backend("ibmq_qasm_simulator")
         self.log.info("Using backend %s", backend.name)
 
         fake_backend = FakeManila()

--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -107,7 +107,7 @@ class TestBackendRunInSession(IBMIntegrationTestCase):
 
     def test_session_id(self):
         """Test that session_id is updated correctly and maintained throughout the session"""
-        backend = self.service.get_backend("ibmq_qasm_simulator")
+        backend = self.service.backend("ibmq_qasm_simulator")
         backend.open_session()
         self.assertEqual(backend.session.session_id, None)
         self.assertTrue(backend.session.active)
@@ -131,7 +131,7 @@ class TestBackendRunInSession(IBMIntegrationTestCase):
 
     def test_backend_and_primitive_in_session(self):
         """Test Sampler.run and backend.run in the same session."""
-        backend = self.service.get_backend("ibmq_qasm_simulator")
+        backend = self.service.backend("ibmq_qasm_simulator")
         with Session(backend=backend) as session:
             sampler = Sampler(session=session)
             job1 = sampler.run(circuits=ReferenceCircuits.bell())


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Users should use ``QiskitRuntimeService.backend()`` instead.


### Details and comments
Fixes #1261

