### PR TITLE
Remove downloading result from external url

### DIFF
--- a/qiskit_ibm_runtime/runtime_job.py
+++ b/qiskit_ibm_runtime/runtime_job.py
@@ -164,9 +164,7 @@ class RuntimeJob(Job, BaseRuntimeJob):
                 "Unable to retrieve result for job {}. " "Job was cancelled.".format(self.job_id())
             )
 
-        result_raw = self._download_external_result(
-            self._api_client.job_results(job_id=self.job_id())
-        )
+        result_raw = self._api_client.job_results(job_id=self.job_id())
 
         return _decoder.decode(result_raw) if result_raw else None  # type: ignore
 

--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -141,9 +141,7 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
                 "Unable to retrieve result for job {}. " "Job was cancelled.".format(self.job_id())
             )
 
-        result_raw = self._download_external_result(
-            self._api_client.job_results(job_id=self.job_id())
-        )
+        result_raw = self._api_client.job_results(job_id=self.job_id())
 
         return _decoder.decode(result_raw) if result_raw else None  # type: ignore
 

--- a/test/unit/test_circuit_runner_job.py
+++ b/test/unit/test_circuit_runner_job.py
@@ -62,9 +62,6 @@ class FakeCircuitRunnerJob(RuntimeJob):
         """
         return JOB_FINAL_STATES
 
-    def _download_external_result(self, response: Any) -> Any:
-        return self._data
-
     def submit(self) -> None:
         """Fake submit"""
         pass

--- a/test/unit/test_circuit_runner_job.py
+++ b/test/unit/test_circuit_runner_job.py
@@ -34,6 +34,7 @@ class FakeCircuitRunnerJob(RuntimeJob):
         """
         self._data = data
         api_client = MagicMock()
+        api_client.job_results = MagicMock(return_value=self._data)
         client_params = MagicMock()
         backend = job_id = program_id = service = None
         super().__init__(

--- a/test/unit/test_jobs.py
+++ b/test/unit/test_jobs.py
@@ -14,7 +14,6 @@
 
 import random
 import time
-from unittest.mock import MagicMock, patch
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.jobstatus import JobStatus
@@ -224,18 +223,3 @@ class TestRuntimeJob(IBMTestCase):
         service.delete_job(job.job_id())
         with self.assertRaises(RuntimeJobNotFound):
             service.job(job.job_id())
-
-    @run_quantum_and_cloud_fake
-    def test_download_external_job_result(self, service):
-        """Test downloading the job result from an external URL."""
-        with patch("qiskit_ibm_runtime.base_runtime_job.requests") as request_mock:
-            job = run_program(service=service)
-            with mock_wait_for_final_state(service, job):
-                mock_response = MagicMock()
-                mock_response.text = "content-from-external-url"
-                request_mock.get.return_value = mock_response
-                with mock_wait_for_final_state(service, job):
-                    job.wait_for_final_state()
-                    result = job.result()
-
-        self.assertTrue(result)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

From a slack conversation with @daka1510 regarding when `_download_external_result` was first added [here](https://github.com/Qiskit/qiskit-ibm-runtime/pull/709) to support osprey

> We have now cleaned up the corresponding code on the server-side to support this special result flow. Feel free to remove it from the SDK, too, if no one in this group objects.
Allowing clients to fetch data from COS directly via the SDK might become a priority again, but probably not follow this design with pre-signed URLs. Since it's all unclear right now, it's probably not a good idea to keep this code around.

### Details and comments
Fixes #

