### PR TITLE
Fix the name of the attribute used in the error message

### DIFF
--- a/qiskit_ibm_runtime/options/estimator_options.py
+++ b/qiskit_ibm_runtime/options/estimator_options.py
@@ -97,6 +97,6 @@ class EstimatorOptions(OptionsV2):
         """Validate resilience_level."""
         if not 0 <= resilience_level <= MAX_RESILIENCE_LEVEL:
             raise ValueError(
-                "Invalid optimization_level. Valid range is " f"0-{MAX_RESILIENCE_LEVEL}"
+                "Invalid resilience_level. Valid range is " f"0-{MAX_RESILIENCE_LEVEL}"
             )
         return resilience_level


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The error message in `_validate_resilience_level` says `optimization_level` when it should be `resilience_level`.