### PR TITLE
Update deprecated actions in workflows 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
     name: Run code quality checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -45,11 +45,11 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -69,7 +69,7 @@ jobs:
       - name: Build documentation
         run: tox -edocs
       - name: Upload documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: html_docs
           path: docs/_build/html
@@ -88,11 +88,11 @@ jobs:
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -102,12 +102,12 @@ jobs:
       - name: Run unit tests
         run: make unit-test-coverage
       - name: Report coverage to coveralls.io
-        uses: coverallsapp/github-action@1.1.3
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: unit-tests_python${{ matrix.python-version }}-${{ matrix.os }}
           parallel: true
-          path-to-lcov: coverage.lcov
+          file: coverage.lcov
   integration-tests:
     if: github.event_name == 'push' && github.repository_owner == 'Qiskit'
     # only kick-off resource intensive integration tests if unit tests and all basic checks succeeded
@@ -130,11 +130,11 @@ jobs:
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify coveralls.io that all parallel tests have finished
-        uses: coverallsapp/github-action@1.1.3
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,8 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9.12'
     - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
     - name: Build docs
       run: tox -e docs
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: html_docs
         path: docs/_build/html

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,11 +37,11 @@ jobs:
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/integration-tests-qiskit-main.yml
+++ b/.github/workflows/integration-tests-qiskit-main.yml
@@ -37,11 +37,11 @@ jobs:
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,11 +37,11 @@ jobs:
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/q-ctrl-tests.yml
+++ b/.github/workflows/q-ctrl-tests.yml
@@ -37,11 +37,11 @@ jobs:
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/unit-tests-terra-main.yml
+++ b/.github/workflows/unit-tests-terra-main.yml
@@ -25,11 +25,11 @@ jobs:
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ Qconfig.py
 .DS_Store
 
 /docs/stubs/
+
+# PyCharm
+./idea


### PR DESCRIPTION
### Summary
In recent PRs including my PR https://github.com/Qiskit/qiskit-ibm-runtime/pull/1431, the CI has been throwing several errors due to old versions of actions that are using node12 or node16 instead of node20. I updated the actions to use the latest versions which should eliminate the CI warnings.
