### PR TITLE
Make `NoiseLearnerResult` JSON serializable

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -77,6 +77,8 @@ from qiskit_ibm_runtime.options.zne_options import (  # pylint: disable=ungroupe
 )
 from qiskit_ibm_runtime.execution_span import SliceSpan, ExecutionSpans
 
+from .noise_learner_result import NoiseLearnerResult
+
 _TERRA_VERSION = tuple(
     int(x) for x in re.match(r"\d+\.\d+\.\d", _terra_version_string).group(0).split(".")[:3]
 )
@@ -322,6 +324,9 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, PrimitiveResult):
             out_val = {"pub_results": obj._pub_results, "metadata": obj.metadata}
             return {"__type__": "PrimitiveResult", "__value__": out_val}
+        if isinstance(obj, NoiseLearnerResult):
+            out_val = {"data": obj.data, "metadata": obj.metadata}
+            return {"__type__": "NoiseLearnerResult", "__value__": out_val}
         if isinstance(obj, SliceSpan):
             out_val = {
                 "start": obj.start,
@@ -443,6 +448,8 @@ class RuntimeDecoder(json.JSONDecoder):
                 return PubResult(**obj_val)
             if obj_type == "PrimitiveResult":
                 return PrimitiveResult(**obj_val)
+            if obj_type == "NoiseLearnerResult":
+                return NoiseLearnerResult(**obj_val)
             if obj_type == "ExecutionSpan":
                 new_slices = {
                     int(idx): (tuple(shape), slice(*sl_args))

--- a/qiskit_ibm_runtime/utils/noise_learner_result.py
+++ b/qiskit_ibm_runtime/utils/noise_learner_result.py
@@ -205,7 +205,7 @@ class NoiseLearnerResult:
                 pubs should be placed in their metadata fields. Keys are expected to be strings.
         """
         self._data = list(data)
-        self._metadata = metadata.copy() or {}
+        self._metadata = {} if metadata is None else metadata.copy()
 
     @property
     def data(self) -> List[LayerError]:

--- a/release-notes/unreleased/1908.feat.rst
+++ b/release-notes/unreleased/1908.feat.rst
@@ -1,0 +1,1 @@
+Added logic to encode and decode ``NoiseLearnerResult``.

--- a/test/integration/test_noise_learner.py
+++ b/test/integration/test_noise_learner.py
@@ -16,7 +16,6 @@ from copy import deepcopy
 from unittest import SkipTest
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.providers.jobstatus import JobStatus
 
 from qiskit_ibm_runtime import RuntimeJob, Session, EstimatorV2
 from qiskit_ibm_runtime.noise_learner import NoiseLearner
@@ -135,7 +134,6 @@ class TestIntegrationNoiseLearner(IBMIntegrationTestCase):
 
     def _verify(self, job: RuntimeJob, expected_input_options: dict, n_results: int) -> None:
         job.wait_for_final_state()
-        self.assertEqual(job.status(), JobStatus.DONE, job.error_message())
 
         result = job.result()
         self.assertEqual(len(result), n_results)

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -41,7 +41,11 @@ from qiskit.primitives.containers import (
 )
 from qiskit_aer.noise import NoiseModel
 from qiskit_ibm_runtime.utils import RuntimeEncoder, RuntimeDecoder
-from qiskit_ibm_runtime.utils.noise_learner_result import PauliLindbladError, LayerError, NoiseLearnerResult
+from qiskit_ibm_runtime.utils.noise_learner_result import (
+    PauliLindbladError,
+    LayerError,
+    NoiseLearnerResult,
+)
 from qiskit_ibm_runtime.fake_provider import FakeNairobi
 from qiskit_ibm_runtime.execution_span import SliceSpan, ExecutionSpans
 
@@ -454,7 +458,7 @@ class TestContainerSerialization(IBMTestCase):
         result = PrimitiveResult(pub_results, metadata)
         primitive_results.append(result)
         return primitive_results
-    
+
     def make_test_noise_learner_results(self):
         """Generates test data for NoiseLearnerResult test"""
         noise_learner_results = []

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -26,7 +26,7 @@ from qiskit.circuit import Parameter, ParameterVector, QuantumCircuit
 from qiskit.circuit.library import EfficientSU2, CXGate, PhaseGate, U2Gate
 
 import qiskit.quantum_info as qi
-from qiskit.quantum_info import SparsePauliOp, Pauli
+from qiskit.quantum_info import SparsePauliOp, Pauli, PauliList
 from qiskit.result import Result, Counts
 from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.observables_array import ObservablesArray
@@ -41,6 +41,7 @@ from qiskit.primitives.containers import (
 )
 from qiskit_aer.noise import NoiseModel
 from qiskit_ibm_runtime.utils import RuntimeEncoder, RuntimeDecoder
+from qiskit_ibm_runtime.utils.noise_learner_result import PauliLindbladError, LayerError, NoiseLearnerResult
 from qiskit_ibm_runtime.fake_provider import FakeNairobi
 from qiskit_ibm_runtime.execution_span import SliceSpan, ExecutionSpans
 
@@ -333,6 +334,25 @@ class TestContainerSerialization(IBMTestCase):
 
         self.assertEqual(primitive_result1.metadata, primitive_result2.metadata)
 
+    def assert_pauli_lindblad_error_equal(self, error1, error2):
+        """Tests that two PauliLindbladError objects are equal"""
+        self.assertEqual(error1.generators, error2.generators)
+        self.assertEqual(error1.rates.tolist(), error2.rates.tolist())
+
+    def assert_layer_errors_equal(self, layer_error1, layer_error2):
+        """Tests that two LayerError objects are equal"""
+        self.assertEqual(layer_error1.circuit, layer_error2.circuit)
+        self.assertEqual(layer_error1.qubits, layer_error2.qubits)
+        self.assert_pauli_lindblad_error_equal(layer_error1.error, layer_error2.error)
+
+    def assert_noise_learner_results_equal(self, result1, result2):
+        """Tests that two NoiseLearnerResult objects are equal"""
+        self.assertEqual(len(result1), len(result2))
+        for layer_error1, layer_error2 in zip(result1, result2):
+            self.assert_layer_errors_equal(layer_error1, layer_error2)
+
+        self.assertEqual(result1.metadata, result2.metadata)
+
     # Data generation methods
 
     def make_test_data_bins(self):
@@ -434,6 +454,19 @@ class TestContainerSerialization(IBMTestCase):
         result = PrimitiveResult(pub_results, metadata)
         primitive_results.append(result)
         return primitive_results
+    
+    def make_test_noise_learner_results(self):
+        """Generates test data for NoiseLearnerResult test"""
+        noise_learner_results = []
+        circuit = QuantumCircuit(2)
+        circuit.cx(0, 1)
+        circuit.measure_all()
+        error = PauliLindbladError(PauliList(["XX", "ZZ"]), [0.1, 0.2])
+        layer_error = LayerError(circuit, [3, 5], error)
+
+        noise_learner_result = NoiseLearnerResult([layer_error])
+        noise_learner_results.append(noise_learner_result)
+        return noise_learner_results
 
     # Tests
     @data(
@@ -558,6 +591,15 @@ class TestContainerSerialization(IBMTestCase):
             decoded = json.loads(encoded, cls=RuntimeDecoder)["primitive_result"]
             self.assertIsInstance(decoded, PrimitiveResult)
             self.assert_primitive_results_equal(primitive_result, decoded)
+
+    def test_noise_learner_result(self):
+        """Test encoding and decoding NoiseLearnerResult"""
+        for noise_learner_result in self.make_test_noise_learner_results():
+            payload = {"noise_learner_result": noise_learner_result}
+            encoded = json.dumps(payload, cls=RuntimeEncoder)
+            decoded = json.loads(encoded, cls=RuntimeDecoder)["noise_learner_result"]
+            self.assertIsInstance(decoded, NoiseLearnerResult)
+            self.assert_noise_learner_results_equal(noise_learner_result, decoded)
 
     def test_unknown_settings(self):
         """Test settings not on whitelisted path."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Allows `NoiseLearnerResult` to be JSON serialized/deserialized with the `RuntimeEncoder` and `RuntimeDecoder`.


### Details and comments
Fixes #1908 

