### PR TITLE
Fix zne options doc

### DIFF
--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -36,7 +36,7 @@ ExtrapolatorType = Literal[
 class ZneOptions:
     """Zero noise extrapolation mitigation options. This is only used by the V2 Estimator.
 
-    ..note::
+    .. note::
 
         Any V2 estimator is guaranteed to return data fields called ``evs`` and ``stds`` that
         report the desired expectation value estimates and errors, respectively.

--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -62,7 +62,7 @@ class ZneOptions:
            ``ensemble_stds_noise_factors`` assumes only shot noise and no drift.
 
         Technical note: for single observables with multiple basis terms it might turn out that
-        multiple extrapolation methods are used in _the same_ expectation value, for example, ``XX``
+        multiple extrapolation methods are used in *the same* expectation value, for example, ``XX``
         gets linearly extrapolated but ``XY`` gets exponentially extrapolated in the observable
         ``{"XX": 0.5, "XY": 0.5}``. Let's call this a *hetergeneous fit*. The data from (2) is
         evaluated from heterogeneous fits by selecting the best fit for every individual distinct


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Zne options doc is not rendering correctly 

https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.ZneOptions

<img width="895" alt="Screenshot 2024-08-21 at 10 40 30 AM" src="https://github.com/user-attachments/assets/03e57744-d328-4118-a45f-7e7ae73eb7d6">


### Details and comments
Fixes #

