### PR TITLE
Add max_time parameter to IBMBackend.open_session()

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -762,9 +762,11 @@ class IBMBackend(Backend):
                 raise RuntimeError(f"The session {self._session.session_id} is closed.")
             session_id = self._session.session_id
             start_session = session_id is None
+            max_session_time = self._session._max_time
         else:
             session_id = None
             start_session = False
+            max_session_time = None
 
         log_level = getattr(self.options, "log_level", None)  # temporary
         try:
@@ -777,6 +779,7 @@ class IBMBackend(Backend):
                 job_tags=job_tags,
                 session_id=session_id,
                 start_session=start_session,
+                session_time=max_session_time,
                 image=image,
             )
         except RequestsApiError as ex:
@@ -827,9 +830,9 @@ class IBMBackend(Backend):
                 run_config_dict[key] = backend_options[key]
         return run_config_dict
 
-    def open_session(self) -> ProviderSession:
+    def open_session(self, max_time: Optional[Union[int, str]] = None) -> ProviderSession:
         """Open session"""
-        self._session = ProviderSession()
+        self._session = ProviderSession(max_time=max_time)
         return self._session
 
     @property

--- a/releasenotes/notes/max_session_time-0bd8665656bf439c.yaml
+++ b/releasenotes/notes/max_session_time-0bd8665656bf439c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added ``max_time`` parameter to ``IBMBackend.open_session()``.

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -17,6 +17,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, wait
 
 from unittest.mock import MagicMock, Mock, patch
+from qiskit.providers.fake_provider import FakeManila
 
 from qiskit_ibm_runtime import Session
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
@@ -65,6 +66,12 @@ class TestSession(IBMTestCase):
 
     def test_max_time(self):
         """Test max time."""
+        model_backend = FakeManila()
+        backend = IBMBackend(
+            configuration=model_backend.configuration(),
+            service=MagicMock(),
+            api_client=None,
+        )
         max_times = [
             (42, 42),
             ("1h", 1 * 60 * 60),
@@ -75,6 +82,8 @@ class TestSession(IBMTestCase):
             with self.subTest(max_time=max_t):
                 session = Session(service=MagicMock(), backend="ibm_gotham", max_time=max_t)
                 self.assertEqual(session._max_time, expected)
+                backend.open_session(max_time=max_t)
+                self.assertEqual(backend.session._max_time, expected)
 
     def test_run_after_close(self):
         """Test running after session is closed."""

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -82,6 +82,8 @@ class TestSession(IBMTestCase):
             with self.subTest(max_time=max_t):
                 session = Session(service=MagicMock(), backend="ibm_gotham", max_time=max_t)
                 self.assertEqual(session._max_time, expected)
+        for max_t, expected in max_times:
+            with self.subTest(max_time=max_t):
                 backend.open_session(max_time=max_t)
                 self.assertEqual(backend.session._max_time, expected)
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Add max_time parameter to IBMBackend.open_session(). This parameter is already supported in `qiskit_ibm_provider`.


### Details and comments
Fixes #1198

