### PR TITLE
Allow user-specified function for producing a block ordering

### DIFF
--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py
@@ -93,10 +93,9 @@ class BlockBasePadder(TransformationPass):
         self._idle_qubits: Set[Qubit] = set()
 
         # Block ordering callable
-        if block_ordering_callable is None:
-            self._block_ordering_callable = block_order_op_nodes
-        else:
-            self._block_ordering_callable = block_ordering_callable
+        self._block_ordering_callable = (
+            block_order_op_nodes if block_ordering_callable is None else block_ordering_callable
+        )
 
         super().__init__()
 

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -34,6 +34,7 @@ except ImportError:
     from qiskit.synthesis import OneQubitEulerDecomposer
 
 from .block_base_padder import BlockBasePadder
+from .utils import BlockOrderingCallableType
 
 
 class PadDynamicalDecoupling(BlockBasePadder):
@@ -127,6 +128,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
         alt_spacings: Optional[Union[List[List[float]], List[float]]] = None,
         schedule_idle_qubits: bool = False,
         dd_barrier: Optional[str] = None,
+        block_ordering_callable: Optional[BlockOrderingCallableType] = None,
     ):
         """Dynamical decoupling initializer.
 
@@ -184,6 +186,8 @@ class PadDynamicalDecoupling(BlockBasePadder):
                 for execution on large backends.
             dd_barrier: only apply DD to delays terminating with a barrier
                 whose label contains the specified string
+            block_ordering_callable: A callable used to produce an ordering of the nodes to minimize the
+                number of blocks needed. If not provided, a potentially slow but performant algorithm is used.
         Raises:
             TranspilerError: When invalid DD sequence is specified.
             TranspilerError: When pulse gate with the duration which is
@@ -191,7 +195,10 @@ class PadDynamicalDecoupling(BlockBasePadder):
             TranspilerError: When the coupling map is not supported (i.e., if degree > 3)
         """
 
-        super().__init__(schedule_idle_qubits=schedule_idle_qubits)
+        super().__init__(
+            schedule_idle_qubits=schedule_idle_qubits,
+            block_ordering_callable=block_ordering_callable,
+        )
         self._durations = durations
 
         # Enforce list of DD sequences

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -187,7 +187,8 @@ class PadDynamicalDecoupling(BlockBasePadder):
             dd_barrier: only apply DD to delays terminating with a barrier
                 whose label contains the specified string
             block_ordering_callable: A callable used to produce an ordering of the nodes to minimize the
-                number of blocks needed. If not provided, a potentially slow but performant algorithm is used.
+                number of blocks needed. If not provided, a potentially slow but performant algorithm is
+                used.
         Raises:
             TranspilerError: When invalid DD sequence is specified.
             TranspilerError: When pulse gate with the duration which is

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -187,8 +187,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
             dd_barrier: only apply DD to delays terminating with a barrier
                 whose label contains the specified string
             block_ordering_callable: A callable used to produce an ordering of the nodes to minimize the
-                number of blocks needed. If not provided, a potentially slow but performant algorithm is
-                used.
+                number of blocks needed. If not provided, :func:`~block_order_op_nodes` will be used.
         Raises:
             TranspilerError: When invalid DD sequence is specified.
             TranspilerError: When pulse gate with the duration which is

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py
@@ -12,12 +12,15 @@
 
 """Padding pass to insert Delay into empty timeslots for dynamic circuit backends."""
 
+from typing import Optional
+
 from qiskit.circuit import Qubit
 from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGNode, DAGOutNode
 from qiskit.transpiler.instruction_durations import InstructionDurations
 
 from .block_base_padder import BlockBasePadder
+from .utils import BlockOrderingCallableType
 
 
 class PadDelay(BlockBasePadder):
@@ -56,6 +59,7 @@ class PadDelay(BlockBasePadder):
         durations: InstructionDurations,
         fill_very_end: bool = True,
         schedule_idle_qubits: bool = False,
+        block_ordering_callable: Optional[BlockOrderingCallableType] = None,
     ):
         """Create new padding delay pass.
 
@@ -65,8 +69,13 @@ class PadDelay(BlockBasePadder):
             schedule_idle_qubits: Set to true if you'd like a delay inserted on idle qubits.
                 This is useful for timeline visualizations, but may cause issues for execution
                 on large backends.
+            block_ordering_callable: A callable used to produce an ordering of the nodes to minimize the
+                number of blocks needed. If not provided, a potentially slow but performant algorithm is used.
         """
