### PR TITLE
Update v2 transpilation options

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -140,7 +140,7 @@ class EstimatorV2(BasePrimitiveV2, Estimator, BaseEstimatorV2):
         # TODO: Server should have different optimization/resilience levels for simulator
 
         if (
-            options["resilience_level"] == 3
+            options.get("resilience", {}).get("pec_mitigation", False) is True
             and self._backend is not None
             and self._backend.configuration().simulator is True
             and not options["simulator"]["coupling_map"]

--- a/qiskit_ibm_runtime/options/estimator_options.py
+++ b/qiskit_ibm_runtime/options/estimator_options.py
@@ -23,7 +23,7 @@ from .utils import (
     skip_unset_validation,
 )
 from .execution_options import ExecutionOptionsV2
-from .transpilation_options import TranspilationOptions
+from .transpilation_options import TranspilationOptionsV2
 from .resilience_options import ResilienceOptionsV2
 from .twirling_options import TwirlingOptions
 from .options import OptionsV2
@@ -32,6 +32,7 @@ from .options import OptionsV2
 from ..qiskit.primitives.options import primitive_dataclass
 
 DDSequenceType = Literal["XX", "XpXm", "XY4"]
+MAX_RESILIENCE_LEVEL: int = 2
 
 
 @primitive_dataclass
@@ -39,17 +40,6 @@ class EstimatorOptions(OptionsV2):
     """Options for EstimatorV2.
 
     Args:
-        optimization_level: How much optimization to perform on the circuits.
-            Higher levels generate more optimized circuits,
-            at the expense of longer transpilation times. This is based on the
-            ``optimization_level`` parameter in qiskit-terra but may include
-            backend-specific optimization. Default: 1.
-
-            * 0: no optimization
-            * 1: light optimization
-            * 2: heavy optimization
-            * 3: even heavier optimization
-
         resilience_level: How much resilience to build against errors.
             Higher levels generate more accurate results,
             at the expense of longer processing times. Default: 1.
@@ -88,40 +78,25 @@ class EstimatorOptions(OptionsV2):
 
     """
 
-    _MAX_OPTIMIZATION_LEVEL: int = Field(3, frozen=True)  # pylint: disable=invalid-name
-    _MAX_RESILIENCE_LEVEL: int = Field(3, frozen=True)  # pylint: disable=invalid-name
-
     # Sadly we cannot use pydantic's built in validation because it won't work on Unset.
-    optimization_level: Union[UnsetType, int] = Unset
     resilience_level: Union[UnsetType, int] = Unset
     dynamical_decoupling: Union[UnsetType, DDSequenceType] = Unset
     seed_estimator: Union[UnsetType, int] = Unset
-    transpilation: Union[TranspilationOptions, Dict] = Field(default_factory=TranspilationOptions)
+    transpilation: Union[TranspilationOptionsV2, Dict] = Field(
+        default_factory=TranspilationOptionsV2
+    )
     resilience: Union[ResilienceOptionsV2, Dict] = Field(default_factory=ResilienceOptionsV2)
     execution: Union[ExecutionOptionsV2, Dict] = Field(default_factory=ExecutionOptionsV2)
     twirling: Union[TwirlingOptions, Dict] = Field(default_factory=TwirlingOptions)
     experimental: Union[UnsetType, dict] = Unset
-
-    @field_validator("optimization_level")
-    @classmethod
-    @skip_unset_validation
-    def _validate_optimization_level(cls, optimization_level: int) -> int:
-        """Validate optimization_leve."""
-        if not 0 <= optimization_level <= EstimatorOptions._MAX_OPTIMIZATION_LEVEL:
-            raise ValueError(
-                "Invalid optimization_level. Valid range is "
-                f"0-{EstimatorOptions._MAX_OPTIMIZATION_LEVEL}"
-            )
-        return optimization_level
 
     @field_validator("resilience_level")
     @classmethod
     @skip_unset_validation
     def _validate_resilience_level(cls, resilience_level: int) -> int:
         """Validate resilience_level."""
-        if not 0 <= resilience_level <= EstimatorOptions._MAX_RESILIENCE_LEVEL:
+        if not 0 <= resilience_level <= MAX_RESILIENCE_LEVEL:
             raise ValueError(
-                "Invalid optimization_level. Valid range is "
-                f"0-{EstimatorOptions._MAX_RESILIENCE_LEVEL}"
+                "Invalid optimization_level. Valid range is " f"0-{MAX_RESILIENCE_LEVEL}"
             )
         return resilience_level

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -127,7 +127,6 @@ class OptionsV2(BaseOptions, BasePrimitiveOptions):
             coupling_map = list(map(list, coupling_map.get_edges()))
         inputs["transpilation"].update(
             {
-                "optimization_level": options_copy.get("optimization_level", Unset),
                 "coupling_map": coupling_map,
                 "basis_gates": sim_options.get("basis_gates", Unset),
             }

--- a/qiskit_ibm_runtime/options/sampler_options.py
+++ b/qiskit_ibm_runtime/options/sampler_options.py
@@ -14,16 +14,15 @@
 
 from typing import Union, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from .utils import (
     Dict,
     Unset,
     UnsetType,
-    skip_unset_validation,
 )
 from .execution_options import ExecutionOptionsV2
-from .transpilation_options import TranspilationOptions
+from .transpilation_options import TranspilationOptionsV2
 from .twirling_options import TwirlingOptions
 from .options import OptionsV2
 
@@ -38,17 +37,6 @@ class SamplerOptions(OptionsV2):
     """Options for v2 Sampler.
 
     Args:
-        optimization_level: How much optimization to perform on the circuits.
-            Higher levels generate more optimized circuits,
-            at the expense of longer transpilation times. This is based on the
-            ``optimization_level`` parameter in qiskit-terra but may include
-            backend-specific optimization. Default: 1.
-
-            * 0: no optimization
-            * 1: light optimization
-            * 2: heavy optimization
-            * 3: even heavier optimization
-
         dynamical_decoupling: Optional, specify a dynamical decoupling sequence to use.
             Allowed values are ``"XX"``, ``"XpXm"``, ``"XY4"``.
             Default: None
@@ -68,24 +56,11 @@ class SamplerOptions(OptionsV2):
 
     """
 
-    _MAX_OPTIMIZATION_LEVEL: int = Field(3, frozen=True)  # pylint: disable=invalid-name
-
     # Sadly we cannot use pydantic's built in validation because it won't work on Unset.
-    optimization_level: Union[UnsetType, int] = Unset
     dynamical_decoupling: Union[UnsetType, DDSequenceType] = Unset
-    transpilation: Union[TranspilationOptions, Dict] = Field(default_factory=TranspilationOptions)
+    transpilation: Union[TranspilationOptionsV2, Dict] = Field(
+        default_factory=TranspilationOptionsV2
+    )
     execution: Union[ExecutionOptionsV2, Dict] = Field(default_factory=ExecutionOptionsV2)
     twirling: Union[TwirlingOptions, Dict] = Field(default_factory=TwirlingOptions)
     experimental: Union[UnsetType, dict] = Unset
-
-    @field_validator("optimization_level")
-    @classmethod
-    @skip_unset_validation
-    def _validate_optimization_level(cls, optimization_level: int) -> int:
-        """Validate optimization_leve."""
-        if not 0 <= optimization_level <= SamplerOptions._MAX_OPTIMIZATION_LEVEL:
-            raise ValueError(
-                "Invalid optimization_level. Valid range is "
-                f"0-{SamplerOptions._MAX_OPTIMIZATION_LEVEL}"
-            )
-        return optimization_level

--- a/qiskit_ibm_runtime/options/transpilation_options.py
+++ b/qiskit_ibm_runtime/options/transpilation_options.py
@@ -34,6 +34,7 @@ RoutingMethodType = Literal[
     "sabre",
     "none",
 ]
+MAX_OPTIMIZATION_LEVEL: int = 1
 
 
 @primitive_dataclass
@@ -74,3 +75,34 @@ class TranspilationOptions:
                 "and 1.0 (no approximation)"
             )
         return degree
+
+
+@primitive_dataclass
+class TranspilationOptionsV2:
+    """Transpilation options for v2 primitives.
+
+    Args:
+
+        skip_transpilation: Whether to skip transpilation. Default is False.
+
+        optimization_level: How much optimization to perform on the circuits.
+            Higher levels generate more optimized circuits,
+            at the expense of longer transpilation times.
+
+            * 0: no optimization
+            * 1: light optimization
+    """
+
+    skip_transpilation: bool = False
+    optimization_level: Union[UnsetType, int] = Unset
+
+    @field_validator("optimization_level")
+    @classmethod
+    @skip_unset_validation
+    def _validate_optimization_level(cls, optimization_level: int) -> int:
+        """Validate optimization_leve."""
+        if not 0 <= optimization_level <= MAX_OPTIMIZATION_LEVEL:
+            raise ValueError(
+                "Invalid optimization_level. Valid range is " f"0-{MAX_OPTIMIZATION_LEVEL}"
+            )
+        return optimization_level

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -271,6 +271,7 @@ class BaseFakeRuntimeClient:
         self._job_kwargs = job_kwargs or {}
         self._channel = channel
         self.session_time = 0
+        self._sessions = set()
 
         # Setup the available backends
         if not backend_specs:
@@ -342,6 +343,8 @@ class BaseFakeRuntimeClient:
         )
         self.session_time = session_time
         self._jobs[job_id] = job
