### PR TITLE
Allow importing SamplerV1 and EstimatorV1

### DIFF
--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -173,15 +173,15 @@ from .exceptions import *
 from .utils.utils import setup_logger
 from .version import __version__
 
-from .estimator import (
+from .estimator import (  # pylint: disable=reimported
     EstimatorV2,
     EstimatorV1,
-    EstimatorV1 as Estimator,  # pylint: disable=reimported
+    EstimatorV1 as Estimator,
 )
-from .sampler import (
+from .sampler import (  # pylint: disable=reimported
     SamplerV2,
     SamplerV1,
-    SamplerV1 as Sampler,  # pylint: disable=reimported
+    SamplerV1 as Sampler,
 )
 from .options import Options, EstimatorOptions, SamplerOptions
 

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -144,7 +144,11 @@ Classes
 
    QiskitRuntimeService
    Estimator
+   EstimatorV1
+   EstimatorV2
    Sampler
+   SamplerV1
+   SamplerV2
    Session
    IBMBackend
    RuntimeJob
@@ -169,8 +173,8 @@ from .exceptions import *
 from .utils.utils import setup_logger
 from .version import __version__
 
-from .estimator import EstimatorV2, EstimatorV1 as Estimator
-from .sampler import SamplerV2, SamplerV1 as Sampler
+from .estimator import EstimatorV2, EstimatorV1, EstimatorV1 as Estimator
+from .sampler import SamplerV2, SamplerV1, SamplerV1 as Sampler
 from .options import Options, EstimatorOptions, SamplerOptions
 
 # Setup the logger for the IBM Quantum Provider package.

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -173,8 +173,16 @@ from .exceptions import *
 from .utils.utils import setup_logger
 from .version import __version__
 
-from .estimator import EstimatorV2, EstimatorV1, EstimatorV1 as Estimator
-from .sampler import SamplerV2, SamplerV1, SamplerV1 as Sampler
+from .estimator import (
+    EstimatorV2,
+    EstimatorV1,
+    EstimatorV1 as Estimator,  # pylint: disable=reimported
+)
+from .sampler import (
+    SamplerV2,
+    SamplerV1,
+    SamplerV1 as Sampler,  # pylint: disable=reimported
+)
 from .options import Options, EstimatorOptions, SamplerOptions
 
 # Setup the logger for the IBM Quantum Provider package.


### PR DESCRIPTION
Right now, users can't import `qiskit_ibm_runtime.SamplerV1` and `qiskit_ibm_runtime.EstimatorV1` because we only expose the aliases `Sampler` and `Estimator`. That gets in the way of users being explicit about which primitive version they're using.

This also is resulting in the API docs not including the pages for both the V1 and V2 primitives in https://github.com/Qiskit/documentation/pull/973 because we didn't tell autosummary about them.