### PR TITLE
Fix unrelated release notes being added to 0.15 entry (Cherry-pick of #1486)

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,13 +1,16 @@
 .. 
   For some reason, Reno stopped including release notes
   for 0.16+ starting on the stable/0.21 branch. We can get
-  things working by using two release-note entries. The
-  API conversion in qiskit/documentation will merge these two
-  lists together. Refer to
+  things working by using two release-note entries. Refer to
   https://github.com/Qiskit/documentation/issues/978
 
-.. release-notes:: Release Notes
+=============
+Release Notes
+=============
+
+.. release-notes::
   :earliest-version: 0.16.0
 
-.. release-notes:: HACK FOR RENO ISSUE
+.. release-notes::
+  :branch: stable/0.15
   :earliest-version: 0.1.0rc1


### PR DESCRIPTION
This is a better fix for https://github.com/Qiskit/documentation/issues/978 than https://github.com/Qiskit/qiskit-ibm-runtime/pull/1479 was. 

The issue with #1479 is release notes for 0.16+ were being put into the 0.15 entry.

This new approach also allows us to move the hacky code we needed in qiskit/documentation. This new file was tested with our API generation script and does the right thing.