### PR TITLE
Treat resilience_level=0 for EstimatorV2 properly (replace of 1541)

### DIFF
--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -163,7 +163,7 @@ class OptionsV2(BaseOptions):
         remove_empty_dict(output_options)
 
         inputs = {"options": output_options, "version": OptionsV2._VERSION, "support_qiskit": True}
-        if options_copy.get("resilience_level"):
+        if options_copy.get("resilience_level", Unset) != Unset:
             inputs["resilience_level"] = options_copy["resilience_level"]
 
         return inputs

--- a/release-notes/unreleased/1541.bug.rst
+++ b/release-notes/unreleased/1541.bug.rst
@@ -1,0 +1,2 @@
+Fix a bug that caused setting of ``resilience_level=0`` in ``EstimatorV2``
+to be ignored (and the default value used instead).

--- a/test/unit/test_sampler_options.py
+++ b/test/unit/test_sampler_options.py
@@ -18,11 +18,18 @@ from ddt import data, ddt
 from pydantic import ValidationError
 
 from qiskit_aer.noise import NoiseModel
+from qiskit_ibm_runtime import SamplerV2 as Sampler
 from qiskit_ibm_runtime.options import SamplerOptions
 from qiskit_ibm_runtime.fake_provider import FakeManila
 
 from ..ibm_test_case import IBMTestCase
-from ..utils import dict_keys_equal, dict_paritally_equal, flat_dict_partially_equal
+from ..utils import (
+    dict_keys_equal,
+    dict_paritally_equal,
+    flat_dict_partially_equal,
+    get_mocked_backend,
+    get_primitive_inputs,
+)
 
 
 @ddt
@@ -123,3 +130,15 @@ class TestSamplerOptions(IBMTestCase):
         )
         # Make sure the structure didn't change.
         self.assertTrue(dict_keys_equal(asdict(options), asdict(SamplerOptions())))
+
+    @data(
+        {"default_shots": 0},
+        {"execution": {"rep_delay": 0.0}},
+    )
+    def test_zero_values(self, opt_dict):
+        """Test options with values of 0."""
+        backend = get_mocked_backend()
+        sampler = Sampler(backend=backend, options=opt_dict)
+        _ = sampler.run(**get_primitive_inputs(sampler))
+        options = backend.service.run.call_args.kwargs["inputs"]["options"]
+        self.assertDictEqual(options, opt_dict)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is a copy of #1541 but with tests. I opened this as a separate PR because I couldn't push to @t-imamichi's repo. 

### Details and comments
Fixes #

