### PR TITLE
Remove mthree from requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,6 @@ websockets>=8
 black~=22.0
 coverage>=6.3
 pylatexenc
-mthree
 scikit-learn
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`mthree` dependency is still install qiskit-terra in our CI, failing the tests 
https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/7751612975/job/21139794481

### Details and comments
Fixes #

