### PR TITLE
Don't cache target in target_history

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -346,8 +346,15 @@ class IBMBackend(Backend):
         """
         self._get_properties(datetime=datetime)
         self._get_defaults()
-        self._convert_to_target(refresh=True)
-        return self._target
+        return convert_to_target(
+            configuration=self._configuration,
+            properties=self._properties,
+            defaults=self._defaults,
+            # In IBM backend architecture as of today
+            # these features can be only exclusively supported.
+            include_control_flow=not self.options.use_fractional_gates,
+            include_fractional_gates=self.options.use_fractional_gates,
+        )
 
     def properties(
         self, refresh: bool = False, datetime: Optional[python_datetime] = None

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -333,9 +333,9 @@ class IBMBackend(Backend):
         Returns:
             Target
         """
-        self._get_properties()
+        self._get_properties(datetime=python_datetime.now())
         self._get_defaults()
-        self._convert_to_target()
+        self._convert_to_target(refresh=True)
         return self._target
 
     def target_history(self, datetime: Optional[python_datetime] = None) -> Target:
@@ -346,15 +346,8 @@ class IBMBackend(Backend):
         """
         self._get_properties(datetime=datetime)
         self._get_defaults()
-        return convert_to_target(
-            configuration=self._configuration,
-            properties=self._properties,
-            defaults=self._defaults,
-            # In IBM backend architecture as of today
-            # these features can be only exclusively supported.
-            include_control_flow=not self.options.use_fractional_gates,
-            include_fractional_gates=self.options.use_fractional_gates,
-        )
+        self._convert_to_target(refresh=True)
+        return self._target
 
     def properties(
         self, refresh: bool = False, datetime: Optional[python_datetime] = None

--- a/release-notes/unreleased/1791.bug.rst
+++ b/release-notes/unreleased/1791.bug.rst
@@ -1,0 +1,2 @@
+Fixed an issue where calling :meth:`IBMBackend.target_history` would cache the backend target and
+then calling :meth:`IBMBackend.target` would incorrectly return that cached target.

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -457,8 +457,6 @@ class BaseFakeRuntimeClient:
 
     def backend_properties(self, backend_name: str, datetime: Any = None) -> Dict[str, Any]:
         """Return the properties of a backend."""
-        if datetime:
-            raise NotImplementedError("'datetime' is not supported.")
         if ret := self._find_backend(backend_name).properties:
             return ret.copy()
         return None


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If `target` is called after `target_history()`, the cached backend target will be returned instead of the most current backend target. 

### Details and comments
Fixes #1615 

