### PR TITLE
Remove backend cache from QiskitRuntimeService

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -45,6 +45,7 @@ class RuntimeClient(BaseBackendClient):
             **params.connection_parameters(),
         )
         self._api = Runtime(self._session)
+        self._configuration_registry = {}
 
     def program_run(
         self,
@@ -301,7 +302,11 @@ class RuntimeClient(BaseBackendClient):
         Returns:
             Backend configuration.
         """
-        return self._api.backend(backend_name).configuration()
+        if backend_name not in self._configuration_registry:
+            self._configuration_registry[backend_name] = self._api.backend(
+                backend_name
+            ).configuration()
+        return self._configuration_registry[backend_name].copy()
 
     def backend_status(self, backend_name: str) -> Dict[str, Any]:
         """Return the status of the IBM backend.

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -45,7 +45,7 @@ class RuntimeClient(BaseBackendClient):
             **params.connection_parameters(),
         )
         self._api = Runtime(self._session)
-        self._configuration_registry = {}
+        self._configuration_registry: Dict[str, Dict[str, Any]] = {}
 
     def program_run(
         self,

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -148,7 +148,6 @@ class QiskitRuntimeService:
             self._api_client = RuntimeClient(self._client_params)
             self._backend_allowed_list = self._discover_cloud_backends()
             self._validate_channel_strategy()
-            return
         else:
             auth_client = self._authenticate_ibm_quantum_account(self._client_params)
             # Update client parameters to use authenticated values.

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -43,7 +43,7 @@ from .hub_group_project import HubGroupProject  # pylint: disable=cyclic-import
 from .utils.result_decoder import ResultDecoder
 from .runtime_job import RuntimeJob
 from .runtime_job_v2 import RuntimeJobV2
-from .utils import RuntimeDecoder, RuntimeEncoder, to_python_identifier
+from .utils import RuntimeDecoder, RuntimeEncoder
 from .api.client_parameters import ClientParameters
 from .runtime_options import RuntimeOptions
 from .ibm_backend import IBMBackend
@@ -170,10 +170,6 @@ class QiskitRuntimeService:
                 self._current_instance = self._get_hgp().name
                 logger.info("Default instance: %s", self._current_instance)
         QiskitRuntimeService.global_service = self
-
-        # TODO - it'd be nice to allow some kind of autocomplete, but `service.ibmq_foo`
-        # just seems wrong since backends are not runtime service instances.
-        # self._discover_backends()
 
     def _discover_account(
         self,
@@ -452,16 +448,6 @@ class QiskitRuntimeService:
             )
 
         raise QiskitBackendNotFoundError(error_message)
-
-    def _discover_backends(self) -> None:
-        """Discovers the remote backends for this account, if not already known."""
-        for backend_name in self._discover_cloud_backends():
-            backend = self._create_backend_obj(backend_name)
-            attr_backend_name = to_python_identifier(backend_name)
-            # Append _ if duplicate
-            while attr_backend_name in self.__dict__:
-                attr_backend_name += "_"
-            setattr(self, attr_backend_name, backend)
 
     # pylint: disable=arguments-differ
     def backends(

--- a/release-notes/unreleased/1732.upgrade.rst
+++ b/release-notes/unreleased/1732.upgrade.rst
@@ -1,0 +1,4 @@
+Backend object cache in the :class:`.QiskitRuntimeService` was removed.
+This indicates retrieving the backend from the same service instance incurs communication costs with the server each time.
+You can always reuse the same backend instance to build primitives to run,
+instead of retrieving the backend object from the service multiple times.

--- a/release-notes/unreleased/1732.upgrade.rst
+++ b/release-notes/unreleased/1732.upgrade.rst
@@ -1,4 +1,0 @@
-Backend object cache in the :class:`.QiskitRuntimeService` was removed.
-This indicates retrieving the backend from the same service instance incurs communication costs with the server each time.
-You can always reuse the same backend instance to build primitives to run,
-instead of retrieving the backend object from the service multiple times.

--- a/release-notes/unreleased/1732.upgrade.rst
+++ b/release-notes/unreleased/1732.upgrade.rst
@@ -1,0 +1,5 @@
+The :meth:`.QiskitRuntimeService.backends` now always returns
+new :class:`IBMBackend` instance even for the same query.
+The backend properties and defaults data are retrieved from the server
+for every instance when they are accessed for the first time,
+while the configuration data is cached internally in the service instance.

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -441,7 +441,9 @@ class BaseFakeRuntimeClient:
 
     def backend_configuration(self, backend_name: str) -> Dict[str, Any]:
         """Return the configuration a backend."""
-        return self._find_backend(backend_name).configuration
+        if ret := self._find_backend(backend_name).configuration:
+            return ret.copy()
+        return None
 
     def backend_status(self, backend_name: str) -> Dict[str, Any]:
         """Return the status of a backend."""
@@ -451,11 +453,15 @@ class BaseFakeRuntimeClient:
         """Return the properties of a backend."""
         if datetime:
             raise NotImplementedError("'datetime' is not supported.")
-        return self._find_backend(backend_name).properties
+        if ret := self._find_backend(backend_name).properties:
+            return ret.copy()
+        return None
 
     def backend_pulse_defaults(self, backend_name: str) -> Dict[str, Any]:
         """Return the pulse defaults of a backend."""
-        return self._find_backend(backend_name).defaults
+        if ret := self._find_backend(backend_name).defaults:
+            return ret.copy()
+        return None
 
     # pylint: disable=unused-argument
     def create_session(

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -296,3 +296,23 @@ class TestGetBackend(IBMTestCase):
             "while_loop" in test_backend.target.operation_names,
             not use_fractional,
         )
+
+    def test_backend_with_and_without_fractional_from_same_service(self):
+        """Test getting backend with and without fractional gates from the same service.
+
+        Backend with and without opt-in must be different object.
+        """
+        service = FakeRuntimeService(
+            channel="ibm_quantum",
+            token="my_token",
+            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
+        )
+
+        backend_with_fg = service.backend("fake_fractional", use_fractional_gates=True)
+        self.assertIn("rx", backend_with_fg.target)
+
+        backend_without_fg = service.backend("fake_fractional", use_fractional_gates=False)
+        self.assertNotIn("rx", backend_without_fg.target)
+        self.assertIn("rx", backend_with_fg.target)
+
+        self.assertIsNot(backend_with_fg, backend_without_fg)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1715 we implemented new pattern to retrieve backend from the service, namely, opt-int. With opt-in, the same backend can have different Target, and thus they must be different Python objects.

This PR removes backend instance cache mechanism from `QiskitRuntimeService`. Instead, cache for the configuration data is implemented in the `RuntimeClient`. `IBMBackend` object is created every time it is requested, but the source data is cached and the communication with the server occurs only once.

### Details and comments

Once after we announce the fractional gate opt-in (not limited to fractional, some future opt-ins), user may try to compare the performance of our system with and without opt-in. One may write 

```python
backend_with_fg = service.backend("my_backend", use_fractional_gates=True)
backend_without_fg = service.backend("my_backend", use_fractional_gates=False)

# Run our system with fractional gates
sampler = SamplerV2(backend_with_fg)
isa_circ = transpile(qc, backend_with_fg)
result_with_fg = sampler.run(isa_circ).result()

# Run our system without fractional gates
sampler = SamplerV2(backend_without_fg)
isa_circ = transpile(qc, backend_without_fg)
result_without_fg = sampler.run(isa_circ).result()
```

Note that this does **NOT** work as expected BUT doesn't raise any warning or error. Note that `backend_with_fg` is silently mutated at the second retrieval via the cache, and both sampler jobs run without fractional gates. One may wonder why two results look comparable.

This PR will remove this complication and make internal code much simpler.