### PR TITLE
ZNE options validation fix

### DIFF
--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -53,6 +53,14 @@ class ZneOptions:
     noise_factors: Union[UnsetType, Sequence[float]] = Unset
     extrapolator: Union[UnsetType, ExtrapolatorType, Sequence[ExtrapolatorType]] = Unset
 
+    @classmethod
+    def _default_noise_factors(cls):
+        return (1, 3, 5)
+
+    @classmethod
+    def _default_extrapolator(cls):
+        return ("exponential", "linear")
+
     @field_validator("noise_factors")
     @classmethod
     @skip_unset_validation
@@ -65,24 +73,29 @@ class ZneOptions:
     @model_validator(mode="after")
     def _validate_options(self) -> "ZneOptions":
         """Check that there are enough noise factors for all extrapolators."""
-        if self.extrapolator and self.noise_factors:
-            required_factors = {
-                "linear": 2,
-                "exponential": 2,
-                "double_exponential": 4,
-            }
-            for idx in range(1, 8):
-                required_factors[f"polynomial_degree_{idx}"] = idx + 1
+        noise_factors = (
+            self.noise_factors if self.noise_factors != Unset else self._default_noise_factors()
+        )
+        extrapolator = (
+            self.extrapolator if self.extrapolator != Unset else self._default_extrapolator()
+        )
 
-            extrapolators: Sequence = (
-                [self.extrapolator]  # type: ignore[assignment]
-                if isinstance(self.extrapolator, str)
-                else self.extrapolator
-            )
-            for extrap in extrapolators:  # pylint: disable=not-an-iterable
-                if len(self.noise_factors) < required_factors[extrap]:  # type: ignore[arg-type]
-                    raise ValueError(
-                        f"{extrap} requires at least {required_factors[extrap]} noise_factors"
-                    )
+        required_factors = {
+            "linear": 2,
+            "exponential": 2,
+            "double_exponential": 4,
+        }
+        for idx in range(1, 8):
+            required_factors[f"polynomial_degree_{idx}"] = idx + 1
 
+        extrapolators: Sequence = (
+            [extrapolator]  # type: ignore[assignment]
+            if isinstance(extrapolator, str)
+            else extrapolator
+        )
+        for extrap in extrapolators:  # pylint: disable=not-an-iterable
+            if len(noise_factors) < required_factors[extrap]:  # type: ignore[arg-type]
+                raise ValueError(
+                    f"{extrap} requires at least {required_factors[extrap]} noise_factors"
+                )
         return self

--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -54,11 +54,11 @@ class ZneOptions:
     extrapolator: Union[UnsetType, ExtrapolatorType, Sequence[ExtrapolatorType]] = Unset
 
     @classmethod
-    def _default_noise_factors(cls):
+    def _default_noise_factors(cls) -> Sequence[float]:
         return (1, 3, 5)
 
     @classmethod
-    def _default_extrapolator(cls):
+    def _default_extrapolator(cls) -> Sequence[ExtrapolatorType]:
         return ("exponential", "linear")
 
     @field_validator("noise_factors")

--- a/test/unit/test_estimator_options.py
+++ b/test/unit/test_estimator_options.py
@@ -90,9 +90,9 @@ class TestEstimatorOptions(IBMTestCase):
     )
     def test_bad_inputs(self, val):
         """Test invalid inputs."""
-        input, error_msg = val
+        bad_input, error_msg = val
         with self.assertRaisesRegex(ValidationError, error_msg):
-            EstimatorOptions(**input)
+            EstimatorOptions(**bad_input)
 
     def test_program_inputs(self):
         """Test converting to program inputs from estimator options."""

