### PR TITLE
Add recursive nesting to HTML option table rendering

### DIFF
--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -57,10 +57,12 @@ def _make_data_row(indent: int, name: str, value: Any, is_section: bool) -> Iter
 
 
 def _iter_all_fields(
-    data_cls: Any, indent=0, dict_form=None
+    data_cls: Any, indent: int = 0, dict_form: Union[dict, None] = None
 ) -> Iterable[tuple[int, str, Any, bool]]:
     """Recursively iterate over a dataclass, yielding (indent, name, value, is_dataclass) fields."""
+    # we pass dict_form through recursion simply to avoid calling asdict() more than once
     dict_form = dict_form or asdict(data_cls)
+
     suboptions = []
     for name, val in dict_form.items():
         if is_dataclass(subopt := getattr(data_cls, name)):

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -13,7 +13,7 @@
 """Primitive options."""
 
 from abc import abstractmethod
-from typing import Iterable, Optional, Union, ClassVar, Any
+from typing import Iterable, Optional, Tuple, Union, ClassVar, Any
 from dataclasses import dataclass, fields, field, asdict, is_dataclass
 import copy
 import warnings
@@ -58,7 +58,7 @@ def _make_data_row(indent: int, name: str, value: Any, is_section: bool) -> Iter
 
 def _iter_all_fields(
     data_cls: Any, indent: int = 0, dict_form: Union[dict, None] = None
-) -> Iterable[tuple[int, str, Any, bool]]:
+) -> Iterable[Tuple[int, str, Any, bool]]:
     """Recursively iterate over a dataclass, yielding (indent, name, value, is_dataclass) fields."""
     # we pass dict_form through recursion simply to avoid calling asdict() more than once
     dict_form = dict_form or asdict(data_cls)

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -56,7 +56,9 @@ def _make_data_row(indent: int, name: str, value: Any, is_section: bool) -> Iter
     yield "  </tr>"
 
 
-def _iter_all_fields(data_cls, indent=0, dict_form=None) -> Iterable[tuple[int, str, Any, Any]]:
+def _iter_all_fields(
+    data_cls: Any, indent=0, dict_form=None
+) -> Iterable[tuple[int, str, Any, bool]]:
     """Recursively iterate over a dataclass, yielding (indent, name, value, is_dataclass) fields."""
     dict_form = dict_form or asdict(data_cls)
     suboptions = []


### PR DESCRIPTION
### Summary

This PR modifies the existing `_repr_html_` method on the options base class to support recursive nesting.
Previously, it would stop expanding sub options past the first level.

### Details and comments

Previously, I would get this for the estimator V2 options:

![image](https://github.com/Qiskit/qiskit-ibm-runtime/assets/2229105/f7b93e29-2c8a-42fc-805f-e0760c9a0beb)

With this PR I get:

![image](https://github.com/Qiskit/qiskit-ibm-runtime/assets/2229105/dd0774e7-4beb-448e-92ab-c78362597c11)
 
 
 Sampler V2 demo:
 
 
![image](https://github.com/Qiskit/qiskit-ibm-runtime/assets/2229105/67034cbc-6260-43cb-aaa2-09fd4928fdb0)


V1 demo:

![image](https://github.com/Qiskit/qiskit-ibm-runtime/assets/2229105/4e248fed-6d31-4caf-9675-c190d9119b43)


