### PR TITLE
Small bugfix in resilience validation

### DIFF
--- a/qiskit_ibm_runtime/options/resilience_options.py
+++ b/qiskit_ibm_runtime/options/resilience_options.py
@@ -24,7 +24,9 @@ from .pec_options import PecOptions
 from .layer_noise_learning_options import LayerNoiseLearningOptions
 
 
-NoiseAmplifierType = Literal["LocalFoldingAmplifier",]
+NoiseAmplifierType = Literal[
+    "LocalFoldingAmplifier",
+]
 ExtrapolatorType = Literal[
     "LinearExtrapolator",
     "QuadraticExtrapolator",

--- a/qiskit_ibm_runtime/options/resilience_options.py
+++ b/qiskit_ibm_runtime/options/resilience_options.py
@@ -81,16 +81,16 @@ class ResilienceOptionsV2:
     def _validate_options(self) -> "ResilienceOptionsV2":
         """Validate the model."""
         if not self.measure_mitigation and any(
-            [value != Unset for value in asdict(self.measure_noise_learning).values()]
+            value != Unset for value in asdict(self.measure_noise_learning).values()
         ):
             raise ValueError(
                 "'measure_noise_learning' options are set, but 'measure_mitigation' is not set to True."
             )
 
-        if not self.zne_mitigation and any([value != Unset for value in asdict(self.zne).values()]):
+        if not self.zne_mitigation and any(value != Unset for value in asdict(self.zne).values()):
             raise ValueError("'zne' options are set, but 'zne_mitigation' is not set to True.")
 
-        if not self.pec_mitigation and any([value != Unset for value in asdict(self.pec).values()]):
+        if not self.pec_mitigation and any(value != Unset for value in asdict(self.pec).values()):
             raise ValueError("'pec' options are set, but 'pec_mitigation' is not set to True.")
 
         # Validate not ZNE+PEC

--- a/qiskit_ibm_runtime/options/resilience_options.py
+++ b/qiskit_ibm_runtime/options/resilience_options.py
@@ -24,9 +24,7 @@ from .pec_options import PecOptions
 from .layer_noise_learning_options import LayerNoiseLearningOptions
 
 
-NoiseAmplifierType = Literal[
-    "LocalFoldingAmplifier",
-]
+NoiseAmplifierType = Literal["LocalFoldingAmplifier",]
 ExtrapolatorType = Literal[
     "LinearExtrapolator",
     "QuadraticExtrapolator",
@@ -80,15 +78,17 @@ class ResilienceOptionsV2:
     @model_validator(mode="after")
     def _validate_options(self) -> "ResilienceOptionsV2":
         """Validate the model."""
-        if not self.measure_mitigation and any(asdict(self.measure_noise_learning).values()):
+        if not self.measure_mitigation and any(
+            [value != Unset for value in asdict(self.measure_noise_learning).values()]
+        ):
             raise ValueError(
                 "'measure_noise_learning' options are set, but 'measure_mitigation' is not set to True."
             )
 
-        if not self.zne_mitigation and any(asdict(self.zne).values()):
+        if not self.zne_mitigation and any([value != Unset for value in asdict(self.zne).values()]):
             raise ValueError("'zne' options are set, but 'zne_mitigation' is not set to True.")
 
-        if not self.pec_mitigation and any(asdict(self.pec).values()):
+        if not self.pec_mitigation and any([value != Unset for value in asdict(self.pec).values()]):
             raise ValueError("'pec' options are set, but 'pec_mitigation' is not set to True.")
 
         # Validate not ZNE+PEC

--- a/test/unit/test_estimator_options.py
+++ b/test/unit/test_estimator_options.py
@@ -87,6 +87,10 @@ class TestEstimatorOptions(IBMTestCase):
             {"resilience": {"zne": {"noise_factors": [1, 3, 5]}}},
             "'zne' options are set, but 'zne_mitigation' is not set to True",
         ),
+        (
+            {"resilience": {"pec": {"max_overhead": None, "noise_gain": 0}}},
+            "'pec' options are set, but 'pec_mitigation' is not set to True",
+        ),
     )
     def test_bad_inputs(self, val):
         """Test invalid inputs."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes a bug in `ResilienceOptionsV2` where validation misses a corner case where `pec_mitigation` is `False` although pec options were passed.

### Details and comments
The bug results from the check `any(asdict(self.pec).values())` which attempts to deduce whether any pec options were passed. Since some valid options are treated as `False` by Python, this check might fail. An example was added to the unit tests:

`{"resilience": {"pec": {"max_overhead": None, "noise_gain": 0}}},`

Where both the `None` and the `0` values are valid options (requiring `pec_mitigation=True`) but both are treated as `False` by Python.

The simple solution is to explicitly compare the values to `Unset` and the check passes in there is any value different than `Unset`.

The same fix was performed for `zne` and `measure_noise_learning` options.