### PR TITLE
Add back alias docs pages for Sampler and Estimator

### DIFF
--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -185,7 +185,9 @@ Classes
    :toctree: ../stubs/
 
    QiskitRuntimeService
+   Estimator
    EstimatorV2
+   Sampler
    SamplerV2
    Session
    Batch


### PR DESCRIPTION
This results in a dedicated docs page being created like below. This is useful to avoid 404ing the page and to make extra-explicit that Estimator is now an alias for EstimatorV2.

<img width="333" alt="Screenshot 2024-08-16 at 9 30 32 AM" src="https://github.com/user-attachments/assets/51b83d7e-2930-431e-8733-577c04ccb452">
