### PR TITLE
Deprecate service.runtime

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -53,6 +53,7 @@ from .utils import RuntimeDecoder, to_python_identifier
 from .api.client_parameters import ClientParameters
 from .runtime_options import RuntimeOptions
 from .ibm_backend import IBMBackend
+from .utils.deprecation import issue_deprecation_msg
 
 logger = logging.getLogger(__name__)
 
@@ -1187,6 +1188,12 @@ class QiskitRuntimeService(Provider):
         Returns:
             self
         """
+        issue_deprecation_msg(
+            msg="The runtime property is deprecated",
+            version="0.18.0",
+            remedy="",
+            period="1 month",
+        )
         return self
 
     def __repr__(self) -> str:

--- a/releasenotes/notes/deprecate-service-runtime-1138cb5ec43fc4ff.yaml
+++ b/releasenotes/notes/deprecate-service-runtime-1138cb5ec43fc4ff.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    :meth:`~qiskit_ibm_runtime.QiskitRuntimeService.runtime` has been deprecated.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`service.runtime` was added in #419, and is no longer necessary. 

### Details and comments
Fixes part of #1276