-        super().__init__(schedule_idle_qubits=schedule_idle_qubits)
+        super().__init__(
+            schedule_idle_qubits=schedule_idle_qubits,
+            block_ordering_callable=block_ordering_callable,
+        )
         self._durations = durations
         self.fill_very_end = fill_very_end
 

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py
@@ -70,8 +70,8 @@ class PadDelay(BlockBasePadder):
                 This is useful for timeline visualizations, but may cause issues for execution
                 on large backends.
             block_ordering_callable: A callable used to produce an ordering of the nodes to minimize
-                the number of blocks needed. If not provided, a potentially slow but performant
-                algorithm is used.
+                the number of blocks needed. If not provided, :func:`~block_order_op_nodes` will be
+                used.
         """
         super().__init__(
             schedule_idle_qubits=schedule_idle_qubits,

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py
@@ -69,8 +69,9 @@ class PadDelay(BlockBasePadder):
             schedule_idle_qubits: Set to true if you'd like a delay inserted on idle qubits.
                 This is useful for timeline visualizations, but may cause issues for execution
                 on large backends.
-            block_ordering_callable: A callable used to produce an ordering of the nodes to minimize the
-                number of blocks needed. If not provided, a potentially slow but performant algorithm is used.
+            block_ordering_callable: A callable used to produce an ordering of the nodes to minimize
+                the number of blocks needed. If not provided, a potentially slow but performant
+                algorithm is used.
         """
         super().__init__(
             schedule_idle_qubits=schedule_idle_qubits,

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
@@ -57,8 +57,9 @@ class BaseDynamicCircuitAnalysis(TransformationPass):
 
         Args:
             durations: Durations of instructions to be used in scheduling.
-            block_ordering_callable: A callable used to produce an ordering of the nodes to minimize the
-                number of blocks needed. If not provided, a potentially slow but performant algorithm is used.
+            block_ordering_callable: A callable used to produce an ordering of the nodes to minimize
+                the number of blocks needed. If not provided, a potentially slow but performant
+                algorithm is used.
         """
         self._durations = durations
         if block_ordering_callable is None:

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
@@ -62,10 +62,9 @@ class BaseDynamicCircuitAnalysis(TransformationPass):
                 algorithm is used.
         """
         self._durations = durations
-        if block_ordering_callable is None:
-            self._block_ordering_callable = block_order_op_nodes
-        else:
-            self._block_ordering_callable = block_ordering_callable
+        self._block_ordering_callable = (
+            block_order_op_nodes if block_ordering_callable is None else block_ordering_callable
+        )
 
         self._dag: Optional[DAGCircuit] = None
         self._block_dag: Optional[DAGCircuit] = None

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
@@ -58,8 +58,8 @@ class BaseDynamicCircuitAnalysis(TransformationPass):
         Args:
             durations: Durations of instructions to be used in scheduling.
             block_ordering_callable: A callable used to produce an ordering of the nodes to minimize
-                the number of blocks needed. If not provided, a potentially slow but performant
-                algorithm is used.
+                the number of blocks needed. If not provided, :func:`~block_order_op_nodes` will be
+                used.
         """
         self._durations = durations
         self._block_ordering_callable = (

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py
@@ -27,7 +27,7 @@ from qiskit.circuit.bit import Bit
 from qiskit.dagcircuit import DAGCircuit, DAGNode
 from qiskit.transpiler.exceptions import TranspilerError
 
-from .utils import block_order_op_nodes
+from .utils import BlockOrderingCallableType, block_order_op_nodes
 
 
 class BaseDynamicCircuitAnalysis(TransformationPass):
@@ -49,14 +49,22 @@ class BaseDynamicCircuitAnalysis(TransformationPass):
     """
 
     def __init__(
-        self, durations: qiskit.transpiler.instruction_durations.InstructionDurations
+        self,
+        durations: qiskit.transpiler.instruction_durations.InstructionDurations,
+        block_ordering_callable: Optional[BlockOrderingCallableType] = None,
     ) -> None:
         """Scheduler for dynamic circuit backends.
 
         Args:
             durations: Durations of instructions to be used in scheduling.
+            block_ordering_callable: A callable used to produce an ordering of the nodes to minimize the
+                number of blocks needed. If not provided, a potentially slow but performant algorithm is used.
         """
         self._durations = durations
+        if block_ordering_callable is None:
+            self._block_ordering_callable = block_order_op_nodes
+        else:
+            self._block_ordering_callable = block_ordering_callable
 
         self._dag: Optional[DAGCircuit] = None
         self._block_dag: Optional[DAGCircuit] = None
@@ -102,7 +110,7 @@ class BaseDynamicCircuitAnalysis(TransformationPass):
         self._time_unit_converter.run(block)
         self._begin_new_circuit_block()
 
-        for node in block_order_op_nodes(block):
+        for node in self._block_ordering_callable(block):
             self._visit_node(node)
 
         # Final flush

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
@@ -27,7 +27,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.providers import Backend, BackendV1
 
 
-BlockOrderingCallableType = Callable[List[DAGCircuit], Generator[DAGOpNode, None, None]]
+BlockOrderingCallableType = Callable[[DAGCircuit], Generator[DAGOpNode, None, None]]
 
 
 def block_order_op_nodes(dag: DAGCircuit) -> Generator[DAGOpNode, None, None]:

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
@@ -13,7 +13,7 @@
 """Utility functions for scheduling passes."""
 
 import warnings
-from typing import Callable, Generator, Optional, Tuple, Union
+from typing import Callable, Generator, List, Optional, Tuple, Union
 from functools import lru_cache
 
 from qiskit.circuit import ControlFlowOp, Measure, Reset, Parameter
@@ -27,7 +27,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.providers import Backend, BackendV1
 
 
-BlockOrderingCallableType = Callable[DAGCircuit, Generator[DAGOpNode, None, None]]
+BlockOrderingCallableType = Callable[List[DAGCircuit], Generator[DAGOpNode, None, None]]
 
 
 def block_order_op_nodes(dag: DAGCircuit) -> Generator[DAGOpNode, None, None]:

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
@@ -13,7 +13,7 @@
 """Utility functions for scheduling passes."""
 
 import warnings
-from typing import Generator, Optional, Tuple, Union
+from typing import Callable, Generator, Optional, Tuple, Union
 from functools import lru_cache
 
 from qiskit.circuit import ControlFlowOp, Measure, Reset, Parameter
@@ -25,6 +25,9 @@ from qiskit.transpiler.instruction_durations import (
 from qiskit.transpiler.target import Target
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.providers import Backend, BackendV1
+
+
+BlockOrderingCallableType = Callable[DAGCircuit, Generator[DAGOpNode, None, None]]
 
 
 def block_order_op_nodes(dag: DAGCircuit) -> Generator[DAGOpNode, None, None]:

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
@@ -13,7 +13,7 @@
 """Utility functions for scheduling passes."""
 
 import warnings
-from typing import Callable, Generator, List, Optional, Tuple, Union
+from typing import Callable, Generator, Optional, Tuple, Union
 from functools import lru_cache
 
 from qiskit.circuit import ControlFlowOp, Measure, Reset, Parameter

--- a/release-notes/unreleased/1531.feat.rst
+++ b/release-notes/unreleased/1531.feat.rst
@@ -1,5 +1,5 @@
-Add ``block_ordering_callable: Optional[BlockOrderingCallableType]`` argument to ``BlockBasePadder``,
-``PadDynamicalDecoupling``, ``PadDelay``, and ``BaseDynamicCircuitAnalysis``. This allows the user
+Add `block_ordering_callable: Optional[BlockOrderingCallableType]` argument to `BlockBasePadder`,
+`PadDynamicalDecoupling`, `PadDelay``, and `BaseDynamicCircuitAnalysis`. This allows the user
 to construct blocks using an algorithm of their choosing. No assumptions or checks are made on the
-validity of the output that the block_ordering_callable produces. The motivation for this argument is
-that for some families of circuits, the existing function ``block_order_op_nodes`` can be very slow.
+validity of the output that the `block_ordering_callable` produces. The motivation for this argument is
+that for some families of circuits, the existing function `block_order_op_nodes` can be very slow.

--- a/release-notes/unreleased/1531.feat.rst
+++ b/release-notes/unreleased/1531.feat.rst
@@ -1,0 +1,5 @@
+Add ``block_ordering_callable: Optional[BlockOrderingCallableType]`` argument to ``BlockBasePadder``,
+``PadDynamicalDecoupling``, ``PadDelay``, and ``BaseDynamicCircuitAnalysis``. This allows the user
+to construct blocks using an algorithm of their choosing. No assumptions or checks are made on the
+validity of the output that the block_ordering_callable produces. The motivation for this argument is
+that for some families of circuits, the existing function ``block_order_op_nodes`` can be very slow.

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -116,18 +116,31 @@ class TestPadDynamicalDecoupling(IBMTestCase):
 
         self.assertEqual(ghz4_dd, expected)
 
-    def test_insert_dd_ghz_one_qubit(self):
+    @data(True, False)
+    def test_insert_dd_ghz_one_qubit(self, use_topological_ordering):
         """Test DD gates are inserted on only one qubit."""
         dd_sequence = [XGate(), XGate()]
+
+        if use_topological_ordering:
+            def _top_ord(dag):
+                return dag.topological_op_nodes()
+            block_ordering_callable = _top_ord
+        else:
+            block_ordering_callable = None
+
         pm = PassManager(
             [
-                ASAPScheduleAnalysis(self.durations),
+                ASAPScheduleAnalysis(
+                    durations=self.durations,
+                    block_ordering_callable=block_ordering_callable,
+                ),
                 PadDynamicalDecoupling(
                     self.durations,
                     dd_sequence,
                     qubits=[0],
                     pulse_alignment=1,
                     schedule_idle_qubits=True,
+                    block_ordering_callable=block_ordering_callable,
                 ),
             ]
         )
@@ -244,17 +257,30 @@ class TestPadDynamicalDecoupling(IBMTestCase):
 
         self.assertEqual(ghz4_dd, expected)
 
-    def test_insert_midmeas_hahn(self):
+    @data(True, False)
+    def test_insert_midmeas_hahn(self, use_topological_ordering):
         """Test a single X gate as Hahn echo can absorb in the upstream circuit."""
         dd_sequence = [RXGate(pi / 4)]
+
+        if use_topological_ordering:
+            def _top_ord(dag):
+                return dag.topological_op_nodes()
+            block_ordering_callable = _top_ord
+        else:
+            block_ordering_callable = None
+
         pm = PassManager(
             [
-                ASAPScheduleAnalysis(self.durations),
+                ASAPScheduleAnalysis(
+                    durations=self.durations,
+                    block_ordering_callable=block_ordering_callable,
+                ),
                 PadDynamicalDecoupling(
                     self.durations,
                     dd_sequence,
                     pulse_alignment=1,
                     schedule_idle_qubits=True,
+                    block_ordering_callable=block_ordering_callable,
                 ),
             ]
         )

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -122,8 +122,10 @@ class TestPadDynamicalDecoupling(IBMTestCase):
         dd_sequence = [XGate(), XGate()]
 
         if use_topological_ordering:
+
             def _top_ord(dag):
                 return dag.topological_op_nodes()
+
             block_ordering_callable = _top_ord
         else:
             block_ordering_callable = None
@@ -263,8 +265,10 @@ class TestPadDynamicalDecoupling(IBMTestCase):
         dd_sequence = [RXGate(pi / 4)]
 
         if use_topological_ordering:
+
             def _top_ord(dag):
                 return dag.topological_op_nodes()
+
             block_ordering_callable = _top_ord
         else:
             block_ordering_callable = None


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR partially addresses the issue (#1531) found while profiling the DD passes used for dynamic circuits, namely that `block_order_op_nodes` is very slow for common families of circuits. The changes here expose an argument

```python
block_ordering_callable: Optional[BlockOrderingCallableType] = None
```

where

```python
BlockOrderingCallableType = Callable[DAGCircuit, Generator[DAGOpNode, None, None]]
```

in the relevant places to allow the user to construct blocks using an algorithm of their choosing. No assumptions or checks are made on the validity of the output that the `block_ordering_callable` produces. This argument is propagated to
- `BlockBasePadder`
- `PadDynamicalDecoupling`
- `PadDelay`
- `BaseDynamicCircuitAnalysis`

i.e. anywhere `block_order_op_nodes` is currently used.

### Details and comments

Partial fix for #1531 in the sense that the user can choose a potentially more performant function to construct the blocks.