+        if start_session:
+            self._sessions.add(job_id)
         return {"id": job_id, "backend": backend_name}
 
     def job_get(self, job_id: str, exclude_params: bool = True) -> Any:
@@ -454,6 +457,12 @@ class BaseFakeRuntimeClient:
     def backend_pulse_defaults(self, backend_name: str) -> Dict[str, Any]:
         """Return the pulse defaults of a backend."""
         return self._find_backend(backend_name).defaults
+
+    def close_session(self, session_id: str) -> None:
+        """Close the session."""
+        if session_id not in self._sessions:
+            raise ValueError(f"Session {session_id} not found.")
+        self._sessions.remove(session_id)
 
     def _find_backend(self, backend_name):
         for back in self._backends:

--- a/test/unit/test_estimator.py
+++ b/test/unit/test_estimator.py
@@ -94,8 +94,8 @@ class TestEstimatorV2(IBMTestCase):
     def test_unsupported_values_for_estimator_options(self):
         """Test exception when options levels are not supported."""
         options_bad = [
-            {"resilience_level": 4, "optimization_level": 3},
-            {"optimization_level": 4, "resilience_level": 2},
+            {"resilience_level": 3},
+            {"resilience_level": 4},
         ]
 
         with Session(
@@ -108,13 +108,13 @@ class TestEstimatorV2(IBMTestCase):
                     inst.options.update(**bad_opt)
                 self.assertIn(list(bad_opt.keys())[0], str(exc.exception))
 
-    def test_res_level3_simulator(self):
-        """Test the correct default error levels are used."""
+    def test_pec_simulator(self):
+        """Test error is raised when using pec on simulator without coupling map."""
 
         session = MagicMock(spec=MockSession)
         session.service.backend().configuration().simulator = True
 
-        inst = EstimatorV2(session=session, options={"resilience_level": 3})
+        inst = EstimatorV2(session=session, options={"resilience": {"pec_mitigation": True}})
         with self.assertRaises(ValueError) as exc:
             inst.run((self.circuit, self.observables))
         self.assertIn("coupling map", str(exc.exception))
@@ -128,16 +128,12 @@ class TestEstimatorV2(IBMTestCase):
                 {"resilience_level": 1},
             ),
             (
-                EstimatorOptions(optimization_level=3),  # pylint: disable=unexpected-keyword-arg
-                {"transpilation": {"optimization_level": 3}},
-            ),
-            (
                 {
-                    "transpilation": {"initial_layout": [1, 2]},
+                    "transpilation": {"optimization_level": 1},
                     "execution": {"shots": 100},
                 },
                 {
-                    "transpilation": {"initial_layout": [1, 2]},
+                    "transpilation": {"optimization_level": 1},
                     "execution": {"shots": 100},
                 },
             ),

