### PR TITLE
Update tests to not assume DataBins are dataclasses

### DIFF
--- a/test/integration/test_sampler_v2.py
+++ b/test/integration/test_sampler_v2.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import unittest
-from dataclasses import astuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -514,7 +513,7 @@ class TestSampler(IBMIntegrationTestCase):
                     result = sampler.run([qc]).result()
                     self.assertEqual(len(result), 1)
                     data = result[0].data
-                    self.assertEqual(len(astuple(data)), 3)
+                    self.assertEqual(len(data._FIELDS), 3)
                     for creg in qc.cregs:
                         self.assertTrue(hasattr(data, creg.name))
                         self._assert_allclose(getattr(data, creg.name), np.array(target[creg.name]))

--- a/test/unit/qiskit/test_backend_sampler_v2.py
+++ b/test/unit/qiskit/test_backend_sampler_v2.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import unittest
-from dataclasses import astuple
 
 import numpy as np
 from ddt import ddt
@@ -621,7 +620,7 @@ class TestBackendSamplerV2(IBMTestCase):
                 result = sampler.run([qc], shots=self._shots).result()
                 self.assertEqual(len(result), 1)
                 data = result[0].data
-                self.assertEqual(len(astuple(data)), 3)
+                self.assertEqual(len(data._FIELDS), 3)
                 for creg in qc.cregs:
                     self.assertTrue(hasattr(data, creg.name))
                     self._assert_allclose(getattr(data, creg.name), np.array(target[creg.name]))
@@ -657,7 +656,7 @@ class TestBackendSamplerV2(IBMTestCase):
         result = sampler.run([qc2], shots=self._shots).result()
         self.assertEqual(len(result), 1)
         data = result[0].data
-        self.assertEqual(len(astuple(data)), 3)
+        self.assertEqual(len(data._FIELDS), 3)
         for creg_name in target:  # pylint: disable=consider-using-dict-items
             self.assertTrue(hasattr(data, creg_name))
             self._assert_allclose(getattr(data, creg_name), np.array(target[creg_name]))


### PR DESCRIPTION
### Summary

This PR updates tests to stop assuming that `DataBin`s are dataclasses. This fact is an internal implementation detail, and will no longer be true in qiskit 1.1.

Notice that this PR uses the private `_FIELDS` attribute. This is because there is currently no better way to do this in `qiskit<1.1,>=1.0`, so that this field has become de-facto public. Once we depend on qiskit 1.1, we can change all such instances to use the new `__len__` method. There are more methods to fix other shortcomings, as well.



### Details and comments
Fixes #1665