--- a/test/unit/test_estimator_options.py
+++ b/test/unit/test_estimator_options.py
@@ -37,24 +37,62 @@ class TestEstimatorOptions(IBMTestCase):
     """Class for testing the EstimatorOptions class."""
 
     @data(
-        {"optimization_level": 99},
-        {"resilience_level": -1},
-        {"default_precision": 0},
-        {"dynamical_decoupling": "foo"},
-        {"execution": {"init_qubits": 2}},
-        {"twirling": {"strategy": "foo"}},
-        {"resilience": {"zne": {"noise_factors": [0.5]}}},
-        {"noise_factors": [1, 3, 5]},
-        {"zne_mitigation": True, "pec_mitigation": True},
-        {"simulator": {"noise_model": "foo"}},
-        {"resilience": {"measure_noise_learning": {"num_randomizations": 1}}},
-        {"resilience": {"zne": {"noise_factors": [1]}}},
+        ({"optimization_level": 99}, "optimization_level must be <=1"),
+        ({"resilience_level": -1}, "resilience_level must be >=0"),
+        ({"default_precision": 0}, "default_precision must be >0"),
+        (
+            {"dynamical_decoupling": "foo"},
+            "Input should be a dictionary or an instance of DynamicalDecouplingOptions",
+        ),
+        ({"execution": {"init_qubits": 2}}, "Input should be a valid boolean"),
+        (
+            {"twirling": {"strategy": "foo"}},
+            "Input should be 'active', 'active-accum', 'active-circuit' or 'all'",
+        ),
+        (
+            {"resilience": {"zne": {"noise_factors": [0.5]}}},
+            "noise_factors` option value must all be >= 1",
+        ),
+        ({"noise_factors": [1, 3, 5]}, "Unexpected keyword argument"),
+        (
+            {"resilience": {"zne_mitigation": True, "pec_mitigation": True}},
+            "pec_mitigation and zne_mitigation`options cannot be simultaneously enabled",
+        ),
+        (
+            {"simulator": {"noise_model": "foo"}},
+            "'noise_model' can only be a dictionary or qiskit_aer.noise.NoiseModel",
+        ),
+        (
+            {"resilience": {"measure_noise_learning": {"num_randomizations": 1}}},
+            "'measure_noise_learning' options are set, but 'measure_mitigation' is not set to True",
+        ),
+        (
+            {
+                "resilience": {
+                    "measure_mitigation": True,
+                    "measure_noise_learning": {"num_randomizations": 0},
+                }
+            },
+            "num_randomizations must be >=1",
+        ),
+        (
+            {"resilience": {"zne_mitigation": True, "zne": {"noise_factors": [1]}}},
+            "exponential requires at least 2 noise_factors",
+        ),
+        (
+            {"resilience": {"zne_mitigation": True, "zne": {"noise_factors": []}}},
+            "exponential requires at least 2 noise_factors",
+        ),
+        (
+            {"resilience": {"zne": {"noise_factors": [1, 3, 5]}}},
+            "'zne' options are set, but 'zne_mitigation' is not set to True",
+        ),
     )
     def test_bad_inputs(self, val):
         """Test invalid inputs."""
-        with self.assertRaises(ValidationError) as exc:
-            EstimatorOptions(**val)
-        self.assertIn(list(val.keys())[0], str(exc.exception))
+        input, error_msg = val
+        with self.assertRaisesRegex(ValidationError, error_msg):
+            EstimatorOptions(**input)
 
     def test_program_inputs(self):
         """Test converting to program inputs from estimator options."""


### PR DESCRIPTION
### Summary
This PR fixes some error in the way ZNE options are validated and tested.


### Details and comments
Currently, ZNE validation and testing have the following problems:
1. The `_validate_zne_noise_factors` method passes in the case the noise factors are the empty list `[]` although this is an invalid input, since the initial check `if self.extrapolator and self.noise_factors` considers `self.noise_factors` to be `False` in case it is an empty list.
2. ZNE tests pass for wrong reason. e.g. for `{"resilience": {"zne": {"noise_factors": [1]}}}` the `test_bad_inputs` test succeeds because `ValidationError` is thrown even though the intended error (not enough noise factors) is not tested, since this error is masked by the error of not having `zne_mitigation: True` in the resilience dictionary.

These problems are handled in the following manner:

1.  `_validate_zne_noise_factors` now never skips. If noise factors or extrapolators are missing, it uses the default values described in the class's file.
2. `test_bad_inputs` now uses `assertRaisesRegex` with relevant error message for each test case, to avoid passing when irrelevant exceptions are thrown.
3. Another tests were added to `test_bad_inputs` for the case of empty noise factors list and for the case of missing `zne_mitigation: True`.
