### PR TITLE
feat: Add qctrl validation for Primitives v2

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -30,7 +30,7 @@ from .ibm_backend import IBMBackend
 from .options import Options
 from .options.estimator_options import EstimatorOptions
 from .base_primitive import BasePrimitiveV1, BasePrimitiveV2
-from .utils.qctrl import validate as qctrl_validate,
+from .utils.qctrl import validate as qctrl_validate
 from .utils.qctrl import validate_v2 as qctrl_validate_v2
 
 

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -30,7 +30,8 @@ from .ibm_backend import IBMBackend
 from .options import Options
 from .options.estimator_options import EstimatorOptions
 from .base_primitive import BasePrimitiveV1, BasePrimitiveV2
-from .utils.qctrl import validate as qctrl_validate
+from .utils.qctrl import validate as qctrl_validate,
+from .utils.qctrl import validate_v2 as qctrl_validate_v2
 
 
 # pylint: disable=unused-import,cyclic-import
@@ -130,9 +131,6 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
         Estimator.__init__(self)
         BasePrimitiveV2.__init__(self, backend=backend, session=session, options=options)
 
-        if self._service._channel_strategy == "q-ctrl":
-            raise NotImplementedError("EstimatorV2 is not supported with q-ctrl channel strategy.")
-
     def run(
         self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None
     ) -> RuntimeJobV2:
@@ -159,6 +157,11 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
             ValidationError: if validation fails.
             ValueError: if validation fails.
         """
+
+        if self._service._channel_strategy == "q-ctrl":
+            qctrl_validate_v2(options)
+            return
+
         if (
             options.get("resilience", {}).get("pec_mitigation", False) is True
             and self._backend is not None

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -32,6 +32,7 @@ from .base_primitive import BasePrimitiveV1, BasePrimitiveV2
 # pylint: disable=unused-import,cyclic-import
 from .session import Session
 from .utils.qctrl import validate as qctrl_validate
+from .utils.qctrl import validate_v2 as qctrl_validate_v2
 from .options import SamplerOptions
 
 logger = logging.getLogger(__name__)
@@ -90,9 +91,6 @@ class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
         Sampler.__init__(self)
         BasePrimitiveV2.__init__(self, backend=backend, session=session, options=options)
 
-        if self._service._channel_strategy == "q-ctrl":
-            raise NotImplementedError("SamplerV2 is not supported with q-ctrl channel strategy.")
-
     def run(self, pubs: Iterable[SamplerPubLike], *, shots: int | None = None) -> RuntimeJobV2:
         """Submit a request to the sampler primitive.
 
