### PR TITLE
Set _active flag to false if session already closed

### DIFF
--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -369,6 +369,7 @@ class Session:
         response = service._api_client.session_details(session_id)
         backend = response.get("backend_name")
         mode = response.get("mode")
+        state = response.get("state")
         class_name = "dedicated" if cls.__name__.lower() == "session" else cls.__name__.lower()
         if mode != class_name:
             raise IBMInputValueError(
@@ -376,6 +377,8 @@ class Session:
             )
 
         session = cls(service, backend)
+        if state == "closed":
+            session._active = False
         session._session_id = session_id
         return session
 

--- a/release-notes/unreleased/1780.feat.rst
+++ b/release-notes/unreleased/1780.feat.rst
@@ -1,0 +1,2 @@
+If jobs are run in a session created with :meth:`QiskitRuntimeService.Session.from_id` where the 
+session is already closed, the jobs are rejected immediately.

--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -107,6 +107,9 @@ class TestIntegrationSession(IBMIntegrationTestCase):
 
         new_session = Session.from_id(session_id=session._session_id, service=service)
         self.assertEqual(session._session_id, new_session._session_id)
+        self.assertTrue(new_session._active)
+        new_session.close()
+        self.assertFalse(new_session._active)
 
         with self.assertRaises(IBMInputValueError):
             Batch.from_id(session_id=session._session_id, service=service)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If the session created with `from_id` is already closed, jobs should be rejected immediately. 

### Details and comments
Fixes #1597 

