### PR TITLE
Add access to transpiled_circuits

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -231,6 +231,17 @@ class RuntimeClient(BaseBackendClient):
         """
         return self._api.program_job(job_id).metadata()
 
+    def job_transpiled_circuits(self, job_id: str) -> str:
+        """Get job transpiled circuits.
+
+        Args:
+            job_id: Program job ID.
+
+        Returns:
+            Job transpiled circuits.
+        """
+        return self._api.program_job(job_id).transpiled_circuits()
+
     def cancel_session(self, session_id: str) -> None:
         """Close all jobs in the runtime session.
 

--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -41,6 +41,7 @@ from .exceptions import (
     IBMRuntimeError,
     RuntimeJobTimeoutError,
     RuntimeJobMaxTimeoutError,
+    IBMInputValueError,
 )
 from .utils.result_decoder import ResultDecoder
 from .api.clients import RuntimeClient, RuntimeWebsocketClient, WebsocketClientCloseCode
@@ -688,6 +689,16 @@ class RuntimeJob(Job):
             }
 
         return self._usage_estimation
+
+    @property
+    def transpiled_circuits(self) -> Dict[str, Any]:
+        """Return the transpiled circuits for this job."""
+        if self._program_id == "estimator":
+            raise IBMInputValueError("Transpiled circuits are not available for estimator jobs.")
+        result = self._download_external_result(
+            self._api_client.job_transpiled_circuits(self.job_id())
+        )
+        return json.loads(result)
 
     def queue_position(self, refresh: bool = False) -> Optional[int]:
         """Return the position of the job in the server queue.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

On hold for now, can merge after #1285 to add `transpiled_circuits` method to `program_job.py`

```python
def transpiled_circuits(self) -> str:
  """Retrieve job transpiled circuits
  
  Returns:
      job transpiled circuits
  """
  return self.session.get(self.get_url("transpiled_circuits")).text
```

### Details and comments
Fixes #898

