### PR TITLE
Local testing mode support for V2 primitivse

### DIFF
--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -98,7 +98,7 @@ instance is used when instantiating a primitive or a session. For example::
     from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
     from qiskit_ibm_runtime import Session
-    from qiskit_ibm_runtime import Sampler
+    from qiskit_ibm_runtime import SamplerV2 as Sampler
     from qiskit_ibm_runtime.fake_provider import FakeManilaV2
 
     # Bell Circuit

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -35,7 +35,7 @@ from .runtime_job_v2 import RuntimeJobV2
 from .ibm_backend import IBMBackend
 from .utils.default_session import get_cm_session
 from .utils.deprecation import issue_deprecation_msg
-from .utils.utils import validate_isa_circuits
+from .utils.utils import validate_isa_circuits, is_simulator
 from .constants import DEFAULT_DECODERS
 from .qiskit_runtime_service import QiskitRuntimeService
 from .fake_provider.local_service import QiskitRuntimeLocalService
@@ -56,15 +56,15 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
 
     def __init__(
         self,
-        backend: Optional[Union[str, IBMBackend]] = None,
-        session: Optional[Union[Session, str, IBMBackend]] = None,
+        backend: Optional[Union[str, BackendV1, BackendV2]] = None,
+        session: Optional[Session] = None,
         options: Optional[Union[Dict, OptionsT]] = None,
     ):
         """Initializes the primitive.
 
         Args:
 
-            backend: Backend to run the primitive. This can be a backend name or an :class:`IBMBackend`
+            backend: Backend to run the primitive. This can be a backend name or a ``Backend``
                 instance. If a name is specified, the default account (e.g. ``QiskitRuntimeService()``)
                 is used.
 
@@ -75,30 +75,32 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
                 :class:`qiskit_ibm_runtime.Session` context manager, then the session is used.
                 Otherwise if IBM Cloud channel is used, a default backend is selected.
 
-            options: Primitive options, see :class:`Options` for detailed description.
-                The ``backend`` keyword is still supported but is deprecated.
+            options: Primitive options, see :class:`qiskit_ibm_runtime.options.EstimatorOptions`
+                and :class:`qiskit_ibm_runtime.options.SamplerOptions` for detailed description
+                on estimator and sampler options, respectively.
 
         Raises:
             ValueError: Invalid arguments are given.
         """
         self._session: Optional[Session] = None
-        self._service: QiskitRuntimeService = None
-        self._backend: Optional[IBMBackend] = None
+        self._service: QiskitRuntimeService | QiskitRuntimeLocalService = None
+        self._backend: Optional[BackendV1 | BackendV2] = None
 
         self._set_options(options)
 
         if isinstance(session, Session):
             self._session = session
             self._service = self._session.service
-            self._backend = self._service.backend(
-                name=self._session.backend(), instance=self._session._instance
-            )
+            self._backend = self._session._backend
             return
-        elif session is not None:
+        elif session is not None:  # type: ignore[unreachable]
             raise ValueError("session must be of type Session or None")
 
-        if isinstance(backend, IBMBackend):
+        if isinstance(backend, IBMBackend):  # type: ignore[unreachable]
             self._service = backend.service
