### PR TITLE
Hacky fix for Reno removing 0.16+ release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,2 +1,13 @@
+.. 
+  For some reason, Reno stopped including release notes
+  for 0.16+ starting on the stable/0.21 branch. We can get
+  things working by using two release-note entries. The
+  API conversion in qiskit/documentation will merge these two
+  lists together. Refer to
+  https://github.com/Qiskit/documentation/issues/978
+
 .. release-notes:: Release Notes
+  :earliest-version: 0.16.0
+
+.. release-notes:: HACK FOR RENO ISSUE
   :earliest-version: 0.1.0rc1


### PR DESCRIPTION
Reno stopped including 0.16+ and newer on the stable/0.21 branch and on main, but it still works for stable/0.20. @arnaucasau and I spent two hours trying to debug this and couldn't figure it out.

To unblock getting out release notes for 0.21, we're going to use this hacky workaround to generate two separate release notes. The API generation script in qiskit/documentation will merge back to a single list.

We're going to either investigate more closely what happened later, or switch away from Reno so it doesn't matter. See https://github.com/Qiskit/documentation/issues/978