### PR TITLE
Update twirling docstring

### DIFF
--- a/qiskit_ibm_runtime/options/twirling_options.py
+++ b/qiskit_ibm_runtime/options/twirling_options.py
@@ -33,7 +33,8 @@ class TwirlingOptions:
         enable_gates: Whether to apply 2-qubit gate twirling. Default: False.
 
         enable_measure: Whether to enable twirling of measurements. Twirling will only be applied to
-         those measurement registers not involved within a conditional logic. Default: True.
+         those measurement registers not involved within a conditional logic.
+         Default: True for Estimator, false for Sampler.
 
         num_randomizations: The number of random samples to use when twirling or
             peforming sampled mitigation. If "auto", the value will be chosen automatically

--- a/release-notes/unreleased/1722.bug.rst
+++ b/release-notes/unreleased/1722.bug.rst
@@ -1,0 +1,1 @@
+Fixed measurement twirling docstring which incorrectly indicated it's enabled by default for Sampler.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix twirling docstring to say measurement twirling is not actually enabled by default for Sampler. 


### Details and comments
Fixes #