@@ -128,7 +126,10 @@ class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
         Raises:
             ValidationError: if validation fails.
         """
-        pass
+
+        if self._service._channel_strategy == "q-ctrl":
+            qctrl_validate_v2(options)
+            return
 
     @classmethod
     def _program_id(cls) -> str:

--- a/qiskit_ibm_runtime/utils/qctrl.py
+++ b/qiskit_ibm_runtime/utils/qctrl.py
@@ -83,7 +83,85 @@ def _warn_and_clean_options(options: Dict[str, Any]) -> None:
         },
     }
 
-    # Collect keys with miss-matching values
+    # Collect keys with mis-matching values
+    different_keys = _validate_values(expected_options, options)
+    # Override options
+    _update_values(expected_options, options)
+    if different_keys:
+        logger.warning(
+            "The following settings cannot be customized and will be overwritten: %s",
+            ",".join(sorted(different_keys)),
+        )
+
+
+def validate_v2(options: Dict[str, Any]) -> None:
+    """Validates the options for qctrl"""
+
+    # Raise error on bad options.
+    _raise_if_error_in_options_v2(options)
+    # Override options and warn.
+    _warn_and_clean_options_v2(options)
+
+    # Default validation otherwise.
+    TranspilationOptions(**options.get("transpilation", {}))
+    execution_time = options.get("max_execution_time")
+    if execution_time is not None:
+        if execution_time > Options._MAX_EXECUTION_TIME:
+            raise ValueError(
+                f"max_execution_time must be below " f"{Options._MAX_EXECUTION_TIME} seconds."
+            )
+
+    EnvironmentOptions(**options.get("environment", {}))
+    ExecutionOptions(**options.get("execution", {}))
+    SimulatorOptions(**options.get("simulator", {}))
+
+
+def _raise_if_error_in_options_v2(options: Dict[str, Any]) -> None:
+    """Checks for settings that produce errors and raise a ValueError"""
+
+    # Fail on resilience_level set to 0
+    resilience_level = options.get("resilience_level", 1)
+    _check_argument(
+        resilience_level > 0,
+        description=(
+            "Q-CTRL Primitives do not support resilience level 0. Please "
+            "set resilience_level to 1 and re-try"
+        ),
+        arguments={},
+    )
+
+    optimization_level = options.get("optimization_level", 1)
+    _check_argument(
+        optimization_level > 0,
+        description="Q-CTRL Primitives do not support optimization level 0. Please\
+        set optimization_level to 1 and re-try",
+        arguments={},
+    )
+
+
+def _warn_and_clean_options_v2(options: Dict[str, Any]) -> None:
+    """
+    Validate and update transpilation settings
+    """
+    # Issue a warning and override if any of these setting is not None
+    # or a different value than the default below
+    expected_options = {
+        "optimization_level": 1,
+        "resilience_level": 1,
+        "resilience": {
+            "measure_mitigation": None,
+            "measure_noise_learning": None,
+            "zne_mitigation": None,
+            "zne": None,
+            "pec_mitigation": None,
+            "pec": None,
+            "layer_noise_learning": None,
+        },
+        "twirling": None,
+        "dynamical_decoupling": None,
+    }
+
+    # Collect keys with mis-matching values
     different_keys = _validate_values(expected_options, options)
     # Override options
     _update_values(expected_options, options)

--- a/qiskit_ibm_runtime/utils/qctrl.py
+++ b/qiskit_ibm_runtime/utils/qctrl.py
@@ -17,6 +17,7 @@ from typing import Any, Optional, Dict, List
 
 from ..options import Options
 from ..options import EnvironmentOptions, ExecutionOptions, TranspilationOptions, SimulatorOptions
+from ..options.utils import UnsetType
 
 logger = logging.getLogger(__name__)
 
@@ -105,14 +106,14 @@ def validate_v2(options: Dict[str, Any]) -> None:
     # Default validation otherwise.
     TranspilationOptions(**options.get("transpilation", {}))
     execution_time = options.get("max_execution_time")
-    if execution_time is not None:
+    if execution_time is not None and not isinstance(execution_time, UnsetType):
         if execution_time > Options._MAX_EXECUTION_TIME:
             raise ValueError(
                 f"max_execution_time must be below " f"{Options._MAX_EXECUTION_TIME} seconds."
             )
 
     EnvironmentOptions(**options.get("environment", {}))
-    ExecutionOptions(**options.get("execution", {}))
+    # ExecutionOptions(**options.get("execution", {}))
     SimulatorOptions(**options.get("simulator", {}))
 
 
@@ -121,6 +122,8 @@ def _raise_if_error_in_options_v2(options: Dict[str, Any]) -> None:
 
     # Fail on resilience_level set to 0
     resilience_level = options.get("resilience_level", 1)
+    if isinstance(resilience_level, UnsetType):
+        resilience_level = 1
     _check_argument(
         resilience_level > 0,
         description=(
@@ -131,6 +134,8 @@ def _raise_if_error_in_options_v2(options: Dict[str, Any]) -> None:
     )
 
     optimization_level = options.get("optimization_level", 1)
+    if isinstance(optimization_level, UnsetType):
+        optimization_level = 1
     _check_argument(
         optimization_level > 0,
         description="Q-CTRL Primitives do not support optimization level 0. Please\
@@ -189,7 +194,7 @@ def _validate_values(
             )
         else:
             current_value = current_options.get(expected_key, None)
-            if current_value is not None and expected_value != current_value:
+            if (current_value not in (None, UnsetType)) and expected_value != current_value:
                 different_keys.append(expected_key)
     return different_keys
 

--- a/release-notes/unreleased/1550.feat.rst
+++ b/release-notes/unreleased/1550.feat.rst
@@ -1,0 +1,4 @@
+The Sampler and Estimator V2 Primitives have been enhanced to incorporate custom validation procedures when
+the channel_strategy property is set as "q-ctrl."
+This customized validation logic effectively rectifies incorrect input options and safeguards users against
+inadvertently disabling Q-CTRL's performance enhancements.

--- a/releasenotes/notes/q-ctrl-validation-primitives-v2-71c103cac4635a94.yaml
+++ b/releasenotes/notes/q-ctrl-validation-primitives-v2-71c103cac4635a94.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The Sampler and Estimator Primitives v2 have been enhanced to incorporate custom validation procedures when
+    the channel_strategy property within the :class:qiskit_ibm_runtime.QiskitRuntimeService is configured as "q-ctrl."
+    This customized validation logic effectively rectifies incorrect input options and safeguards users against
+    inadvertently disabling Q-CTRL's performance enhancements.

--- a/releasenotes/notes/q-ctrl-validation-primitives-v2-71c103cac4635a94.yaml
+++ b/releasenotes/notes/q-ctrl-validation-primitives-v2-71c103cac4635a94.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    The Sampler and Estimator Primitives v2 have been enhanced to incorporate custom validation procedures when
-    the channel_strategy property within the :class:qiskit_ibm_runtime.QiskitRuntimeService is configured as "q-ctrl."
-    This customized validation logic effectively rectifies incorrect input options and safeguards users against
-    inadvertently disabling Q-CTRL's performance enhancements.

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -676,34 +676,35 @@ class TestPrimitivesV2(IBMTestCase):
             f"{dict1} and {dict2} not partially equal.",
         )
 
-    @skip("Q-Ctrl does not support v2 yet")
     def test_qctrl_supported_values_for_options(self):
         """Test exception when options levels not supported."""
         no_resilience_options = {
-            "noise_factors": None,
-            "extrapolator": None,
+            "measure_mitigation": None,
+            "measure_noise_learning": None,
+            "zne_mitigation": None,
+            "zne": None,
+            "pec_mitigation": None,
+            "pec": None,
+            "layer_noise_learning": None,
         }
 
         options_good = [
-            # Minium working settings
+            # Minimum working settings
             {},
             # No warnings, we need resilience options here because by default they are getting populated.
             {"resilience": no_resilience_options},
-            # Arbitrary approximation degree (issues warning)
-            {"approximation_degree": 1},
             # Arbitrary resilience options(issue warning)
             {
                 "resilience_level": 1,
-                "resilience": {"noise_factors": (1, 1, 3)},
-                "approximation_degree": 1,
+                "resilience": {"measure_mitigation": True},
             },
             # Resilience level > 1 (issue warning)
             {"resilience_level": 2},
-            # Optimization level = 1,2 (issue warning)
-            {"optimization_level": 1},
+            # Optimization level = 2,3 (issue warning)
             {"optimization_level": 2},
-            # Skip transpilation level(issue warning)
-            {"skip_transpilation": True},
+            {"optimization_level": 3},
+            {"twirling": {"gates": True}},
+            {"dynamical_decoupling": "XX"},
         ]
         session = MagicMock(spec=MockSession)
         session.service._channel_strategy = "q-ctrl"
@@ -718,7 +719,6 @@ class TestPrimitivesV2(IBMTestCase):
                     else:
                         _ = inst.run(self.circ, **options)
 
-    @skip("Q-Ctrl does not support v2 yet")
     def test_qctrl_unsupported_values_for_options(self):
         """Test exception when options levels are not supported."""
         options_bad = [

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -23,11 +23,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.quantum_info import SparsePauliOp
 
-from qiskit_ibm_runtime import (
-    Sampler,
-    Estimator,
-    Session,
-)
+from qiskit_ibm_runtime import Session
 from qiskit_ibm_runtime.utils.default_session import _DEFAULT_SESSION
 from qiskit_ibm_runtime import EstimatorV2, SamplerV2
 from qiskit_ibm_runtime.estimator import Estimator as IBMBaseEstimator
@@ -42,7 +38,6 @@ from ..utils import (
     dict_keys_equal,
     create_faulty_backend,
     combine,
-    MockSession,
     get_primitive_inputs,
     get_mocked_backend,
     bell,

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -13,7 +13,6 @@
 """Tests for primitive classes."""
 
 from dataclasses import asdict
-from unittest import skip
 from unittest.mock import MagicMock, patch
 
 from ddt import data, ddt


### PR DESCRIPTION
### Summary
- This PR introduces changes to validate inputs for qctrl's primitives v2.

### Details and comments
- Relies on the channel_strategy property
- Routes parameter validation in Primitives v2 to qctrl's logic if the q-ctrl string is found in the `channel_strategy` property
- Implements parameter validation for options in Primitives v2