### PR TITLE
stop depending on qiskit-ibm-provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ python-dateutil>=2.8.0
 websocket-client>=1.5.1
 typing-extensions>=4.0.0
 ibm-platform-services>=0.22.6
-qiskit-ibm-provider>=0.8.0


### PR DESCRIPTION
Once https://github.com/Qiskit/qiskit-ibm-runtime/issues/1128 gets fully solved, the features from qiskit-ibm-provider that are needed by qiskit-ibm-runtime are going to fully live in this codebase. Therefore, the dependency should be removed.

https://github.com/Qiskit/qiskit-ibm-runtime/blob/9cf11bd3006fe5db498643cfcc213bab525dda7b/requirements.txt#L10

blocked by https://github.com/Qiskit/qiskit-ibm-runtime/issues/1128
