### PR TITLE
Cast use_symengine input to a bool

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -245,7 +245,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, ParameterView):
             return obj.data
         if isinstance(obj, Instruction):
-            kwargs: dict[str, object] = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
+            kwargs = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
             if _TERRA_VERSION[0] >= 1:
                 # NOTE: This can be updated only after the server side has
                 # updated to a newer qiskit version.

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -215,7 +215,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if hasattr(obj, "to_json"):
             return {"__type__": "to_json", "__value__": obj.to_json()}
         if isinstance(obj, QuantumCircuit):
-            kwargs = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
+            kwargs: dict[str, object] = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
             if _TERRA_VERSION[0] >= 1:
                 # NOTE: This can be updated only after the server side has
                 # updated to a newer qiskit version.
@@ -245,7 +245,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, ParameterView):
             return obj.data
         if isinstance(obj, Instruction):
-            kwargs = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
+            kwargs: dict[str, object] = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
             if _TERRA_VERSION[0] >= 1:
                 # NOTE: This can be updated only after the server side has
                 # updated to a newer qiskit version.

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -215,7 +215,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if hasattr(obj, "to_json"):
             return {"__type__": "to_json", "__value__": obj.to_json()}
         if isinstance(obj, QuantumCircuit):
-            kwargs = {"use_symengine": optionals.HAS_SYMENGINE}
+            kwargs = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
             if _TERRA_VERSION[0] >= 1:
                 # NOTE: This can be updated only after the server side has
                 # updated to a newer qiskit version.
@@ -239,13 +239,13 @@ class RuntimeEncoder(json.JSONEncoder):
                 data=obj,
                 serializer=_write_parameter_expression,
                 compress=False,
-                use_symengine=optionals.HAS_SYMENGINE,
+                use_symengine=bool(optionals.HAS_SYMENGINE),
             )
             return {"__type__": "ParameterExpression", "__value__": value}
         if isinstance(obj, ParameterView):
             return obj.data
         if isinstance(obj, Instruction):
-            kwargs = {"use_symengine": optionals.HAS_SYMENGINE}
+            kwargs = {"use_symengine": bool(optionals.HAS_SYMENGINE)}
             if _TERRA_VERSION[0] >= 1:
                 # NOTE: This can be updated only after the server side has
                 # updated to a newer qiskit version.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit works around a bug in Qiskit 0.45.x, 0.46.0, and 1.0.0rc1 with the `use_symengine` flag on `qpy.dump()`. The dump function has a bug when it receives a truthy value instead of a bool literal that it will generate a corrupt qpy because of a mismatch between how the encoding was processed (the encoding is incorrectly set to sympy in the file header but uses symengine encoding in the actual body of the circuit.  This is being fixed in Qiskit/qiskit#11730 for 1.0.0, and will be backported to 0.46.1. But to ensure compatibility with 0.45.x, 0.46.0, and 1.0.0rc1 while waiting for those releases we can workaround this by just casting the value to a boolean.

### Details and comments