### PR TITLE
Add `resilience.zne.amplifier` to EstimatorV2 options

### DIFF
--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -37,6 +37,18 @@ class ZneOptions:
     """Zero noise extrapolation mitigation options.
 
     Args:
+        amplifier: Which technique to use for amplifying noise. One of:
+
+            * `"gate_folding"` (default) uses 2-qubit gate folding to amplify noise. If the noise
+              factor requires amplifying only a subset of the gates, then these gates are chosen
+              randomly.
+            * `"gate_folding_front"` uses 2-qubit gate folding to amplify noise. If the noise
+              factor requires amplifying only a subset of the gates, then these gates are selected
+              from the front of the topologically ordered DAG circuit.
+            * `"gate_folding_back"` uses 2-qubit gate folding to amplify noise. If the noise
+              factor requires amplifying only a subset of the gates, then these gates are selected
+              from the back of the topologically ordered DAG circuit.
+
         noise_factors: Noise factors to use for noise amplification. Default: (1, 3, 5).
 
         extrapolator: Extrapolator(s) to try (in order) for extrapolating to zero noise.
@@ -50,6 +62,22 @@ class ZneOptions:
             Default: ("exponential", "linear").
     """
 
+    amplifier: Union[
+        UnsetType, Literal["gate_folding", "gate_folding_front", "gate_folding_back"]
+    ] = Unset
+    """
+    
+    * `"pea"` corresponds to probabilistic error amplification based on learned
+      layer noise models will be used.
+    * `"gate_folding"` uses 2-qubit gate folding to amplify noise. If the noise
+      factor requires amplifying a the subset gates these gates are chosen randomly.
+    * `"gate_folding_front"` uses 2-qubit gate folding to amplify noise. If the noise
+      factor requires amplifying a the subset gates these gates are selected from the
+      front of the topologically ordered DAG circuit.
+    * `"gate_folding_back"` uses 2-qubit gate folding to amplify noise. If the noise
+      factor requires amplifying a the subset gates these gates are selected from the
+      back of the topologically ordered DAG circuit.
+    """
     noise_factors: Union[UnsetType, Sequence[float]] = Unset
     extrapolator: Union[UnsetType, ExtrapolatorType, Sequence[ExtrapolatorType]] = Unset
 

--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -65,19 +65,6 @@ class ZneOptions:
     amplifier: Union[
         UnsetType, Literal["gate_folding", "gate_folding_front", "gate_folding_back"]
     ] = Unset
-    """
-    
-    * `"pea"` corresponds to probabilistic error amplification based on learned
-      layer noise models will be used.
-    * `"gate_folding"` uses 2-qubit gate folding to amplify noise. If the noise
-      factor requires amplifying a the subset gates these gates are chosen randomly.
-    * `"gate_folding_front"` uses 2-qubit gate folding to amplify noise. If the noise
-      factor requires amplifying a the subset gates these gates are selected from the
-      front of the topologically ordered DAG circuit.
-    * `"gate_folding_back"` uses 2-qubit gate folding to amplify noise. If the noise
-      factor requires amplifying a the subset gates these gates are selected from the
-      back of the topologically ordered DAG circuit.
-    """
     noise_factors: Union[UnsetType, Sequence[float]] = Unset
     extrapolator: Union[UnsetType, ExtrapolatorType, Sequence[ExtrapolatorType]] = Unset
 

--- a/release-notes/unreleased/1679.feat.rst
+++ b/release-notes/unreleased/1679.feat.rst
@@ -1,0 +1,11 @@
+The `ZneOptions.amplifier` option was added, which can be one of these strings:
+
+* `"gate_folding"` (default) uses 2-qubit gate folding to amplify noise. If the noise
+  factor requires amplifying only a subset of the gates, then these gates are chosen
+  randomly.
+* `"gate_folding_front"` uses 2-qubit gate folding to amplify noise. If the noise
+  factor requires amplifying only a subset of the gates, then these gates are selected
+  from the front of the topologically ordered DAG circuit.
+* `"gate_folding_back"` uses 2-qubit gate folding to amplify noise. If the noise
+  factor requires amplifying only a subset of the gates, then these gates are selected
+  from the back of the topologically ordered DAG circuit.

--- a/test/integration/test_estimator_v2.py
+++ b/test/integration/test_estimator_v2.py
@@ -82,6 +82,7 @@ class TestEstimatorV2(IBMIntegrationTestCase):
         estimator.options.seed_estimator = 42
         estimator.options.resilience.measure_mitigation = True
         estimator.options.resilience.zne_mitigation = True
+        estimator.options.resilienc.zne.amplifier = "gate_folding_back"
         estimator.options.resilience.zne.noise_factors = [3, 5]
         estimator.options.resilience.zne.extrapolator = "linear"
         estimator.options.resilience.pec_mitigation = False


### PR DESCRIPTION
### Summary

This PR adds the `ZneOptions` attribute `amplifier` which can be one of these strings:

* `"gate_folding"` (default) uses 2-qubit gate folding to amplify noise. If the noise
  factor requires amplifying only a subset of the gates, then these gates are chosen
  randomly.
* `"gate_folding_front"` uses 2-qubit gate folding to amplify noise. If the noise
  factor requires amplifying only a subset of the gates, then these gates are selected
  from the front of the topologically ordered DAG circuit.
* `"gate_folding_back"` uses 2-qubit gate folding to amplify noise. If the noise
  factor requires amplifying only a subset of the gates, then these gates are selected
  from the back of the topologically ordered DAG circuit.


### Details and comments
Fixes #1670

