### PR TITLE
Fix URL for Qiskit Serverless

### DIFF
--- a/release-notes/0.14.0.rst
+++ b/release-notes/0.14.0.rst
@@ -17,6 +17,6 @@ Deprecation Notes
 
 -  Custom programs are being deprecated as of qiskit-ibm-runtime 0.14.0
    and will be removed on November 27, 2023. Users can instead convert
-   their custom programs to use Qiskit Runtime primitives with Quantum
+   their custom programs to use Qiskit Runtime primitives with Qiskit
    Serverless. Refer to the migration guide for instructions:
-   https://qiskit-extensions.github.io/quantum-serverless/migration/migration_from_qiskit_runtime_programs.html
+   https://qiskit-extensions.github.io/qiskit-serverless/migration/migration_from_qiskit_runtime_programs.html


### PR DESCRIPTION
The docs and name recently changed from Quantum Serverless to Qiskit Serverless.