### PR TITLE
Fix 0-d zne options encoding bug

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -214,6 +214,8 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, np.ndarray):
             if obj.dtype == object:
                 return {"__type__": "ndarray", "__value__": obj.tolist()}
+            elif obj.size == 0:
+                return obj.tolist()
             value = _serialize_and_encode(obj, np.save, allow_pickle=False)
             return {"__type__": "ndarray", "__value__": value}
         if isinstance(obj, np.int64):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Need to wait for server side changes to fully test. I'm still a bit confused about this bug - 

```python 

if isinstance(obj, np.ndarray):
    if obj.dtype == object:
        ...
    elif obj.ndim: # this value is 1? Do we need to check for obj.size instead
        ...
```

### Details and comments
Fixes #

