### PR TITLE
Reactive the viewcode extension for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,8 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    # This is used by qiskit/documentation to generate links to github.com.
+    "sphinx.ext.viewcode",
     'jupyter_sphinx',
     'sphinx_autodoc_typehints',
     'reno.sphinxext',


### PR DESCRIPTION
We got source links working in API docs on docs.quantum.ibm.com! See https://github.com/Qiskit/documentation/pull/620. To do this, we need to active `sphinx.ext.viewcode`.

Note that we still plan to improve this implementation in the future to have more precise links by using `sphinx.ext.linkcode`, tracked by https://github.com/Qiskit/documentation/issues/517. This PR is to unblock the first iteration of this source links mechanism.