### PR TITLE
Improve save_account() error msg

### DIFF
--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -332,5 +332,7 @@ class CloudAccount(Account):
         """Assert that the instance name is valid for the given account type."""
         if not (isinstance(instance, str) and len(instance) > 0):
             raise InvalidAccountError(
-                f"Invalid `instance` value. Expected a non-empty string, got '{instance}'."
+                f"Invalid `instance` value. Expected a non-empty string, got '{instance}'. "
+                "If using the ibm_quantum channel,",
+                "please specify the channel when saving your account with `channel = 'ibm_quantum'`.",
             )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If users attempt to save an IQP account with just a token, and no channel specified, since the default channel is `ibm_cloud`, it will result in a missing instance error. The error message is now improved to be more clear.

### Details and comments
Fixes #

