### PR TITLE
Set use_symengine on qpy generation if symengine is installed

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -55,6 +55,7 @@ from qiskit.circuit import (
 from qiskit.circuit.parametertable import ParameterView
 from qiskit.result import Result
 from qiskit.version import __version__ as _terra_version_string
+from qiskit.utils import optionals
 
 from qiskit_ibm_provider.qpy import (
     _write_parameter,
@@ -219,7 +220,7 @@ class RuntimeEncoder(json.JSONEncoder):
             value = _serialize_and_encode(
                 data=obj,
                 serializer=lambda buff, data: dump(
-                    data, buff, RuntimeEncoder
+                    data, buff, RuntimeEncoder, use_symengine=optionals.HAS_SYMENGINE
                 ),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit sets the use_symengine flag during qpy export used during job payload generation if symengine is installed. For qiskit <1.0 symengine is a hard dependency on platforms that have support for it (x86_64, aarch64, and ppc64le linux and macOS) and an optional requirement on other qiskit supported platforms, and when available it greatly improves the runtime performance of symbolic expressions in Qiskit. By default QPY opts for the more compatible sympy representation of an unbound ParameterExpression as it's maximally compatible, and means that no matter the environment the payload will be loaded from it will be able to parse the payload. In QPY version 10 a new flag was added to the payload definition that enables users to use a native binary symengine representation of a symbolic expression that is significantly faster to generate and parse, but it still defaults to sympy as using this flag limits the compatibility of the payload. However, for runtime job submission we know that the service always has symengine available so we should be using this flag for job submission if the local environment has symengine installed as it will greatly speed up the serialization of unbound ParameterExpression objects.

In Qiskit 1.0, symengine is promoted to a hard requriment for all environments and use_symengine=True is the default in Qiskit's qpy module. But, setting it like this is still a good idea as it will always be safe to do this, it's just in qiskit 1.0 symengine will always be installed.
