### PR TITLE
Exclude params on job retrieval by default

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -100,7 +100,7 @@ class RuntimeClient(BaseBackendClient):
             **hgp_dict,
         )
 
-    def job_get(self, job_id: str, exclude_params: bool = None) -> Dict:
+    def job_get(self, job_id: str, exclude_params: bool = True) -> Dict:
         """Get job data.
 
         Args:

--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -621,7 +621,7 @@ class RuntimeJob(Job):
             Input parameters used in this job.
         """
         if not self._params:
-            response = self._api_client.job_get(job_id=self.job_id())
+            response = self._api_client.job_get(job_id=self.job_id(), exclude_params=False)
             self._params = response.get("params", {})
         return self._params
 

--- a/releasenotes/notes/exclude-job-params-default-00133498a5c5c15d.yaml
+++ b/releasenotes/notes/exclude-job-params-default-00133498a5c5c15d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Many methods in :class:`~qiskit_ibm_runtime.RuntimeJob` require retrieving the job data from the API with
+    ``job_get()``. This API call will now exclude the ``params`` field by default because they are only necessary in
+    :meth:`qiskit_ibm_runtime.RuntimeJob.inputs`.

--- a/test/integration/test_retrieve_job.py
+++ b/test/integration/test_retrieve_job.py
@@ -72,6 +72,18 @@ class TestIntegrationRetrieveJob(IBMIntegrationJobTestCase):
         self.assertTrue(rjob._params)
 
     @run_integration_test
+    @quantum_only
+    def test_params_not_retrieved(self, service):
+        """Test excluding params when unnecessary."""
+        job = self._run_program(service)
+        job.wait_for_final_state()
+
+        self.assertTrue(job.creation_date)
+        self.assertFalse(job._params)
+        self.assertTrue(job.inputs)
+        self.assertTrue(job._params)
+
+    @run_integration_test
     def test_retrieve_all_jobs(self, service):
         """Test retrieving all jobs."""
         job = self._run_program(service)

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -344,7 +344,7 @@ class BaseFakeRuntimeClient:
         self._jobs[job_id] = job
         return {"id": job_id, "backend": backend_name}
 
-    def job_get(self, job_id: str, exclude_params: bool = None) -> Any:
+    def job_get(self, job_id: str, exclude_params: bool = True) -> Any:
         """Get the specific job."""
         return self._get_job(job_id, exclude_params).to_dict()
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Job params should only be returned by the api with `job.inputs()`

### Details and comments
Fixes #1307 

