### PR TITLE
Exposing `NoiseLearnerOptions` in docs

### DIFF
--- a/qiskit_ibm_runtime/options/__init__.py
+++ b/qiskit_ibm_runtime/options/__init__.py
@@ -68,6 +68,7 @@ Suboptions
 .. autosummary::
    :toctree: ../stubs/
 
+   NoiseLearnerOptions
    DynamicalDecouplingOptions
    ResilienceOptionsV2
    LayerNoiseLearningOptions


### PR DESCRIPTION
This PR exposes `NoiseLearnerOptions` in docs, so that they become visible in the website