### PR TITLE
Don't create new session in `from_id()`

### DIFF
--- a/qiskit_ibm_runtime/batch.py
+++ b/qiskit_ibm_runtime/batch.py
@@ -88,6 +88,7 @@ class Batch(Session):
         service: Optional[QiskitRuntimeService] = None,
         backend: Optional[Union[str, BackendV1, BackendV2]] = None,
         max_time: Optional[Union[int, str]] = None,
+        new_session: Optional[bool] = True,
     ):
         """Batch constructor.
 
@@ -105,6 +106,10 @@ class Batch(Session):
                 This value must be less than the
                 `system imposed maximum
                 <https://docs.quantum.ibm.com/guides/max-execution-time>`_.
+
+            new_session:
+                Creates a new session. This defaults to true and should only be false when using
+                ``from_id()`` where a new session should not be created.
 
         Raises:
             ValueError: If an input value is invalid.
@@ -127,7 +132,9 @@ class Batch(Session):
                 period="3 months",
             )
 
-        super().__init__(service=service, backend=backend, max_time=max_time)
+        super().__init__(
+            service=service, backend=backend, max_time=max_time, new_session=new_session
+        )
 
     def _create_session(self) -> Optional[str]:
         """Create a session."""

--- a/qiskit_ibm_runtime/batch.py
+++ b/qiskit_ibm_runtime/batch.py
@@ -88,7 +88,7 @@ class Batch(Session):
         service: Optional[QiskitRuntimeService] = None,
         backend: Optional[Union[str, BackendV1, BackendV2]] = None,
         max_time: Optional[Union[int, str]] = None,
-        new_session: Optional[bool] = True,
+        _new_session: Optional[bool] = True,
     ):
         """Batch constructor.
 
@@ -106,10 +106,6 @@ class Batch(Session):
                 This value must be less than the
                 `system imposed maximum
                 <https://docs.quantum.ibm.com/guides/max-execution-time>`_.
-
-            new_session:
-                Creates a new session. This defaults to true and should only be false when using
-                ``from_id()`` where a new session should not be created.
 
         Raises:
             ValueError: If an input value is invalid.
@@ -133,7 +129,7 @@ class Batch(Session):
             )
 
         super().__init__(
-            service=service, backend=backend, max_time=max_time, new_session=new_session
+            service=service, backend=backend, max_time=max_time, _new_session=_new_session
         )
 
     def _create_session(self) -> Optional[str]:

--- a/qiskit_ibm_runtime/batch.py
+++ b/qiskit_ibm_runtime/batch.py
@@ -83,12 +83,13 @@ class Batch(Session):
     <https://docs.quantum.ibm.com/guides/run-jobs-batch>`_" page.
     """
 
+    _create_new_session = True
+
     def __init__(
         self,
         service: Optional[QiskitRuntimeService] = None,
         backend: Optional[Union[str, BackendV1, BackendV2]] = None,
         max_time: Optional[Union[int, str]] = None,
-        _new_session: Optional[bool] = True,
     ):
         """Batch constructor.
 
@@ -128,13 +129,11 @@ class Batch(Session):
                 period="3 months",
             )
 
-        super().__init__(
-            service=service, backend=backend, max_time=max_time, _new_session=_new_session
-        )
+        super().__init__(service=service, backend=backend, max_time=max_time)
 
     def _create_session(self) -> Optional[str]:
         """Create a session."""
-        if isinstance(self._service, QiskitRuntimeService):
+        if isinstance(self._service, QiskitRuntimeService) and Batch._create_new_session:
             session = self._service._api_client.create_session(
                 self.backend(), self._instance, self._max_time, self._service.channel, "batch"
             )

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -87,7 +87,7 @@ class Session:
         service: Optional[QiskitRuntimeService] = None,
         backend: Optional[Union[str, BackendV1, BackendV2]] = None,
         max_time: Optional[Union[int, str]] = None,
-        new_session: Optional[bool] = True,
+        _new_session: Optional[bool] = True,
     ):  # pylint: disable=line-too-long
         """Session constructor.
 
@@ -105,11 +105,6 @@ class Session:
                 This value must be less than the
                 `system imposed maximum
                 <https://docs.quantum.ibm.com/guides/max-execution-time>`_.
-
-            new_session:
-                Creates a new session. This defaults to true and should only be false when using
-                ``from_id()`` where a new session should not be created.
-
         Raises:
             ValueError: If an input value is invalid.
         """
@@ -165,7 +160,7 @@ class Session:
 
         if isinstance(self._backend, IBMBackend):
             self._instance = self._backend._instance
-            if not self._backend.configuration().simulator and new_session:
+            if not self._backend.configuration().simulator and _new_session:
                 self._session_id = self._create_session()
 
     def _create_session(self) -> Optional[str]:
@@ -381,7 +376,7 @@ class Session:
                 f"Input ID {session_id} has execution mode {mode} instead of {class_name}."
             )
 
-        session = cls(service, backend, new_session=False)
+        session = cls(service, backend, _new_session=False)
         if state == "closed":
             session._active = False
         session._session_id = session_id

--- a/release-notes/unreleased/1896.bug.rst
+++ b/release-notes/unreleased/1896.bug.rst
@@ -1,0 +1,2 @@
+Fixed an issue where ``Session.from_id()`` would create 
+a new empty session. 

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -151,6 +151,8 @@ class TestSession(IBMTestCase):
         session_id = "123"
         session = Session.from_id(session_id=session_id, service=service)
         session.run(program_id="foo", inputs={})
+        session._create_session = MagicMock()
+        self.assertTrue(session._create_session.assert_not_called)
         self.assertEqual(session.session_id, session_id)
 
     def test_correct_execution_mode(self):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`Session.from_id()` calls the POST /Session endpoint which is unnecessary because the session and session id already exist 

### Details and comments
Fixes #1895 

