### PR TITLE
Adding `fallback` option to ZNE extrapolators

### DIFF
--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -29,6 +29,7 @@ ExtrapolatorType = Literal[
     "polynomial_degree_5",
     "polynomial_degree_6",
     "polynomial_degree_7",
+    "fallback",
 ]
 
 
@@ -116,6 +117,8 @@ class ZneOptions:
                 * ``"polynomial_degree_(1 <= k <= 7)"``, which uses a polynomial function defined as
                   :math:`f(x; c_0, c_1, \\ldots, c_k) = \\sum_{i=0, k} c_i x^i`.
                 * ``"linear"``, which is equivalent to ``"polynomial_degree_1"``.
+                * ``"fallback"``, which simply returns the raw data corresponding to the lowest noise
+                  factor (typically ``1``) without performing any sort of extrapolation.
 
             If more than one extrapolator is specified, the ``evs`` and ``stds`` reported in the
             result's data refer to the first one, while the extrapolated values

--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -170,6 +170,7 @@ class ZneOptions:
             "linear": 2,
             "exponential": 2,
             "double_exponential": 4,
+            "fallback": 1,
         }
         for idx in range(1, 8):
             required_factors[f"polynomial_degree_{idx}"] = idx + 1

--- a/release-notes/unreleased/1902.feat.rst
+++ b/release-notes/unreleased/1902.feat.rst
@@ -1,0 +1,1 @@
+Added ``fallback`` option to ZNE extrapolators.


### PR DESCRIPTION
Closes [#1629](https://github.com/Qiskit/qiskit-ibm-runtime/issues/1629)

Tested it on a bunch of jobs, including:
- `cvbncgjkmd10008ph1z0`
- `cvbndkyvawwg0088xn30`

