### PR TITLE
Break up options classes in docs

### DIFF
--- a/qiskit_ibm_runtime/options/__init__.py
+++ b/qiskit_ibm_runtime/options/__init__.py
@@ -75,7 +75,7 @@ You can also pass dictionaries to each sub-category, for example::
 Classes
 =======
 
-Base Primitive Options
+Base primitive options
 ----------------------
 
 .. autosummary::

--- a/qiskit_ibm_runtime/options/__init__.py
+++ b/qiskit_ibm_runtime/options/__init__.py
@@ -17,7 +17,7 @@ Primitive options (:mod:`qiskit_ibm_runtime.options`)
 
 .. currentmodule:: qiskit_ibm_runtime.options
 
-Options that can be passed to the primitives.
+Options that can be passed to the Qiskit Runtime primitives.
 
 V2 Primitives
 =============
@@ -75,11 +75,23 @@ You can also pass dictionaries to each sub-category, for example::
 Classes
 =======
 
+Base Primitive Options
+----------------------
+
 .. autosummary::
    :toctree: ../stubs/
 
    EstimatorOptions
    SamplerOptions
+   Options
+
+
+Suboptions for V2 primitives only
+---------------------------------
+
+.. autosummary::
+   :toctree: ../stubs/
+
    DynamicalDecouplingOptions
    ResilienceOptionsV2
    LayerNoiseLearningOptions
@@ -88,13 +100,28 @@ Classes
    ZneOptions
    TwirlingOptions
    ExecutionOptionsV2
-   Options
-   TranspilationOptions
-   ResilienceOptions
-   ExecutionOptions
+   SamplerExecutionOptionsV2
+
+
+Suboptions for both V1 and V2 primitives
+----------------------------------------
+
+.. autosummary::
+   :toctree: ../stubs/
+
    EnvironmentOptions
    SimulatorOptions
-   SamplerExecutionOptionsV2
+
+
+Suboptions for V1 primitives only
+---------------------------------
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   TranspilationOptions
+   ExecutionOptions
+   ResilienceOptions
 
 """
 

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -233,7 +233,7 @@ class OptionsV2(BaseOptions):
 
 @dataclass
 class Options(BaseOptions):
-    """Options for the primitives, used by V1 primitives.
+    """Options for V1 primitives.
 
     Args:
         optimization_level: How much optimization to perform on the circuits.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR breaks up the classes in `options` package into different sections, to make it easier to find:

<img width="691" alt="image" src="https://github.com/user-attachments/assets/beed3411-c1d6-47cd-9539-9673e058c19d">


The table for "Base primitive options" is small because the text is short. @Eric-Arellano or @beckykd, if you know to fix that please let me know.  


### Details and comments
Fixes #

