### PR TITLE
Convert the observables to a list when encoding

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -296,7 +296,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, EstimatorPub):
             return (
                 obj.circuit,
-                np.asarray(obj.observables, dtype=object),
+                obj.observables.tolist(),
                 obj.parameter_values.as_array(obj.circuit.parameters),
                 obj.precision,
             )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Avoid converting observables to numpy arrays because https://github.com/Qiskit/qiskit-ibm-runtime/issues/1354 hasn't been fixed yet.

Using `.tolist` as a temporary replacement.