### PR TITLE
Deprecate simulator `noise_model` option

### DIFF
--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -172,6 +172,16 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
 
         logger.info("Submitting job using options %s", primitive_options)
 
+        if not isinstance(self._service, QiskitRuntimeLocalService):
+            if primitive_options.get("options", {}).get("simulator", {}).get("noise_model"):
+                issue_deprecation_msg(
+                    msg="The noise_model option is deprecated",
+                    version="0.29.0",
+                    remedy="Use the local testing mode instead.",
+                    period="3 months",
+                    stacklevel=3,
+                )
+
         # Batch or Session
         if self._mode:
             return self._mode.run(

--- a/release-notes/unreleased/1892.deprecation.rst
+++ b/release-notes/unreleased/1892.deprecation.rst
@@ -1,0 +1,2 @@
+The simulator option ``noise_model`` is now deprecated for jobs running on real devices. 
+``noise_model`` will still be an acceptable option when using the local testing mode.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Fixes #

