### PR TITLE
Deprecate optimization_level

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -209,7 +209,7 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
                 "a coupling map is required."
             )
 
-        if "optimization_level" in options:
+        if options.get("optimization_level", None):
             issue_deprecation_msg(
                 msg="The 'optimization_level' option is deprecated",
                 version="0.25.0",

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -214,9 +214,9 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
                 msg="The 'optimization_level' option is deprecated",
                 version="0.25.0",
                 remedy="Instead, you can perform circuit optimization using Qiskit transpiler "
-                    "or Qiskit transpiler service. "
-                    "See https://docs.quantum.ibm.com/transpile for more information."
-                )
+                "or Qiskit transpiler service. "
+                "See https://docs.quantum.ibm.com/transpile for more information.",
+            )
 
     @classmethod
     def _program_id(cls) -> str:

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -209,6 +209,15 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
                 "a coupling map is required."
             )
 
+        if "optimization_level" in options:
+            issue_deprecation_msg(
+                msg="The 'optimization_level' option is deprecated",
+                version="0.25.0",
+                remedy="Instead, you can perform circuit optimization using Qiskit transpiler "
+                    "or Qiskit transpiler service. "
+                    "See https://docs.quantum.ibm.com/transpile for more information."
+                )
+
     @classmethod
     def _program_id(cls) -> str:
         """Return the program ID."""

--- a/qiskit_ibm_runtime/options/estimator_options.py
+++ b/qiskit_ibm_runtime/options/estimator_options.py
@@ -60,19 +60,14 @@ class EstimatorOptions(OptionsV2):
 
             Default: ``None``.
 
-        optimization_level: How much optimization to perform on the circuits.
+        optimization_level: (DEPRECATED) How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,
             at the expense of longer processing times.
 
             * 0: no optimization
             * 1: light optimization
 
-            Refer to the
-            `Configure runtime compilation for Qiskit Runtime
-            <https://docs.quantum.ibm.com/run/configure-runtime-compilation>`_.
-            for more information about the optimization levels.
-
-            Default: 1.
+            Default: 0.
 
         resilience_level: How much resilience to build against errors.
             Higher levels generate more accurate results,

--- a/release-notes/unreleased/1748.deprecation.rst
+++ b/release-notes/unreleased/1748.deprecation.rst
@@ -1,0 +1,2 @@
+The ``optimization_level`` option in ``EstimatorV2`` is deprecated.
+Instead, you can perform circuit optimization using the Qiskit transpiler or Qiskit transpiler service.

--- a/test/integration/test_estimator_v2.py
+++ b/test/integration/test_estimator_v2.py
@@ -78,7 +78,6 @@ class TestEstimatorV2(IBMIntegrationTestCase):
         estimator.options.default_precision = 0.05
         estimator.options.default_shots = 400
         estimator.options.resilience_level = 1
-        estimator.options.optimization_level = 1
         estimator.options.seed_estimator = 42
         estimator.options.resilience.measure_mitigation = True
         estimator.options.resilience.zne_mitigation = True
@@ -116,7 +115,6 @@ class TestEstimatorV2(IBMIntegrationTestCase):
 
         estimator = EstimatorV2(backend=backend)
         estimator.options.resilience_level = 0
-        estimator.options.optimization_level = 0
         estimator.options.resilience.pec_mitigation = True
         estimator.options.resilience.pec_max_overhead = 200
         estimator.options.simulator.set_backend(FakeAuckland())

--- a/test/unit/test_estimator_options.py
+++ b/test/unit/test_estimator_options.py
@@ -251,3 +251,10 @@ class TestEstimatorOptions(IBMTestCase):
         options = backend.service.run.call_args.kwargs["inputs"]
         self.assertIn("resilience_level", options)
         self.assertEqual(options["resilience_level"], 0)
+
+    def test_optimization_level_deprecation(self):
+        """Test optimization level being deprecated."""
+        backend = get_mocked_backend()
+        estimator = Estimator(backend=backend, options={"optimization_level": 1})
+        with self.assertWarnsRegex(DeprecationWarning, r'.*optimization_level.*'):
+            _ = estimator.run(**get_primitive_inputs(estimator))

--- a/test/unit/test_estimator_options.py
+++ b/test/unit/test_estimator_options.py
@@ -256,5 +256,5 @@ class TestEstimatorOptions(IBMTestCase):
         """Test optimization level being deprecated."""
         backend = get_mocked_backend()
         estimator = Estimator(backend=backend, options={"optimization_level": 1})
-        with self.assertWarnsRegex(DeprecationWarning, r'.*optimization_level.*'):
+        with self.assertWarnsRegex(DeprecationWarning, r".*optimization_level.*"):
             _ = estimator.run(**get_primitive_inputs(estimator))

--- a/test/unit/test_local_mode.py
+++ b/test/unit/test_local_mode.py
@@ -185,7 +185,7 @@ class TestLocalModeV2(IBMTestCase):
         primitive=[SamplerV2, EstimatorV2], backend=[FakeManila(), FakeManilaV2(), AerSimulator()]
     )
     def test_primitive_v2_with_not_accepted_options(self, primitive, backend):
-        """Test V1 primitive with accepted options."""
+        """Test V2 primitive with not accepted options."""
         options = {
             "max_execution_time": 200,
             "dynamical_decoupling": {"enable": True},


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Deprecate `optimization_level` from `EstimatorV2`. Also update the docstring as the server default is changed to 0. 


### Details and comments
Fixes #

