### PR TITLE
Fix `BackendSamplerV2` when used with an empty classical register

### DIFF
--- a/qiskit_ibm_runtime/qiskit/primitives/backend_sampler_v2.py
+++ b/qiskit_ibm_runtime/qiskit/primitives/backend_sampler_v2.py
@@ -187,7 +187,10 @@ def _analyze_circuit(circuit: QuantumCircuit) -> tuple[list[_MeasureInfo], int]:
     for creg in circuit.cregs:
         name = creg.name
         num_bits = creg.size
-        start = circuit.find_bit(creg[0]).index
+        if num_bits != 0:
+            start = circuit.find_bit(creg[0]).index
+        else:
+            start = 0
         meas_info.append(
             _MeasureInfo(
                 creg_name=name,

--- a/test/unit/qiskit/test_backend_sampler_v2.py
+++ b/test/unit/qiskit/test_backend_sampler_v2.py
@@ -655,6 +655,21 @@ class TestBackendSamplerV2(IBMTestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0].data), 0)
 
+    @combine(backend=BACKENDS)
+    def test_empty_creg(self, backend):
+        """Test that the sampler works if provided a classical register with no bits."""
+        # Test case for issue #12043
+        q = QuantumRegister(1, "q")
+        c1 = ClassicalRegister(0, "c1")
+        c2 = ClassicalRegister(1, "c2")
+        qc = QuantumCircuit(q, c1, c2)
+        qc.h(0)
+        qc.measure(0, 0)
+
+        sampler = BackendSamplerV2(backend=backend, options=self._options)
+        result = sampler.run([qc], shots=self._shots).result()
+        self.assertEqual(result[0].data.c1.array.shape, (self._shots, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is a port of https://github.com/Qiskit/qiskit/pull/12055 to this repository, since the current repository has its own fork of `BackendSamplerV2` until Qiskit 1.1 is released (#1523).

### Details and comments
I would appreciate if this fix could be backported to the stable branch as well.

