### PR TITLE
Update integration tests to work with new test instance 

### DIFF
--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -110,9 +110,8 @@ class TestIBMBackend(IBMIntegrationTestCase):
             # TODO use real device when cloud supports it
             cls.backend = cls.dependencies.service.least_busy(min_num_qubits=5)
         if cls.dependencies.channel == "ibm_quantum":
-            cls.backend = cls.dependencies.service.least_busy(
-                simulator=False, min_num_qubits=5, instance=cls.dependencies.instance
-            )
+            cls.dependencies.service._account.instance = None
+            cls.backend = cls.dependencies.service.least_busy(simulator=False, min_num_qubits=5)
 
     def test_backend_service(self):
         """Check if the service property is set."""

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -110,7 +110,9 @@ class TestIBMBackend(IBMIntegrationTestCase):
             # TODO use real device when cloud supports it
             cls.backend = cls.dependencies.service.least_busy(min_num_qubits=5)
         if cls.dependencies.channel == "ibm_quantum":
-            cls.dependencies.service._account.instance = None
+            cls.dependencies.service._account.instance = (
+                None  # set instance to none to avoid filtering
+            )
             cls.backend = cls.dependencies.service.least_busy(simulator=False, min_num_qubits=5)
 
     def test_backend_service(self):

--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -95,6 +95,7 @@ class TestIBMJob(IBMIntegrationTestCase):
         if self.dependencies.channel == "ibm_cloud":
             raise SkipTest("Cloud account does not have real backend.")
         # Find the most busy backend
+        self.service._account.instance = None  # set instance to none to avoid filtering
         backend = most_busy_backend(self.service)
         submit_and_cancel(backend, self.log)
 
@@ -264,6 +265,7 @@ class TestIBMJob(IBMIntegrationTestCase):
         """Test waiting for job to reach final state times out."""
         if self.dependencies.channel == "ibm_cloud":
             raise SkipTest("Cloud account does not have real backend.")
+        self.service._account.instance = None  # set instance to none to avoid filtering
         backend = most_busy_backend(TestIBMJob.service)
         sampler = Sampler(backend=backend)
         job = sampler.run([transpile(bell(), backend=backend)])


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Using a new instance for integration tests that has access to `ibmq_qasm_simulator`. The testing account has access to real backends but not the instance. 

### Details and comments
Fixes #

