### PR TITLE
Fix options auto complete

### DIFF
--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -27,7 +27,7 @@ from qiskit.providers.options import Options as TerraOptions
 from .provider_session import get_cm_session as get_cm_provider_session
 
 from .options import Options
-from .options.options import BaseOptions, OptionsV2
+from .options.options import BaseOptions
 from .options.utils import merge_options, set_default_error_levels
 from .runtime_job import RuntimeJob
 from .ibm_backend import IBMBackend
@@ -46,14 +46,14 @@ OptionsT = TypeVar("OptionsT", bound=BaseOptions)
 class BasePrimitiveV2(ABC, Generic[OptionsT]):
     """Base class for Qiskit Runtime primitives."""
 
-    _options_class: Optional[type[BaseOptions]] = OptionsV2
+    _options_class: OptionsT = BaseOptions
     version = 2
 
     def __init__(
         self,
         backend: Optional[Union[str, IBMBackend]] = None,
         session: Optional[Union[Session, str, IBMBackend]] = None,
-        options: Optional[Union[Dict, BaseOptions]] = None,
+        options: Optional[Union[Dict, OptionsT]] = None,
     ):
         """Initializes the primitive.
 
@@ -176,7 +176,7 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
         """Return options"""
         return self._options
 
-    def _set_options(self, options: Optional[Union[Dict, BaseOptions]] = None) -> None:
+    def _set_options(self, options: Optional[Union[Dict, OptionsT]] = None) -> None:
         """Set options."""
         if options is None:
             self._options = self._options_class()

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, Any, Union
+from typing import Dict, Optional, Any, Union, TypeVar, Generic
 import copy
 import logging
 from dataclasses import asdict, replace
@@ -40,9 +40,10 @@ from .qiskit_runtime_service import QiskitRuntimeService
 from .session import Session
 
 logger = logging.getLogger(__name__)
+OptionsT = TypeVar("OptionsT", bound=BaseOptions)
 
 
-class BasePrimitiveV2(ABC):
+class BasePrimitiveV2(ABC, Generic[OptionsT]):
     """Base class for Qiskit Runtime primitives."""
 
     _options_class: Optional[type[BaseOptions]] = OptionsV2
@@ -171,7 +172,7 @@ class BasePrimitiveV2(ABC):
         return self._session
 
     @property
-    def options(self) -> BaseOptions:
+    def options(self) -> OptionsT:
         """Return options"""
         return self._options
 

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, Any, Union, TypeVar, Generic
+from typing import Dict, Optional, Any, Union, TypeVar, Generic, Type
 import copy
 import logging
 from dataclasses import asdict, replace
@@ -27,7 +27,7 @@ from qiskit.providers.options import Options as TerraOptions
 from .provider_session import get_cm_session as get_cm_provider_session
 
 from .options import Options
-from .options.options import BaseOptions
+from .options.options import BaseOptions, OptionsV2
 from .options.utils import merge_options, set_default_error_levels
 from .runtime_job import RuntimeJob
 from .ibm_backend import IBMBackend
@@ -46,7 +46,7 @@ OptionsT = TypeVar("OptionsT", bound=BaseOptions)
 class BasePrimitiveV2(ABC, Generic[OptionsT]):
     """Base class for Qiskit Runtime primitives."""
 
-    _options_class: OptionsT = BaseOptions
+    _options_class: Type[OptionsT] = OptionsV2  # type: ignore[assignment]
     version = 2
 
     def __init__(

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -45,7 +45,7 @@ class Estimator:
     version = 0
 
 
-class EstimatorV2(BasePrimitiveV2, Estimator, BaseEstimatorV2):
+class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2):
     r"""Class for interacting with Qiskit Runtime Estimator primitive service.
 
     Qiskit Runtime Estimator primitive service estimates expectation values of quantum circuits and

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -42,7 +42,7 @@ class Sampler:
     version = 0
 
 
-class SamplerV2(BasePrimitiveV2, Sampler, BaseSamplerV2):
+class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
     """Class for interacting with Qiskit Runtime Sampler primitive service.
 
     This class supports version 2 of the Sampler interface, which uses different


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `options` property was declared in the base primitive class and returned the generic `BaseOptions`. This breaks auto-complete as it only covered fields in `BaseOptions` (which has nothing). 

This PR updates the return type to be the one used by sampler or estimator. 


### Details and comments
Fixes #

