### PR TITLE
Use IBM-Provider-vendored pub/sub mechanism

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -21,7 +21,6 @@ import warnings
 
 from qiskit import QuantumCircuit
 from qiskit.qobj.utils import MeasLevel, MeasReturnType
-from qiskit.tools.events.pubsub import Publisher
 
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
@@ -66,6 +65,14 @@ from .utils.backend_converter import (
     convert_to_target,
 )
 from .utils.default_session import get_cm_session as get_cm_primitive_session
+
+# If using a new-enough version of the IBM Provider, access the pub/sub
+# mechanism from it as a broker, but fall back to Qiskit if we're using
+# an old version (in which case it will also be falling back to Qiskit).
+try:
+    from qiskit_ibm_provider.utils.pubsub import Publisher
+except ImportError:
+    from qiskit.tools.events.pubsub import Publisher  # pylint: disable=ungrouped-imports
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Summary

This is being removed from Qiskit 1.0, and the IBM Provider is (until deprecated) taking over brokering the IBM-Runtime-internal events.

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

See Qiskit/qiskit-ibm-provider#799 for the base, though this PR should apply cleanly even before that one, because of the backwards-compatibilty check.
