### PR TITLE
Fix merging experimental options

### DIFF
--- a/qiskit_ibm_runtime/options/utils.py
+++ b/qiskit_ibm_runtime/options/utils.py
@@ -115,6 +115,9 @@ def merge_options(
         for key, val in matched.items():
             old[key] = val
 
+        # Clear the matched dict so it's not reused
+        matched.clear()
+
     if is_dataclass(old_options):
         combined = asdict(old_options)
     elif isinstance(old_options, dict):

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -397,7 +397,7 @@ class TestPrimitivesV2(IBMTestCase):
 
     @combine(
         primitive=[EstimatorV2],
-        exp_opt=[{"foo": "bar"}, {"transpilation": {"foo": "bar"}}],
+        exp_opt=[{"foo": "bar"}, {"transpilation": {"extra_key": "bar"}}],
     )
     def test_run_experimental_options(self, primitive, exp_opt):
         """Test specifying arbitrary options in run."""
@@ -407,6 +407,20 @@ class TestPrimitivesV2(IBMTestCase):
         inst.run(**get_primitive_inputs(inst))
         inputs = session.run.call_args.kwargs["inputs"]
         self._assert_dict_partially_equal(inputs, exp_opt)
+        self.assertNotIn("extra_key", inputs)
+
+    @combine(
+        primitive=[EstimatorV2],
+        exp_opt=[{"foo": "bar"}, {"execution": {"extra_key": "bar"}}],
+    )
+    def test_run_experimental_options_init(self, primitive, exp_opt):
+        """Test specifying arbitrary options in initialization."""
+        session = MagicMock(spec=MockSession)
+        inst = primitive(session=session, options={"experimental": exp_opt})
+        inst.run(**get_primitive_inputs(inst))
+        inputs = session.run.call_args.kwargs["inputs"]
+        self._assert_dict_partially_equal(inputs, exp_opt)
+        self.assertNotIn("extra_key", inputs)
 
     @data(EstimatorV2)
     def test_run_unset_options(self, primitive):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It was reported that using the `experimental` to pass in nested options didn't always work. For example:

```
options = {
    "optimization_level": 0,
    "execution": {
        "shots": 1,
        "max_circuits": 40,
    },
    "twirling": {"strategy": "active-circuit", "gates": True, "measure": True},
}

Estimator(backend).run([(circuit, observable, parameter_values)]).result()
```

fails with 

`main() got an unexpected keyword argument 'max_circuits'`

It turns out this could happen if the dictionary containing the experimental option (in this case `execution`) is the last one to be merged in, because in `_update_options`, the `matched` dictionary is not cleared after each iteration and the residual value can be reused. 

### Details and comments
Fixes #

