### PR TITLE
Raise if abstract circuits are used

### DIFF
--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -150,6 +150,7 @@ class BasePrimitive(ABC):
             and isinstance(self._backend, IBMBackend)
             and isinstance(self._backend.service, QiskitRuntimeService)
             and hasattr(self._backend, "target")
+            and self._service._channel_strategy != 'q-ctrl'
         ):
             validate_isa_circuits(primitive_inputs["circuits"], self._backend.target)
 

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -74,17 +74,14 @@ def validate_isa_circuits(circuits: Sequence[QuantumCircuit], target: Target) ->
     for circuit in circuits:
         message = is_isa_circuit(circuit, target)
         if message:
-            warnings.warn(
+            raise IBMInputValueError(
                 message
-                + " Circuits that do not match the target hardware definition will no longer be "
-                "supported after March 1, 2024. See the transpilation documentation "
+                + " Circuits that do not match the target hardware definition are no longer "
+                "supported after 4 March 2024. See the transpilation documentation "
                 "(https://docs.quantum.ibm.com/transpile) for instructions to transform circuits and "
                 "the primitive examples (https://docs.quantum.ibm.com/run/primitives-examples) to see "
-                "this coupled with operator transformations.",
-                DeprecationWarning,
-                stacklevel=6,
+                "this coupled with operator transformations."
             )
-            break
 
 
 def validate_job_tags(job_tags: Optional[List[str]]) -> None:

--- a/releasenotes/notes/isa-circuit-required-ed361bd65cef5ed8.yaml
+++ b/releasenotes/notes/isa-circuit-required-ed361bd65cef5ed8.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    Circuits that do not match the target hardware definition are no longer
+    supported by Qiskit Runtime primitives, unless ``channel_strategy="q-ctrl"``
+    is used. See the transpilation documentation
+    (https://docs.quantum.ibm.com/transpile) for instructions to transform
+    circuits and the primitive examples
+    (https://docs.quantum.ibm.com/run/primitives-examples) to see
+    this coupled with operator transformations.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We will start failing jobs that submit abstract circuits on March 4 (with the exception of Q-Ctrl). This PR updates the check to raise instead of issue a warning. 

### Details and comments
Fixes #

