### PR TITLE
Add instance property to job

### DIFF
--- a/qiskit_ibm_runtime/base_runtime_job.py
+++ b/qiskit_ibm_runtime/base_runtime_job.py
@@ -470,7 +470,9 @@ class BaseRuntimeJob(ABC):
 
     @property
     def instance(self) -> Optional[str]:
-        """Return the instance the job was run on"""
+        """For ibm_quantum channel jobs, return the instance where the job was run.
+        For ibm_cloud, `None` is returned.
+        """
         return self._backend._instance
 
     @abstractmethod

--- a/qiskit_ibm_runtime/base_runtime_job.py
+++ b/qiskit_ibm_runtime/base_runtime_job.py
@@ -468,6 +468,11 @@ class BaseRuntimeJob(ABC):
 
         return self._usage_estimation
 
+    @property
+    def instance(self) -> Optional[str]:
+        """Return the instance the job was run on"""
+        return self._backend._instance
+
     @abstractmethod
     def in_final_state(self) -> bool:
         """Return whether the job is in a final job state such as ``DONE`` or ``ERROR``."""

--- a/release-notes/unreleased/1771.feat.rst
+++ b/release-notes/unreleased/1771.feat.rst
@@ -1,0 +1,2 @@
+Added an ``instance`` property to :class:`BaseRuntimeJob` which returns the instance
+where the job was run.

--- a/test/integration/test_ibm_job_attributes.py
+++ b/test/integration/test_ibm_job_attributes.py
@@ -63,6 +63,10 @@ class TestIBMJobAttributes(IBMTestCase):
         """Test getting a job ID."""
         self.assertTrue(self.sim_job.job_id() is not None)
 
+    def test_job_instance(self):
+        """Test getting job instance."""
+        self.assertTrue(self.dependencies.instance, self.sim_job.instance)
+
     def test_get_backend_name(self):
         """Test getting a backend name."""
         self.assertTrue(self.sim_job.backend().name == self.sim_backend.name)

--- a/test/integration/test_ibm_job_attributes.py
+++ b/test/integration/test_ibm_job_attributes.py
@@ -65,7 +65,7 @@ class TestIBMJobAttributes(IBMTestCase):
 
     def test_job_instance(self):
         """Test getting job instance."""
-        self.assertTrue(self.dependencies.instance, self.sim_job.instance)
+        self.assertEqual(self.dependencies.instance, self.sim_job.instance)
 
     def test_get_backend_name(self):
         """Test getting a backend name."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

From a slack conversation - it'd be nice if there was an easy, documented way to get the instance where a job was run. 

### Details and comments
Fixes #

