### PR TITLE
Raise IBMRuntimeError when session is closed

### DIFF
--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -22,7 +22,7 @@ import warnings
 from qiskit.providers.backend import BackendV1, BackendV2
 
 from qiskit_ibm_runtime import QiskitRuntimeService
-from .exceptions import IBMInputValueError
+from .exceptions import IBMInputValueError, IBMRuntimeError
 from .runtime_job import RuntimeJob
 from .runtime_job_v2 import RuntimeJobV2
 from .utils.result_decoder import ResultDecoder
@@ -39,7 +39,7 @@ def _active_session(func):  # type: ignore
     @wraps(func)
     def _wrapper(self, *args, **kwargs):  # type: ignore
         if not self._active:
-            raise RuntimeError("The session is closed.")
+            raise IBMRuntimeError("The session is closed.")
         return func(self, *args, **kwargs)
 
     return _wrapper

--- a/test/unit/test_batch.py
+++ b/test/unit/test_batch.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 from qiskit_ibm_runtime import Batch
 from qiskit_ibm_runtime.utils.default_session import _DEFAULT_SESSION
+from qiskit_ibm_runtime.exceptions import IBMRuntimeError
 
 from ..ibm_test_case import IBMTestCase
 from ..utils import get_mocked_backend
@@ -46,7 +47,7 @@ class TestBatch(IBMTestCase):
         """Test running after session is closed."""
         session = Batch(service=MagicMock(), backend="ibm_gotham")
         session.cancel()
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(IBMRuntimeError):
             session.run(program_id="program_id", inputs={})
 
     def test_context_manager(self):

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 from qiskit_ibm_runtime.fake_provider import FakeManila
 from qiskit_ibm_runtime import Session, QiskitRuntimeService
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
+from qiskit_ibm_runtime.exceptions import IBMRuntimeError
 from qiskit_ibm_runtime.utils.default_session import _DEFAULT_SESSION
 
 from .mock.fake_runtime_service import FakeRuntimeService
@@ -95,7 +96,7 @@ class TestSession(IBMTestCase):
         """Test running after session is closed."""
         session = Session(service=MagicMock(), backend="ibm_gotham")
         session.cancel()
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(IBMRuntimeError):
             session.run(program_id="program_id", inputs={})
 
     def test_run(self):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

I think it might be a good idea to also raise an `IBMRuntimeError` when a session is no longer active (or maybe at least a `QiskitError`?) in order to be able to distinguish an error related to Qiskit from any potential error happening somewhere else so you can take appropriate action such as renewing the session or saving the progress so far.