### PR TITLE
Change use_fractional_gates default to False

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -458,7 +458,7 @@ class QiskitRuntimeService:
         dynamic_circuits: Optional[bool] = None,
         filters: Optional[Callable[["ibm_backend.IBMBackend"], bool]] = None,
         *,
-        use_fractional_gates: Optional[bool] = True,
+        use_fractional_gates: bool = False,
         **kwargs: Any,
     ) -> List["ibm_backend.IBMBackend"]:
         """Return all backends accessible via this account, subject to optional filtering.
@@ -735,7 +735,7 @@ class QiskitRuntimeService:
         self,
         name: str = None,
         instance: Optional[str] = None,
-        use_fractional_gates: bool = True,
+        use_fractional_gates: bool = False,
     ) -> Backend:
         """Return a single backend matching the specified filtering.
 

--- a/release-notes/unreleased/1755.bug.rst
+++ b/release-notes/unreleased/1755.bug.rst
@@ -1,0 +1,1 @@
+Disallowing fractional gates by default, so backend target would not exclude control flow.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When we introduced the `use_fractional_gates` flag, we set the default to True. That'd actually break both dynamic circuits and twirling. This PR changes the default to False. 


### Details and comments
Fixes #

