### PR TITLE
Fix missing releases notes before Runtime 0.9

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,1 +1,2 @@
 .. release-notes:: Release Notes
+  :earliest-version: 0.1.0rc1


### PR DESCRIPTION
Even though we had the release note files, Reno was not including them.