### PR TITLE
Use polling for job status instead of websockets

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -319,10 +319,7 @@ class RuntimeJob(Job, BaseRuntimeJob):
         self,
         timeout: Optional[float] = None,
     ) -> None:
-        """Use the websocket server to wait for the final the state of a job.
-
-        The server will remain open if the job is still running and the connection will
-        be terminated once the job completes. Then update and return the status of the job.
+        """Poll for the job status from the API until the status is in a final state.
 
         Args:
             timeout: Seconds to wait for the job. If ``None``, wait indefinitely.
@@ -332,12 +329,6 @@ class RuntimeJob(Job, BaseRuntimeJob):
         """
         try:
             start_time = time.time()
-            if self._status not in self.JOB_FINAL_STATES and not self._is_streaming():
-                self._ws_client_future = self._executor.submit(self._start_websocket_client)
-            if self._is_streaming():
-                self._ws_client_future.result(timeout)
-            # poll for status after stream has closed until status is final
-            # because status doesn't become final as soon as stream closes
             status = self.status()
             while status not in self.JOB_FINAL_STATES:
                 elapsed_time = time.time() - start_time

--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -236,10 +236,7 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
         self,
         timeout: Optional[float] = None,
     ) -> None:
-        """Use the websocket server to wait for the final the state of a job.
-
-        The server will remain open if the job is still running and the connection will
-        be terminated once the job completes. Then update and return the status of the job.
+        """Poll for the job status from the API until the status is in a final state.
 
         Args:
             timeout: Seconds to wait for the job. If ``None``, wait indefinitely.
@@ -249,12 +246,6 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
         """
         try:
             start_time = time.time()
-            if self._status not in self.JOB_FINAL_STATES and not self._is_streaming():
-                self._ws_client_future = self._executor.submit(self._start_websocket_client)
-            if self._is_streaming():
-                self._ws_client_future.result(timeout)
-            # poll for status after stream has closed until status is final
-            # because status doesn't become final as soon as stream closes
             status = self.status()
             while status not in self.JOB_FINAL_STATES:
                 elapsed_time = time.time() - start_time


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Can fully remove the websocket code after the deprecation period in #1776 

### Details and comments
Fixes #1775 

