### PR TITLE
Adds `default_shots` option to `SamplerOptions`

### DIFF
--- a/qiskit_ibm_runtime/options/sampler_options.py
+++ b/qiskit_ibm_runtime/options/sampler_options.py
@@ -31,6 +31,9 @@ class SamplerOptions(OptionsV2):
     """Options for v2 Sampler.
 
     Args:
+        default_shots: The default number of shots to use if none are specified in the pubs or in the
+            run method. Default: ``4096``.
+
         optimization_level: How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,
             at the expense of longer processing times.
@@ -57,6 +60,7 @@ class SamplerOptions(OptionsV2):
     """
 
     # Sadly we cannot use pydantic's built in validation because it won't work on Unset.
+    default_shots: int = 4096
     optimization_level: Union[UnsetType, int] = Unset
     dynamical_decoupling: Union[UnsetType, DDSequenceType] = Unset
     execution: Union[ExecutionOptionsV2, Dict] = Field(default_factory=ExecutionOptionsV2)

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -111,6 +111,8 @@ class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
         Raises:
             ValueError: Invalid arguments are given.
         """
+        if shots is None:
+            shots = self.options.default_shots
         coerced_pubs = [SamplerPub.coerce(pub, shots) for pub in pubs]
 
         if any(len(pub.circuit.cregs) == 0 for pub in coerced_pubs):

--- a/test/unit/test_options.py
+++ b/test/unit/test_options.py
@@ -355,12 +355,16 @@ class TestOptionsV2(IBMTestCase):
             "pec_max_overhead": 2,
         }
 
-        estimator_extra = {}
+        extra = {}
         if isinstance(opt_cls, EstimatorOptions):
-            estimator_extra = {
+            extra = {
                 "resilience_level": 2,
                 "resilience": resilience,
                 "seed_estimator": 42,
+            }
+        if isinstance(opt_cls, SamplerOptions):
+            extra = {
+                "default_shots": 1024,
             }
 
         opt = opt_cls(
@@ -371,7 +375,7 @@ class TestOptionsV2(IBMTestCase):
             execution=execution,
             twirling=twirling,
             experimental={"foo": "bar"},
-            **estimator_extra,
+            **extra,
         )
 
         transpilation = {
@@ -392,7 +396,7 @@ class TestOptionsV2(IBMTestCase):
             "execution": execution,
             "foo": "bar",
             "version": 2,
-            **estimator_extra,
+            **extra,
         }
 
         inputs = opt_cls._get_program_inputs(asdict(opt))

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -105,6 +105,10 @@ class TestSamplerV2(IBMTestCase):
                 {"dynamical_decoupling": "XX"},
             ),
             (
+                SamplerOptions(default_shots=42),  # pylint: disable=unexpected-keyword-arg
+                {"default_shots": 42},
+            ),
+            (
                 SamplerOptions(optimization_level=3),  # pylint: disable=unexpected-keyword-arg
                 {"transpilation": {"optimization_level": 3}},
             ),


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR adds the `default_shots: int` option to `SamplerOptions` for the V2 primitives.

### Details and comments
Fixes #

