### PR TITLE
Update are_circuits_dynamic behavior

### DIFF
--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -99,11 +99,11 @@ def validate_isa_circuits(circuits: Sequence[QuantumCircuit], target: Target) ->
             )
 
 
-def are_circuits_dynamic(circuits: List[QuantumCircuit]) -> bool:
+def are_circuits_dynamic(circuits: List[QuantumCircuit], qasm_default: bool = True) -> bool:
     """Checks if the input circuits are dynamic."""
     for circuit in circuits:
         if isinstance(circuit, str):
-            return False  # currently do not verify QASM inputs
+            return qasm_default  # currently do not verify QASM inputs
         for inst in circuit:
             if (
                 isinstance(inst.operation, ControlFlowOp)
@@ -123,7 +123,7 @@ def validate_no_dd_with_dynamic_circuits(circuits: List[QuantumCircuit], options
     """
     if not hasattr(options, "dynamical_decoupling") or not options.dynamical_decoupling.enable:
         return
-    if are_circuits_dynamic(circuits):
+    if are_circuits_dynamic(circuits, False):
         raise IBMInputValueError(
             "Dynamical decoupling currently cannot be used with dynamic circuits"
         )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In this [comment](https://github.com/Qiskit/qiskit-ibm-runtime/pull/1593#discussion_r1565754105), I recommended changing `are_circuits_dynamic()` behavior to return False if the input circuit is a string, so it doesn't block static circuits in QASM format. However, that would cause the existing `backend.run` to call `circuit-runner` instead of `qasm3-runner` if the input is QASM. I'm not sure that's supported by `circuit-runner`, but it's best not to make the change. 

### Details and comments
Fixes #

