### PR TITLE
Add required pydantic version in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIREMENTS = [
     "python-dateutil>=2.8.0",
     "websocket-client>=1.5.1",
     "ibm-platform-services>=0.22.6",
-    "pydantic",
+    "pydantic>=2.5.0",
     "qiskit>=1.1.0",
 ]
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Related to #1577 - users that already have `pydantic` installed in the their environments may run into incompatibility issues because the version of `pydantic` required is not specified in `setup.py`.

### Details and comments
Fixes #

