### PR TITLE
Remove `DynamicCircuitInstructionDurations` patch added in 0.19

### DIFF
--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
@@ -161,43 +161,7 @@ class DynamicCircuitInstructionDurations(InstructionDurations):
             DynamicInstructionDurations: The InstructionDurations constructed from backend.
         """
         if isinstance(backend, BackendV1):
-            # TODO Remove once https://github.com/Qiskit/qiskit/pull/11727 gets released in qiskit 0.46.1
-            # From here ---------------------------------------
-            def patch_from_backend(cls, backend: Backend):  # type: ignore
-                """
-                REMOVE me once https://github.com/Qiskit/qiskit/pull/11727 gets released in qiskit 0.46.1
-                """
-                instruction_durations = []
-                backend_properties = backend.properties()
-                if hasattr(backend_properties, "_gates"):
-                    for gate, insts in backend_properties._gates.items():
-                        for qubits, props in insts.items():
-                            if "gate_length" in props:
-                                gate_length = props["gate_length"][
-                                    0
-                                ]  # Throw away datetime at index 1
-                                instruction_durations.append((gate, qubits, gate_length, "s"))
-                    for (
-                        q,  # pylint: disable=invalid-name
-                        props,
-                    ) in backend.properties()._qubits.items():
-                        if "readout_length" in props:
-                            readout_length = props["readout_length"][
-                                0
-                            ]  # Throw away datetime at index 1
-                            instruction_durations.append(("measure", [q], readout_length, "s"))
-                try:
-                    dt = backend.configuration().dt
-                except AttributeError:
-                    dt = None
-
-                return cls(instruction_durations, dt=dt)
-
-            return patch_from_backend(DynamicCircuitInstructionDurations, backend)
-            # To here --------------------------------------- (remove comment ignore annotations too)
-            return super(  # type: ignore  # pylint: disable=unreachable
-                DynamicCircuitInstructionDurations, cls
-            ).from_backend(backend)
+            return super(DynamicCircuitInstructionDurations, cls).from_backend(backend)
 
         # Get durations from target if BackendV2
         return cls.from_target(backend.target)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Removes patch added in https://github.com/Qiskit/qiskit-ibm-runtime/pull/1383 - this was originally added as a hacky way to support both qiskit 0.45 and 1.0 

### Details and comments
Fixes #

