### PR TITLE
`_write_parameter_expression` takes version parameter 

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -61,6 +61,7 @@ from qiskit.qpy import (
     _read_parameter_expression_v3,
     load,
     dump,
+    QPY_VERSION,
 )
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.primitives.containers.sampler_pub import SamplerPub
@@ -243,12 +244,21 @@ class RuntimeEncoder(json.JSONEncoder):
             )
             return {"__type__": "Parameter", "__value__": value}
         if isinstance(obj, ParameterExpression):
-            value = _serialize_and_encode(
-                data=obj,
-                serializer=_write_parameter_expression,
-                compress=False,
-                use_symengine=bool(optionals.HAS_SYMENGINE),
-            )
+            if QPY_VERSION >= 12:
+                value = _serialize_and_encode(
+                    data=obj,
+                    serializer=_write_parameter_expression,
+                    compress=False,
+                    use_symengine=bool(optionals.HAS_SYMENGINE),
+                    version=QPY_VERSION,
+                )
+            else:
+                value = _serialize_and_encode(
+                    data=obj,
+                    serializer=_write_parameter_expression,
+                    compress=False,
+                    use_symengine=bool(optionals.HAS_SYMENGINE),
+                )
             return {"__type__": "ParameterExpression", "__value__": value}
         if isinstance(obj, ParameterView):
             return obj.data


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

@jakelishman `version` was added as a new argument [here](https://github.com/Qiskit/qiskit/pull/12310) which I believe caused our unit [tests](https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/9057469723/job/24881530623#step:5:3952) against Qiskit/main to start failing. Is this the correct way to handle `version` from the provider? 

### Details and comments


