### PR TITLE
Fix bad Sphinx API doc Provider naming (cherry-pick of #1360)

### DIFF
--- a/qiskit_ibm_runtime/transpiler/__init__.py
+++ b/qiskit_ibm_runtime/transpiler/__init__.py
@@ -12,7 +12,7 @@
 
 """
 ====================================================================
-IBM Backend Transpiler Tools (:mod:`qiskit_ibm_provider.transpiler`)
+IBM Backend Transpiler Tools (:mod:`qiskit_ibm_runtime.transpiler`)
 ====================================================================
 
 A collection of transpiler tools for working with IBM Quantum's

--- a/qiskit_ibm_runtime/transpiler/passes/__init__.py
+++ b/qiskit_ibm_runtime/transpiler/passes/__init__.py
@@ -12,10 +12,10 @@
 
 """
 ================================================================
-Transpiler Passes (:mod:`qiskit_ibm_provider.transpiler.passes`)
+Transpiler Passes (:mod:`qiskit_ibm_runtime.transpiler.passes`)
 ================================================================
 
-.. currentmodule:: qiskit_ibm_provider.transpiler.passes
+.. currentmodule:: qiskit_ibm_runtime.transpiler.passes
 
 A collection of transpiler passes for IBM backends.
 

--- a/qiskit_ibm_runtime/transpiler/passes/basis/__init__.py
+++ b/qiskit_ibm_runtime/transpiler/passes/basis/__init__.py
@@ -12,10 +12,10 @@
 
 """
 ==========================================================
-Basis (:mod:`qiskit_ibm_provider.transpiler.passes.basis`)
+Basis (:mod:`qiskit_ibm_runtime.transpiler.passes.basis`)
 ==========================================================
 
-.. currentmodule:: qiskit_ibm_provider.transpiler.passes.basis
+.. currentmodule:: qiskit_ibm_runtime.transpiler.passes.basis
 
 Passes to layout circuits to IBM backend's instruction sets.
 """

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/__init__.py
@@ -12,10 +12,10 @@
 
 """
 ====================================================================
-Scheduling (:mod:`qiskit_ibm_provider.transpiler.passes.scheduling`)
+Scheduling (:mod:`qiskit_ibm_runtime.transpiler.passes.scheduling`)
 ====================================================================
 
-.. currentmodule:: qiskit_ibm_provider.transpiler.passes.scheduling
+.. currentmodule:: qiskit_ibm_runtime.transpiler.passes.scheduling
 
 A collection of scheduling passes for working with IBM Quantum's next-generation
 backends that support advanced "dynamic circuit" capabilities. Ie.,


### PR DESCRIPTION
This resulted in the imports being called `qiskit_ibm_provider` rather than `qiskit_ibm_runtime`.