### PR TITLE
[experiment] enumerate all Reno branches

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,4 +13,36 @@ Release Notes
 
 .. release-notes::
   :branch: stable/0.15
+  :earliest-version: 0.15.0
+
+.. release-notes::
+  :branch: stable/0.14
+  :earliest-version: 0.14.0
+
+.. release-notes::
+  :branch: stable/0.13
+  :earliest-version: 0.13.0
+
+.. release-notes::
+  :branch: stable/0.12
+  :earliest-version: 0.12.0
+
+.. release-notes::
+  :branch: stable/0.11
+  :earliest-version: 0.11.0
+
+.. release-notes::
+  :branch: stable/0.10
+  :earliest-version: 0.10.0
+
+.. release-notes::
+  :branch: stable/0.9
+  :earliest-version: 0.9.0
+
+.. release-notes::
+  :branch: stable/0.8
+  :earliest-version: 0.8.0
+
+.. release-notes::
+  :branch: stable/0.15
   :earliest-version: 0.1.0rc1

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -44,5 +44,29 @@ Release Notes
   :earliest-version: 0.8.0
 
 .. release-notes::
-  :branch: stable/0.15
+  :branch: stable/0.7
+  :earliest-version: 0.7.0rc1
+
+.. release-notes::
+  :branch: stable/0.6
+  :earliest-version: 0.6.0
+
+.. release-notes::
+  :branch: stable/0.5
+  :earliest-version: 0.5.0
+
+.. release-notes::
+  :branch: stable/0.4
+  :earliest-version: 0.4.0
+
+.. release-notes::
+  :branch: stable/0.3
+  :earliest-version: 0.3.0
+
+.. release-notes::
+  :branch: stable/0.2
+  :earliest-version: 0.2.0
+
+.. release-notes::
+  :branch: stable/0.1
   :earliest-version: 0.1.0rc1


### PR DESCRIPTION
Results in these release notes: https://github.com/Qiskit/documentation/pull/984. Note how certain patch releases are deleted, so I don't think this is acceptable.