### PR TITLE
Scrub RuntimeOptions from docs

### DIFF
--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -196,7 +196,6 @@ Classes
    IBMBackend
    RuntimeJob
    RuntimeJobV2
-   RuntimeOptions
    RuntimeEncoder
    RuntimeDecoder
 """

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -334,7 +334,6 @@ class EstimatorV1(BasePrimitiveV1, Estimator, BaseEstimator):
             parameter_values: Concrete parameters to be bound.
 
             **kwargs: Individual options to overwrite the default primitive options.
-                These include the runtime options in :class:`qiskit_ibm_runtime.RuntimeOptions`.
 
         Returns:
             Submitted job.
@@ -370,7 +369,6 @@ class EstimatorV1(BasePrimitiveV1, Estimator, BaseEstimator):
             parameter_values: An optional list of concrete parameters to be bound.
 
             **kwargs: Individual options to overwrite the default primitive options.
-                These include the runtime options in :class:`~qiskit_ibm_runtime.RuntimeOptions`.
 
         Returns:
             Submitted job

--- a/qiskit_ibm_runtime/fake_provider/local_service.py
+++ b/qiskit_ibm_runtime/fake_provider/local_service.py
@@ -154,7 +154,6 @@ class QiskitRuntimeLocalService:
             inputs: Program input parameters. These input values are passed
                 to the runtime program.
             options: Runtime options that control the execution environment.
-                See :class:`RuntimeOptions` for all available options.
 
         Returns:
             A job representing the execution.

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -804,7 +804,6 @@ class QiskitRuntimeService:
             inputs: Program input parameters. These input values are passed
                 to the runtime program.
             options: Runtime options that control the execution environment.
-                See :class:`RuntimeOptions` for all available options.
 
             callback: Callback function to be invoked for any interim results and final result.
                 The callback function will receive 2 positional parameters:

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -266,7 +266,6 @@ class SamplerV1(BasePrimitiveV1, Sampler, BaseSampler):
                 a list of (parameterized) :class:`~qiskit.circuit.QuantumCircuit`.
             parameter_values: Concrete parameters to be bound.
             **kwargs: Individual options to overwrite the default primitive options.
-                These include the runtime options in :class:`qiskit_ibm_runtime.RuntimeOptions`.
 
         Returns:
             Submitted job.
@@ -296,7 +295,6 @@ class SamplerV1(BasePrimitiveV1, Sampler, BaseSampler):
                 a list of (parameterized) :class:`~qiskit.circuit.QuantumCircuit`.
             parameter_values: An optional list of concrete parameters to be bound.
             **kwargs: Individual options to overwrite the default primitive options.
-                These include the runtime options in :class:`qiskit_ibm_runtime.RuntimeOptions`.
 
         Returns:
             Submitted job.

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -178,7 +178,6 @@ class Session:
             inputs: Program input parameters. These input values are passed
                 to the runtime program.
             options: Runtime options that control the execution environment.
-                See :class:`qiskit_ibm_runtime.RuntimeOptions` for all available options.
             callback: Callback function to be invoked for any interim results and final result.
 
         Returns:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR removes `RuntimeOptions` from docstrings. 

### Details and comments

`RuntimeOptions` was the original options class used when Qiskit Runtime supported only custom programs. Now that we don't support custom programs anymore, exposing that class in the API doc would only cause confusion. Ideally we'd also clean it up from the code, but that requires a bit more work. 