+            self._backend = backend
+        elif isinstance(backend, (BackendV1, BackendV2)):
+            self._service = QiskitRuntimeLocalService()
             self._backend = backend
         elif isinstance(backend, str):
             self._service = (
@@ -123,6 +125,12 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
                 raise ValueError(
                     "A backend or session must be specified when not using ibm_cloud channel."
                 )
+            issue_deprecation_msg(
+                "Not providing a backend is deprecated",
+                "0.22.0",
+                "Passing in a backend will be required, please provide a backend.",
+                3,
+            )
 
     def _run(self, pubs: Union[list[EstimatorPub], list[SamplerPub]]) -> RuntimeJobV2:
         """Run the primitive.
@@ -142,13 +150,11 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
 
         if self._backend:
             for pub in pubs:
-                if (
-                    getattr(self._backend, "target", None)
-                    and not self._backend.configuration().simulator
-                ):
+                if getattr(self._backend, "target", None) and not is_simulator(self._backend):
                     validate_isa_circuits([pub.circuit], self._backend.target)
 
-                self._backend.check_faulty(pub.circuit)
+                if isinstance(self._backend, IBMBackend):
+                    self._backend.check_faulty(pub.circuit)
 
         logger.info("Submitting job using options %s", primitive_options)
 
@@ -162,16 +168,23 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
             )
 
         if self._backend:
-            runtime_options["backend"] = self._backend.name
-            if "instance" not in runtime_options:
+            runtime_options["backend"] = self._backend
+            if "instance" not in runtime_options and isinstance(self._backend, IBMBackend):
                 runtime_options["instance"] = self._backend._instance
 
+        if isinstance(self._service, QiskitRuntimeService):
+            return self._service.run(
+                program_id=self._program_id(),
+                options=runtime_options,
+                inputs=primitive_inputs,
+                callback=options_dict.get("environment", {}).get("callback", None),
+                result_decoder=DEFAULT_DECODERS.get(self._program_id()),
+            )
+
         return self._service.run(
-            program_id=self._program_id(),
+            program_id=self._program_id(),  # type: ignore[arg-type]
             options=runtime_options,
             inputs=primitive_inputs,
-            callback=options_dict.get("environment", {}).get("callback", None),
-            result_decoder=DEFAULT_DECODERS.get(self._program_id()),
         )
 
     @property

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -121,8 +121,7 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
                 :class:`qiskit_ibm_runtime.Session` context manager, then the session is used.
                 Otherwise if IBM Cloud channel is used, a default backend is selected.
 
-            options: Primitive options, see :class:`Options` for detailed description.
-                The ``backend`` keyword is still supported but is deprecated.
+            options: Estimator options, see :class:`EstimatorOptions` for detailed description.
 
         Raises:
             NotImplementedError: If "q-ctrl" channel strategy is used.

--- a/qiskit_ibm_runtime/options/utils.py
+++ b/qiskit_ibm_runtime/options/utils.py
@@ -25,6 +25,7 @@ from pydantic.dataclasses import dataclass
 
 from qiskit.providers.backend import Backend
 
+from ..utils.utils import is_simulator
 
 if TYPE_CHECKING:
     from ..options.options import BaseOptions
@@ -47,9 +48,7 @@ def set_default_error_levels(
     Returns:
         options with correct error level defaults.
     """
-    is_sim = False
-    if hasattr(backend, "configuration"):
-        is_sim = getattr(backend.configuration(), "simulator", False)
+    is_sim = is_simulator(backend)
 
     if options.get("optimization_level") is None:
         if is_sim and not options.get("simulator", {}).get("noise_model"):

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -80,8 +80,7 @@ class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
                 :class:`qiskit_ibm_runtime.Session` context manager, then the session is used.
                 Otherwise if IBM Cloud channel is used, a default backend is selected.
 
-            options: Primitive options, see :class:`Options` for detailed description.
-                The ``backend`` keyword is still supported but is deprecated.
+            options: Sampler options, see :class:`SamplerOptions` for detailed description.
 
         Raises:
             NotImplementedError: If "q-ctrl" channel strategy is used.

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -11,12 +11,13 @@
 # that they have been altered from the originals.
 
 """General utility functions."""
+
+from __future__ import annotations
 import copy
 import keyword
 import logging
 import os
 import re
-import hashlib
 from queue import Queue
 from threading import Condition
 from typing import List, Optional, Any, Dict, Union, Tuple, Sequence
@@ -29,7 +30,22 @@ from ibm_cloud_sdk_core.authenticators import (  # pylint: disable=import-error
 from ibm_platform_services import ResourceControllerV2  # pylint: disable=import-error
 from qiskit.circuit import QuantumCircuit
 from qiskit.transpiler import Target
+from qiskit.providers.backend import BackendV1, BackendV2
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
+
+
+def is_simulator(backend: BackendV1 | BackendV2) -> bool:
+    """Return true if the backend is a simulator.
+
+    Args:
+        backend: Backend to check.
+
+    Returns:
+        True if backend is a simulator.
+    """
+    if hasattr(backend, "configuration"):
+        return getattr(backend.configuration(), "simulator", False)
+    return getattr(backend, "simulator", False)
 
 
 def is_isa_circuit(circuit: QuantumCircuit, target: Target) -> str:
@@ -308,13 +324,6 @@ def _filter_value(data: Dict[str, Any], filter_keys: List[Union[str, Tuple[str, 
                 data[filter_key[0]][filter_key[1]] = "..."
             elif isinstance(value, dict):
                 _filter_value(value, filter_keys)
-
-
-def _hash(hash_str: str) -> str:
-    """Hashes and returns a digest.
-    blake2s is supposedly faster than SHAs.
-    """
-    return hashlib.blake2s(hash_str.encode()).hexdigest()
 
 
 class RefreshQueue(Queue):

--- a/test/unit/test_estimator.py
+++ b/test/unit/test_estimator.py
@@ -12,8 +12,6 @@
 
 """Tests for estimator class."""
 
-from unittest.mock import MagicMock
-
 import numpy as np
 from ddt import data, ddt
 
@@ -28,7 +26,6 @@ from .mock.fake_runtime_service import FakeRuntimeService
 from ..ibm_test_case import IBMTestCase
 from ..utils import (
     get_mocked_backend,
-    MockSession,
     dict_paritally_equal,
     transpile_pubs,
     get_primitive_inputs,
@@ -115,11 +112,10 @@ class TestEstimatorV2(IBMTestCase):
 
     def test_pec_simulator(self):
         """Test error is raised when using pec on simulator without coupling map."""
+        backend = get_mocked_backend()
+        backend.configuration().simulator = True
 
-        session = MagicMock(spec=MockSession)
-        session.service.backend().configuration().simulator = True
-
-        inst = EstimatorV2(session=session, options={"resilience": {"pec_mitigation": True}})
+        inst = EstimatorV2(backend=backend, options={"resilience": {"pec_mitigation": True}})
         with self.assertRaises(ValueError) as exc:
             inst.run(**get_primitive_inputs(inst))
         self.assertIn("coupling map", str(exc.exception))

--- a/test/unit/test_local_mode.py
+++ b/test/unit/test_local_mode.py
@@ -12,10 +12,13 @@
 
 """Tests for local mode."""
 
+import warnings
+
 from ddt import data, ddt
 
 from qiskit_aer import AerSimulator
-from qiskit.primitives import EstimatorResult, SamplerResult
+from qiskit.primitives import EstimatorResult, SamplerResult, PrimitiveResult, PubResult
+from qiskit.primitives.containers.data_bin import DataBin
 
 from qiskit_ibm_runtime.fake_provider import FakeManila, FakeManilaV2
 from qiskit_ibm_runtime import (
@@ -24,6 +27,8 @@ from qiskit_ibm_runtime import (
     Options,
     Session,
     Batch,
+    SamplerV2,
+    EstimatorV2,
 )
 
 from ..ibm_test_case import IBMTestCase
@@ -34,8 +39,8 @@ from ..utils import (
 
 
 @ddt
-class TestLocalMode(IBMTestCase):
-    """Class for testing the Sampler and Estimator classes."""
+class TestLocalModeV1(IBMTestCase):
+    """Class for testing local mode for v1 primitives."""
 
     @combine(backend=[FakeManila(), FakeManilaV2(), AerSimulator()], num_sets=[1, 3])
     def test_v1_sampler(self, backend, num_sets):
@@ -118,6 +123,104 @@ class TestLocalMode(IBMTestCase):
             self.assertIsInstance(result, EstimatorResult)
             self.assertEqual(len(result.values), 1)
             self.assertEqual(len(result.metadata), 1)
+
+
+@ddt
+class TestLocalModeV2(IBMTestCase):
+    """Class for testing local mode for V2 primitives."""
+
+    @combine(backend=[FakeManila(), FakeManilaV2(), AerSimulator()], num_sets=[1, 3])
+    def test_v2_sampler(self, backend, num_sets):
+        """Test V2 Sampler on a local backend."""
+        inst = SamplerV2(backend=backend)
+        job = inst.run(**get_primitive_inputs(inst, backend=backend, num_sets=num_sets))
+        result = job.result()
+        self.assertIsInstance(result, PrimitiveResult)
+        self.assertEqual(len(result), num_sets)
+        for pub_result in result:
+            self.assertIsInstance(pub_result, PubResult)
+            self.assertIsInstance(pub_result.data, DataBin)
+            self.assertIsInstance(pub_result.metadata, dict)
+
+    @combine(backend=[FakeManila(), FakeManilaV2(), AerSimulator()], num_sets=[1, 3])
+    def test_v2_estimator(self, backend, num_sets):
+        """Test V2 Estimator on a local backend."""
+        inst = EstimatorV2(backend=backend)
+        job = inst.run(**get_primitive_inputs(inst, backend=backend, num_sets=num_sets))
+        result = job.result()
+        self.assertIsInstance(result, PrimitiveResult)
+        self.assertEqual(len(result), num_sets)
+        for pub_result in result:
+            self.assertIsInstance(pub_result, PubResult)
+            self.assertIsInstance(pub_result.data, DataBin)
+            self.assertIsInstance(pub_result.metadata, dict)
+
+    @data(FakeManila(), FakeManilaV2(), AerSimulator.from_backend(FakeManila()))
+    def test_v2_sampler_with_accepted_options(self, backend):
+        """Test V2 sampler with accepted options."""
+        options = {"default_shots": 10, "simulator": {"seed_simulator": 42}}
+        inst = SamplerV2(backend=backend, options=options)
+        job = inst.run(**get_primitive_inputs(inst, backend=backend))
+        pub_result = job.result()[0]
+        self.assertEqual(pub_result.data.meas.num_shots, 10)
+        self.assertDictEqual(
+            pub_result.data.meas.get_counts(), {"00010": 1, "00011": 2, "00000": 7}
+        )
+
+    @data(FakeManila(), FakeManilaV2(), AerSimulator.from_backend(FakeManila()))
+    def test_v2_estimator_with_accepted_options(self, backend):
+        """Test V1 estimator with accepted options."""
+        options = {"default_precision": 0.03125, "simulator": {"seed_simulator": 42}}
+        inst = EstimatorV2(backend=backend, options=options)
+        job = inst.run(**get_primitive_inputs(inst, backend=backend))
+        pub_result = job.result()[0]
+        self.assertDictEqual(pub_result.metadata, {"target_precision": 0.03125})
+        self.assertEqual(pub_result.data.evs[0], 0.197265625)
+
+    @combine(
+        primitive=[SamplerV2, EstimatorV2], backend=[FakeManila(), FakeManilaV2(), AerSimulator()]
+    )
+    def test_primitve_v2_with_not_accepted_options(self, primitive, backend):
+        """Test V1 primitive with accepted options."""
+        options = {
+            "max_execution_time": 200,
+            "dynamical_decoupling": {"enable": True},
+            "simulator": {"seed_simulator": 42},
+        }
+        inst = primitive(backend=backend, options=options)
+        with warnings.catch_warnings(record=True) as warns:
+            job = inst.run(**get_primitive_inputs(inst, backend=backend))
+            _ = job.result()
+            self.assertEqual(len(warns), 1)
+            self.assertIn("dynamical_decoupling", str(warns[0].message))
+
+    @combine(session_cls=[Session, Batch], backend=[FakeManila(), FakeManilaV2(), AerSimulator()])
+    def test_sampler_v2_session(self, session_cls, backend):
+        """Testing running v2 sampler inside session."""
+        with session_cls(backend=backend) as session:
+            inst = SamplerV2(session=session)
+            job = inst.run(**get_primitive_inputs(inst, backend=backend))
+            result = job.result()
+            self.assertIsInstance(result, PrimitiveResult)
+            self.assertEqual(len(result), 1)
+            for pub_result in result:
+                self.assertIsInstance(pub_result, PubResult)
+                self.assertIsInstance(pub_result.data, DataBin)
+                self.assertIsInstance(pub_result.metadata, dict)
+
+    @combine(session_cls=[Session, Batch], backend=[FakeManila(), FakeManilaV2(), AerSimulator()])
+    def test_estimator_v2_session(self, session_cls, backend):
+        """Testing running v2 estimator inside session."""
+        with session_cls(backend=backend) as session:
+            inst = EstimatorV2(session=session)
+            job = inst.run(**get_primitive_inputs(inst, backend=backend))
+            result = job.result()
+            self.assertIsInstance(result, PrimitiveResult)
+            self.assertEqual(len(result), 1)
+            for pub_result in result:
+                self.assertIsInstance(pub_result, PubResult)
+                self.assertIsInstance(pub_result.data, DataBin)
+                self.assertIsInstance(pub_result.metadata, dict)
 
     @data(FakeManila(), FakeManilaV2(), AerSimulator())
     def test_non_primitve(self, backend):

--- a/test/utils.py
+++ b/test/utils.py
@@ -18,7 +18,7 @@ import time
 import itertools
 import unittest
 from unittest import mock
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 from datetime import datetime
 from ddt import data, unpack
 
@@ -319,6 +319,17 @@ def get_mocked_backend(
     )
 
     return mock_backend
+
+
+def get_mocked_session(backend: Any = None) -> mock.MagicMock:
+    """Return a mocked session object."""
+    session = mock.MagicMock(spec=Session)
+    session._instance = None
+    session._backend = backend or get_mocked_backend()
+    session._service = getattr(backend, "service", None) or mock.MagicMock(
+        spec=QiskitRuntimeService
+    )
+    return session
 
 
 def submit_and_cancel(backend: IBMBackend, logger: logging.Logger) -> RuntimeJob:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add local testing mode support for V2 primitives (similar to #1495). 

### Details and comments

If an unsupported option is passed to a V2 primitive, a warning is issued. This was not done for V1 because V1 hard codes defaults, so there was no way to differentiate user-set vs defaulted to values. V2 clears out all unset options prior to calling the service. 

There is also no release note because the one from #1495 is generic enough to cover both.  