--- a/test/unit/test_estimator_options.py
+++ b/test/unit/test_estimator_options.py
@@ -25,7 +25,6 @@ class TestEStimatorOptions(IBMTestCase):
     """Class for testing the Sampler class."""
 
     @data(
-        {"optimization_level": 99},
         {"resilience_level": 99},
         {"dynamical_decoupling": "foo"},
         {"transpilation": {"skip_transpilation": "foo"}},

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -420,7 +420,6 @@ class TestPrimitivesV2(IBMTestCase):
         for fld in ["tasks"]:
             inputs.pop(fld, None)
         expected = {"skip_transpilation": False, "execution": {"init_qubits": True}, "version": 2}
-        print(f">>>>>>> inputs is {inputs}")
         self.assertDictEqual(inputs, expected)
 
     @data(EstimatorV2)

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -74,10 +74,9 @@ class TestPrimitivesV2(IBMTestCase):
             {},
             {
                 "max_execution_time": 100,
-                "transpilation": {"initial_layout": [1, 2]},
+                "transpilation": {"optimization_level": 1},
                 "execution": {"shots": 100, "init_qubits": True},
             },
-            {"optimization_level": 2},
             {"transpilation": {}},
         ]
         for options in options_vars:
@@ -363,17 +362,8 @@ class TestPrimitivesV2(IBMTestCase):
             ({"dynamical_decoupling": "XY4"}, {"dynamical_decoupling": "XY4"}),
             ({"shots": 200}, {"execution": {"shots": 200}}),
             (
-                {"optimization_level": 3},
-                {"transpilation": {"optimization_level": 3}},
-            ),
-            (
-                {"initial_layout": [1, 2], "optimization_level": 2},
-                {
-                    "transpilation": {
-                        "optimization_level": 2,
-                        "initial_layout": [1, 2],
-                    }
-                },
+                {"optimization_level": 1},
+                {"transpilation": {"optimization_level": 1}},
             ),
             (
                 {"skip_transpilation": True},
@@ -430,6 +420,7 @@ class TestPrimitivesV2(IBMTestCase):
         for fld in ["tasks"]:
             inputs.pop(fld, None)
         expected = {"skip_transpilation": False, "execution": {"init_qubits": True}, "version": 2}
+        print(f">>>>>>> inputs is {inputs}")
         self.assertDictEqual(inputs, expected)
 
     @data(EstimatorV2)
@@ -458,14 +449,14 @@ class TestPrimitivesV2(IBMTestCase):
     @combine(
         primitive=[EstimatorV2],
         new_opts=[
-            {"optimization_level": 2},
-            {"optimization_level": 3, "shots": 200},
+            {"optimization_level": 0},
+            {"optimization_level": 1, "shots": 200},
         ],
     )
     def test_set_options(self, primitive, new_opts):
         """Test set options."""
         opt_cls = primitive._options_class
-        options = opt_cls(optimization_level=1, execution={"shots": 100})
+        options = opt_cls(transpilation={"optimization_level": 1}, execution={"shots": 100})
 
         session = MagicMock(spec=MockSession)
         inst = primitive(session=session, options=options)
@@ -492,7 +483,7 @@ class TestPrimitivesV2(IBMTestCase):
             {"shots": 10},
             {"seed_simulator": 123},
             {"skip_transpilation": True, "log_level": "ERROR"},
-            {"initial_layout": [1, 2], "shots": 100, "optimization_level": 2},
+            {"shots": 100, "optimization_level": 1},
         ]
 
         expected_list = [opt_cls() for _ in range(len(options_dicts))]
