### PR TITLE
Add missing API Refs to docs (Cherry-pick of #1343)

### DIFF
--- a/docs/apidocs/fake_provider.rst
+++ b/docs/apidocs/fake_provider.rst
@@ -1,0 +1,4 @@
+.. automodule:: qiskit_ibm_runtime.fake_provider
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/docs/apidocs/ibm-runtime.rst
+++ b/docs/apidocs/ibm-runtime.rst
@@ -9,3 +9,5 @@ qiskit-ibm-runtime API reference
 
    runtime_service
    options
+   transpiler
+   fake_provider

--- a/docs/apidocs/transpiler.rst
+++ b/docs/apidocs/transpiler.rst
@@ -1,0 +1,4 @@
+.. automodule:: qiskit_ibm_runtime.transpiler
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'reno.sphinxext',
     'nbsphinx',
     'sphinxcontrib.katex',
+    'matplotlib.sphinxext.plot_directive',
 ]
 templates_path = ['_templates']
 

--- a/qiskit_ibm_runtime/fake_provider/__init__.py
+++ b/qiskit_ibm_runtime/fake_provider/__init__.py
@@ -11,9 +11,9 @@
 # that they have been altered from the originals.
 
 """
-======================================================
+=======================================================
 Fake Provider (:mod:`qiskit_ibm_runtime.fake_provider`)
-======================================================
+=======================================================
 
 .. currentmodule:: qiskit_ibm_runtime.fake_provider
 


### PR DESCRIPTION
### Summary
The documentation from the `transpile` and `fake_provider` modules does not appear in the rendered docs in qiskit.org/documentation or docs.quantum-computing.ibm.com.


### Details and comments

Fixes [Qiskit Docs Issue #238](https://github.com/Qiskit/documentation/issues/238)

Replaces PR #1330.

Transpiler Doc files added:

 - qiskit_ibm_runtime.transpiler.passes.html
- qiskit_ibm_provider.transpiler.passes.basis.html
- qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis.html
- qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis.html
- qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder.html
- qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.html
- qiskit_ibm_provider.transpiler.passes.scheduling.html
- qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay.html
- qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling.html

<details>
<summary> Fake Provider Docs added: </summary>

- qiskit_ibm_runtime.fake_provider.FakeAlmaden.html
- qiskit_ibm_runtime.fake_provider.FakeAlmadenV2.html
- qiskit_ibm_runtime.fake_provider.FakeArmonk.html
- qiskit_ibm_runtime.fake_provider.FakeArmonkV2.html
- qiskit_ibm_runtime.fake_provider.FakeAthens.html
- qiskit_ibm_runtime.fake_provider.FakeAthensV2.html
- qiskit_ibm_runtime.fake_provider.FakeAuckland.html
- qiskit_ibm_runtime.fake_provider.FakeBelem.html
- qiskit_ibm_runtime.fake_provider.FakeBelemV2.html
- qiskit_ibm_runtime.fake_provider.FakeBoeblingen.html
- qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2.html
- qiskit_ibm_runtime.fake_provider.FakeBogota.html
- qiskit_ibm_runtime.fake_provider.FakeBogotaV2.html
- qiskit_ibm_runtime.fake_provider.FakeBrooklyn.html
- qiskit_ibm_runtime.fake_provider.FakeBrooklynV2.html
- qiskit_ibm_runtime.fake_provider.FakeBurlington.html
- qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2.html
- qiskit_ibm_runtime.fake_provider.FakeCairo.html
- qiskit_ibm_runtime.fake_provider.FakeCairoV2.html
- qiskit_ibm_runtime.fake_provider.FakeCambridge.html
- qiskit_ibm_runtime.fake_provider.FakeCambridgeV2.html
- qiskit_ibm_runtime.fake_provider.FakeCasablanca.html
- qiskit_ibm_runtime.fake_provider.FakeCasablancaV2.html
- qiskit_ibm_runtime.fake_provider.FakeEssex.html
- qiskit_ibm_runtime.fake_provider.FakeEssexV2.html
- qiskit_ibm_runtime.fake_provider.FakeGeneva.html
- qiskit_ibm_runtime.fake_provider.FakeGuadalupe.html
- qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2.html
- qiskit_ibm_runtime.fake_provider.FakeHanoi.html
- qiskit_ibm_runtime.fake_provider.FakeHanoiV2.html
- qiskit_ibm_runtime.fake_provider.FakeJakarta.html
- qiskit_ibm_runtime.fake_provider.FakeJakartaV2.html
- qiskit_ibm_runtime.fake_provider.FakeJohannesburg.html
- qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2.html
- qiskit_ibm_runtime.fake_provider.FakeKolkata.html
- qiskit_ibm_runtime.fake_provider.FakeKolkataV2.html
- qiskit_ibm_runtime.fake_provider.FakeLagos.html
- qiskit_ibm_runtime.fake_provider.FakeLagosV2.html
- qiskit_ibm_runtime.fake_provider.FakeLima.html
- qiskit_ibm_runtime.fake_provider.FakeLimaV2.html
- qiskit_ibm_runtime.fake_provider.FakeLondon.html
- qiskit_ibm_runtime.fake_provider.FakeLondonV2.html
- qiskit_ibm_runtime.fake_provider.FakeManhattan.html
- qiskit_ibm_runtime.fake_provider.FakeManhattanV2.html
- qiskit_ibm_runtime.fake_provider.FakeManila.html
- qiskit_ibm_runtime.fake_provider.FakeManilaV2.html
- qiskit_ibm_runtime.fake_provider.FakeMelbourne.html
- qiskit_ibm_runtime.fake_provider.FakeMelbourneV2.html
- qiskit_ibm_runtime.fake_provider.FakeMontreal.html
- qiskit_ibm_runtime.fake_provider.FakeMontrealV2.html
- qiskit_ibm_runtime.fake_provider.FakeMumbai.html
- qiskit_ibm_runtime.fake_provider.FakeMumbaiV2.html
- qiskit_ibm_runtime.fake_provider.FakeNairobi.html
- qiskit_ibm_runtime.fake_provider.FakeNairobiV2.html
- qiskit_ibm_runtime.fake_provider.FakeOslo.html
- qiskit_ibm_runtime.fake_provider.FakeOurense.html
- qiskit_ibm_runtime.fake_provider.FakeOurenseV2.html
- qiskit_ibm_runtime.fake_provider.FakeParis.html
- qiskit_ibm_runtime.fake_provider.FakeParisV2.html
- qiskit_ibm_runtime.fake_provider.FakePerth.html
- qiskit_ibm_runtime.fake_provider.FakePoughkeepsie.html
- qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2.html
- qiskit_ibm_runtime.fake_provider.FakePrague.html
- qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2.html
- qiskit_ibm_runtime.fake_provider.FakeProvider.html
- qiskit_ibm_runtime.fake_provider.FakeQuito.html
- qiskit_ibm_runtime.fake_provider.FakeQuitoV2.html
- qiskit_ibm_runtime.fake_provider.FakeRochester.html
- qiskit_ibm_runtime.fake_provider.FakeRochesterV2.html
- qiskit_ibm_runtime.fake_provider.FakeRome.html
- qiskit_ibm_runtime.fake_provider.FakeRomeV2.html
- qiskit_ibm_runtime.fake_provider.FakeRueschlikon.html
- qiskit_ibm_runtime.fake_provider.FakeSantiago.html
- qiskit_ibm_runtime.fake_provider.FakeSantiagoV2.html
- qiskit_ibm_runtime.fake_provider.FakeSherbrooke.html
- qiskit_ibm_runtime.fake_provider.FakeSingapore.html
- qiskit_ibm_runtime.fake_provider.FakeSingaporeV2.html
- qiskit_ibm_runtime.fake_provider.FakeSydney.html
- qiskit_ibm_runtime.fake_provider.FakeSydneyV2.html
- qiskit_ibm_runtime.fake_provider.FakeTenerife.html
- qiskit_ibm_runtime.fake_provider.FakeTokyo.html
- qiskit_ibm_runtime.fake_provider.FakeToronto.html
- qiskit_ibm_runtime.fake_provider.FakeTorontoV2.html
- qiskit_ibm_runtime.fake_provider.FakeValencia.html
- qiskit_ibm_runtime.fake_provider.FakeValenciaV2.html
- qiskit_ibm_runtime.fake_provider.FakeVigo.html
- qiskit_ibm_runtime.fake_provider.FakeVigoV2.html
- qiskit_ibm_runtime.fake_provider.FakeWashington.html
- qiskit_ibm_runtime.fake_provider.FakeWashingtonV2.html
- qiskit_ibm_runtime.fake_provider.FakeYorktown.html
- qiskit_ibm_runtime.fake_provider.FakeYorktownV2.html

</details>