### PR TITLE
Level 1 measurement support in Sampler options

### DIFF
--- a/qiskit_ibm_runtime/options/sampler_execution_options.py
+++ b/qiskit_ibm_runtime/options/sampler_execution_options.py
@@ -12,7 +12,7 @@
 
 """Sampler Execution options."""
 from typing import Literal, Union
-from . import ExecutionOptionsV2
+from .execution_options import ExecutionOptionsV2
 from .utils import primitive_dataclass, Unset, UnsetType
 
 
@@ -40,5 +40,6 @@ class SamplerExecutionOptionsV2(ExecutionOptionsV2):
       averaging over shots) in arbitrary units. This option is equivalent to selecting
       ``"kerneled"`` and then averaging over the shots axis, but requires less data bandwidth.
 
-    See `Here <https://pubs.aip.org/aip/rsi/article/88/10/104703/836456>`_ for a description of kerneling.
+    See `Here <https://pubs.aip.org/aip/rsi/article/88/10/104703/836456>`_ for 
+    a description of kerneling.
     """

--- a/qiskit_ibm_runtime/options/sampler_execution_options.py
+++ b/qiskit_ibm_runtime/options/sampler_execution_options.py
@@ -40,5 +40,5 @@ class SamplerExecutionOptionsV2(ExecutionOptionsV2):
       averaging over shots) in arbitrary units. This option is equivalent to selecting
       ``"kerneled"`` and then averaging over the shots axis, but requires less data bandwidth.
 
-    See https://pubs.aip.org/aip/rsi/article/88/10/104703/836456 for a description of kerneling.
+    See `Here <https://pubs.aip.org/aip/rsi/article/88/10/104703/836456>`_ for a description of kerneling.
     """

--- a/qiskit_ibm_runtime/options/sampler_execution_options.py
+++ b/qiskit_ibm_runtime/options/sampler_execution_options.py
@@ -1,0 +1,44 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Sampler Execution options."""
+from typing import Literal, Union
+from . import ExecutionOptionsV2
+from .utils import primitive_dataclass, Unset, UnsetType
+
+
+@primitive_dataclass
+class SamplerExecutionOptionsV2(ExecutionOptionsV2):
+    r"""Extension of :class:~.ExecutionOptionsV2` for the sampler primitive."""
+
+    meas_type: Union[UnsetType, Literal["classified", "kerneled", "avg_kerneled"]] = Unset
+    r"""How to process and return measurement results.
+
+    This option sets the return type of all classical registers in all :class:`~.PubResult`\s.
+    If a sampler pub with shape ``pub_shape`` has a circuit that contains a classical register 
+    with size ``creg_size``, then the returned data associated with this register will have one of
+    the following formats depending on the value of this option.
+
+    * ``"classified"``: A :class:`~.BitArray` of shape ``pub_shape`` over ``num_shots`` with a 
+      number of bits equal to ``creg_size``.
+
+    * ``"kerneled"``: A complex NumPy array of shape ``(*pub_shape, num_shots, creg_size)``, where
+      each entry represents an IQ data point (resulting from kerneling the measurement trace) in 
+      arbitrary units.
+
+    * ``"avg_kerneled"``: A complex NumPy array of shape ``(*pub_shape, creg_size)``, where
+      each entry represents an IQ data point (resulting from kerneling the measurement trace and 
+      averaging over shots) in arbitrary units. This option is equivalent to selecting
+      ``"kerneled"`` and then averaging over the shots axis, but requires less data bandwidth.
+
+    See https://pubs.aip.org/aip/rsi/article/88/10/104703/836456 for a description of kerneling.
+    """

--- a/qiskit_ibm_runtime/options/sampler_options.py
+++ b/qiskit_ibm_runtime/options/sampler_options.py
@@ -17,7 +17,7 @@ from typing import Union
 from pydantic import Field
 
 from .utils import Dict, Unset, UnsetType
-from .execution_options import ExecutionOptionsV2
+from .sampler_execution_options import SamplerExecutionOptionsV2
 from .options import OptionsV2
 from .utils import primitive_dataclass
 from .dynamical_decoupling_options import DynamicalDecouplingOptions
@@ -44,5 +44,7 @@ class SamplerOptions(OptionsV2):
     dynamical_decoupling: Union[DynamicalDecouplingOptions, Dict] = Field(
         default_factory=DynamicalDecouplingOptions
     )
-    execution: Union[ExecutionOptionsV2, Dict] = Field(default_factory=ExecutionOptionsV2)
+    execution: Union[SamplerExecutionOptionsV2, Dict] = Field(
+        default_factory=SamplerExecutionOptionsV2
+    )
     experimental: Union[UnsetType, dict] = Unset

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -83,7 +83,10 @@ class TestSamplerV2(IBMTestCase):
             np.testing.assert_allclose(a_pub_param_values, an_input_params)
 
     @data(
-        {"optimization_level": 4}, {"resilience_level": 1}, {"resilience": {"zne_mitigation": True}}
+        {"optimization_level": 4},
+        {"resilience_level": 1},
+        {"resilience": {"zne_mitigation": True}},
+        {"execution": {"meas_type": "unclassified"}},
     )
     def test_unsupported_values_for_sampler_options(self, opt):
         """Test exception when options levels are not supported."""

--- a/test/unit/test_sampler_options.py
+++ b/test/unit/test_sampler_options.py
@@ -49,7 +49,7 @@ class TestSamplerOptions(IBMTestCase):
         self.assertIn(list(val.keys())[0], str(exc.exception))
 
     def test_program_inputs(self):
-        """Test converting to program inputs from estimator options."""
+        """Test converting to program inputs from sampler options."""
         # pylint: disable=unexpected-keyword-arg
 
         noise_model = NoiseModel.from_backend(FakeManila())
@@ -94,7 +94,7 @@ class TestSamplerOptions(IBMTestCase):
         {"default_shots": 1000},
         {"simulator": {"seed_simulator": 42}},
         {"default_shots": 1, "environment": {"log_level": "WARNING"}},
-        {"execution": {"init_qubits": True}},
+        {"execution": {"init_qubits": True, "meas_type": "avg_kerneled"}},
         {"dynamical_decoupling": {"enable": True, "sequence_type": "XX"}},
         {"environment": {"log_level": "ERROR"}},
     )


### PR DESCRIPTION
### Summary
This PR adds support for level 1 measurement options in `SamplerV2`


### Details and comments
This PR extends `ExecutionOptionsV2` to a new class, `SamplerExecutionOptionsV2` having an additional field `meas_type` which can accept the values `"classified", "kerneled", "avg_kerneled"`, where "classified" represents the usual measurement level 2 output, and the other options represent measurement level 1 output.

Fixes part of #1554 