@@ -500,9 +491,8 @@ class TestPrimitivesV2(IBMTestCase):
         expected_list[2].simulator.seed_simulator = 123
         expected_list[3].transpilation.skip_transpilation = True
         expected_list[3].environment.log_level = "ERROR"
-        expected_list[4].transpilation.initial_layout = [1, 2]
         expected_list[4].execution.shots = 100
-        expected_list[4].optimization_level = 2
+        expected_list[4].transpilation.optimization_level = 1
 
         session = MagicMock(spec=MockSession)
         for opts, expected in zip(options_dicts, expected_list):

--- a/test/unit/test_options.py
+++ b/test/unit/test_options.py
@@ -280,12 +280,10 @@ class TestOptionsV2(IBMTestCase):
         options_vars = [
             {},
             {"resilience_level": 9},
-            {"resilience_level": 8, "transpilation": {"initial_layout": [1, 2]}},
             {"shots": 99, "seed_simulator": 42},
-            {"resilience_level": 99, "shots": 98, "initial_layout": [3, 4]},
+            {"resilience_level": 99, "shots": 98, "skip_transpilation": True},
             {
-                "initial_layout": [1, 2],
-                "transpilation": {"layout_method": "trivial"},
+                "transpilation": {"optimization_level": 1},
                 "log_level": "INFO",
             },
         ]
