### PR TITLE
Update `test_retrieve_pending_jobs`

### DIFF
--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -121,12 +121,13 @@ class TestIBMJob(IBMIntegrationTestCase):
 
     def test_retrieve_pending_jobs(self):
         """Test retrieving jobs with the pending filter."""
-        if self.dependencies.channel == "ibm_quantum":
-            raise SkipTest(
-                "Intermittently failing on ibm quantum channel, needs more investigation."
-            )
+        yesterday = datetime.now() - timedelta(days=1)
         pending_job_list = self.service.jobs(
-            program_id="sampler", limit=3, pending=True, created_after=self.last_month
+            program_id="sampler",
+            limit=3,
+            pending=True,
+            created_after=self.last_month,
+            created_before=yesterday,
         )
         for job in pending_job_list:
             self.assertTrue(


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Avoid race condition by only querying for jobs from at least the day before

### Details and comments
Fixes #1817 

