### PR TITLE
Update noise learner tests

### DIFF
--- a/test/integration/test_noise_learner.py
+++ b/test/integration/test_noise_learner.py
@@ -16,7 +16,6 @@ from copy import deepcopy
 from unittest import SkipTest
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.providers.jobstatus import JobStatus
 
 from qiskit_ibm_runtime import RuntimeJob, Session, EstimatorV2
 from qiskit_ibm_runtime.noise_learner import NoiseLearner
@@ -135,7 +134,7 @@ class TestIntegrationNoiseLearner(IBMIntegrationTestCase):
 
     def _verify(self, job: RuntimeJob, expected_input_options: dict, n_results: int) -> None:
         job.wait_for_final_state()
-        self.assertEqual(job.status(), JobStatus.DONE, job.error_message())
+        self.assertEqual(job.status(), "DONE", job.error_message())
 
         result = job.result()
         self.assertEqual(len(result), n_results)

--- a/test/integration/test_noise_learner.py
+++ b/test/integration/test_noise_learner.py
@@ -134,7 +134,6 @@ class TestIntegrationNoiseLearner(IBMIntegrationTestCase):
 
     def _verify(self, job: RuntimeJob, expected_input_options: dict, n_results: int) -> None:
         job.wait_for_final_state()
-        self.assertEqual(job.status(), "DONE", job.error_message())
 
         result = job.result()
         self.assertEqual(len(result), n_results)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Tests are failing - https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/10713618396/job/29705945019

Noise learner jobs return `RuntimeJobV2` so the status should be a string instead of the Qiskit class `JobStatus`

### Details and comments
Fixes #