@@ -330,12 +328,10 @@ class TestOptionsV2(IBMTestCase):
         """Test converting to program inputs from v2 options."""
 
         noise_model = NoiseModel.from_backend(FakeManila())
+        optimization_level = 0
         transpilation = {
             "skip_transpilation": False,
-            "initial_layout": [1, 2],
-            "layout_method": "trivial",
-            "routing_method": "basic",
-            "approximation_degree": 0.5,
+            "optimization_level": optimization_level,
         }
         simulator = {
             "noise_model": noise_model,
@@ -350,7 +346,7 @@ class TestOptionsV2(IBMTestCase):
             "shots_per_sample": 20,
             "interleave_samples": True,
         }
-        optimization_level = 2
+
         twirling = {"gates": True, "measure": True, "strategy": "all"}
         resilience = {
             "measure_noise_mitigation": True,
@@ -365,7 +361,7 @@ class TestOptionsV2(IBMTestCase):
         estimator_extra = {}
         if isinstance(opt_cls, EstimatorOptions):
             estimator_extra = {
-                "resilience_level": 3,
+                "resilience_level": 2,
                 "resilience": resilience,
                 "seed_estimator": 42,
             }
@@ -373,7 +369,6 @@ class TestOptionsV2(IBMTestCase):
         opt = opt_cls(
             max_execution_time=100,
             simulator=simulator,
-            optimization_level=optimization_level,
             dynamical_decoupling="XX",
             transpilation=transpilation,
             execution=execution,
@@ -385,7 +380,6 @@ class TestOptionsV2(IBMTestCase):
         transpilation.pop("skip_transpilation")
         transpilation.update(
             {
-                "optimization_level": optimization_level,
                 "coupling_map": simulator.pop("coupling_map"),
                 "basis_gates": simulator.pop("basis_gates"),
             }
@@ -419,9 +413,9 @@ class TestOptionsV2(IBMTestCase):
             {},
             {"dynamical_decoupling": "XX"},
             {"simulator": {"seed_simulator": 42}},
-            {"optimization_level": 2, "environment": {"log_level": "WARNING"}},
+            {"environment": {"log_level": "WARNING"}},
             {
-                "transpilation": {"initial_layout": [1, 2], "layout_method": "trivial"},
+                "transpilation": {"optimization_level": 1},
                 "execution": {"shots": 100},
             },
             {"twirling": {"gates": True, "strategy": "active"}},
@@ -526,12 +520,12 @@ class TestOptionsV2(IBMTestCase):
     @data(
         {"resilience_level": 2},
         {"max_execution_time": 200},
-        {"resilience_level": 2, "transpilation": {"initial_layout": [1, 2]}},
+        {"resilience_level": 2, "transpilation": {"optimization_level": 1}},
         {"shots": 1024, "seed_simulator": 42},
-        {"resilience_level": 2, "shots": 2048, "initial_layout": [3, 4]},
+        {"resilience_level": 2, "shots": 2048},
         {
-            "initial_layout": [1, 2],
-            "transpilation": {"layout_method": "trivial"},
+            "optimization_level": 1,
+            "transpilation": {"skip_transpilation": True},
             "log_level": "INFO",
         },
     )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Remove `initial_layout` etc from transpilation options for v2 primitives. This closes #1333 
- Move `optimization_level` into transpilation now that we only do light transpilation and don't insert DD by default anymore
- Set max optimization level to 1
- Set max resilience level to 2

### Details and comments
Fixes #

