### PR TITLE
Fix wording in error raised when validating options

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -169,7 +169,7 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
             and not options["simulator"]["coupling_map"]
         ):
             raise ValueError(
-                "When the backend is a simulator and resilience_level == 3,"
+                "When the backend is a simulator and pec_mitigation is enabled, "
                 "a coupling map is required."
             )
 


### PR DESCRIPTION
Fix wording in error raised when using a simulator, pec_mitigation is enabled but a coupling map has not been provided.

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Fixes #

