### PR TITLE
Remove `ParameterExpression`

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -16,7 +16,6 @@
 
 import base64
 import copy
-import functools
 import importlib
 import inspect
 import io
@@ -25,7 +24,7 @@ import re
 import warnings
 import zlib
 from datetime import date
-from typing import Any, Callable, Dict, List, Union, Tuple
+from typing import Any, Callable, Dict, List, Union
 
 import dateutil.parser
 import numpy as np
@@ -47,8 +46,6 @@ except ImportError:
 from qiskit.circuit import (
     Instruction,
     Parameter,
-    ParameterExpression,
-    ParameterVector,
     QuantumCircuit,
     QuantumRegister,
 )
@@ -57,8 +54,6 @@ from qiskit.result import Result
 from qiskit.version import __version__ as _terra_version_string
 from qiskit.utils import optionals
 from qiskit.qpy import (
-    _write_parameter_expression,
-    _read_parameter_expression_v3,
     load,
     dump,
 )
@@ -242,14 +237,6 @@ class RuntimeEncoder(json.JSONEncoder):
                 compress=False,
             )
             return {"__type__": "Parameter", "__value__": value}
-        if isinstance(obj, ParameterExpression):
-            value = _serialize_and_encode(
-                data=obj,
-                serializer=_write_parameter_expression,
-                compress=False,
-                use_symengine=bool(optionals.HAS_SYMENGINE),
-            )
-            return {"__type__": "ParameterExpression", "__value__": value}
         if isinstance(obj, ParameterView):
             return obj.data
         if isinstance(obj, Instruction):
@@ -329,12 +316,6 @@ class RuntimeDecoder(json.JSONDecoder):
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(object_hook=self.object_hook, *args, **kwargs)
-        self.__parameter_vectors: Dict[str, Tuple[ParameterVector, set]] = {}
-        self.__read_parameter_expression = functools.partial(
-            _read_parameter_expression_v3,
-            vectors=self.__parameter_vectors,
-            use_symengine=bool(optionals.HAS_SYMENGINE),
-        )
 
     def object_hook(self, obj: Any) -> Any:
         """Called to decode object."""
@@ -356,10 +337,6 @@ class RuntimeDecoder(json.JSONDecoder):
                 return _decode_and_deserialize(obj_val, load)[0]
             if obj_type == "Parameter":
                 return _decode_and_deserialize(obj_val, _read_parameter, False)
-            if obj_type == "ParameterExpression":
-                return _decode_and_deserialize(
-                    obj_val, self.__read_parameter_expression, False  # type: ignore[arg-type]
-                )
             if obj_type == "Instruction":
                 # Standalone instructions are encoded as the sole instruction in a QPY serialized circuit
                 # to deserialize load qpy circuit and return first instruction object in that circuit.

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -109,12 +109,8 @@ class TestDataSerialization(IBMTestCase):
     def test_coder_operators(self):
         """Test runtime encoder and decoder for operators."""
 
-        coeff_x = Parameter("x")
-        coeff_y = coeff_x + 1
-
         subtests = (
             SparsePauliOp(Pauli("XYZX"), coeffs=[2]),
-            SparsePauliOp(Pauli("XYZX"), coeffs=[coeff_y]),
             SparsePauliOp(Pauli("XYZX"), coeffs=[1 + 2j]),
             Pauli("XYZ"),
         )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

From discussion in slack and https://github.com/Qiskit/qiskit-ibm-runtime/pull/1674, we can drop `ParameterExpression` because it's no longer an input for the primitives. 

### Details and comments
Fixes #

