### PR TITLE
Move from_dict import

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -39,6 +39,7 @@ except ImportError:
 
 try:
     import qiskit_aer
+    from qiskit_ibm_runtime.utils.noise_model import from_dict
 
     HAS_AER = True
 except ImportError:
@@ -70,8 +71,9 @@ from qiskit.primitives.containers import (
     SamplerPubResult,
     PrimitiveResult,
 )
-from qiskit_ibm_runtime.options.zne_options import ExtrapolatorType
-from qiskit_ibm_runtime.utils.noise_model import from_dict
+from qiskit_ibm_runtime.options.zne_options import (  # pylint: disable=ungrouped-imports
+    ExtrapolatorType,
+)
 
 _TERRA_VERSION = tuple(
     int(x) for x in re.match(r"\d+\.\d+\.\d", _terra_version_string).group(0).split(".")[:3]


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Move `from_dict` import so there is no import error if `qiskit-aer` is not installed. 

### Details and comments
Fixes #1899 

