### PR TITLE
Update flaky integration tests

### DIFF
--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -226,7 +226,7 @@ class TestIBMJob(IBMIntegrationTestCase):
         job = self.sim_backend.run(self.bell)
         job.wait_for_final_state()
         newest_jobs = self.service.jobs(
-            limit=10,
+            limit=20,
             pending=False,
             descending=True,
             created_after=self.last_month,

--- a/test/integration/test_retrieve_job.py
+++ b/test/integration/test_retrieve_job.py
@@ -184,7 +184,9 @@ class TestIntegrationRetrieveJob(IBMIntegrationJobTestCase):
         job = self._run_program(service)
         job.wait_for_final_state()
         time_after_job = datetime.now(timezone.utc)
-        rjobs = service.jobs(created_before=time_after_job, created_after=current_time)
+        rjobs = service.jobs(
+            created_before=time_after_job, created_after=current_time, pending=False, limit=20
+        )
         self.assertTrue(job.job_id() in [j.job_id() for j in rjobs])
         for job in rjobs:
             self.assertTrue(job.creation_date <= time_after_job)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

More details in the issue, `test_jobs_filter_by_date` and `test_retrieve_jobs_order` fail intermittently because too many jobs are being run in parallel 

### Details and comments
Fixes #1320 

