### PR TITLE
Fix missing fractional gates in primitive in session

### DIFF
--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -109,7 +109,11 @@ def _get_mode_service_backend(
     elif get_cm_session():
         mode = get_cm_session()
         service = mode.service  # type: ignore
-        backend = service.backend(name=mode.backend(), instance=mode._instance)  # type: ignore
+        backend = service.backend(
+            name=mode.backend(),  # type: ignore
+            instance=mode._instance,  # type: ignore
+            use_fractional_gates=mode._backend.options.use_fractional_gates,  # type: ignore
+        )
         return mode, service, backend  # type: ignore
     else:
         raise ValueError("A backend or session must be specified.")

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -109,11 +109,17 @@ def _get_mode_service_backend(
     elif get_cm_session():
         mode = get_cm_session()
         service = mode.service  # type: ignore
-        backend = service.backend(
-            name=mode.backend(),  # type: ignore
-            instance=mode._instance,  # type: ignore
-            use_fractional_gates=mode._backend.options.use_fractional_gates,  # type: ignore
-        )
+        try:
+            backend = service.backend(
+                name=mode.backend(),  # type: ignore
+                instance=mode._instance,  # type: ignore
+                use_fractional_gates=mode._backend.options.use_fractional_gates,  # type: ignore
+            )
+        except (AttributeError, TypeError):
+            backend = service.backend(
+                name=mode.backend(),  # type: ignore
+                instance=mode._instance,  # type: ignore
+            )
         return mode, service, backend  # type: ignore
     else:
         raise ValueError("A backend or session must be specified.")

--- a/release-notes/unreleased/1922.but.rst
+++ b/release-notes/unreleased/1922.but.rst
@@ -1,0 +1,1 @@
+Fix a bug that we cannot run primitives in the session context with fractional gates.

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -15,12 +15,13 @@
 from unittest.mock import MagicMock, patch
 
 from qiskit_ibm_runtime.fake_provider import FakeManila
-from qiskit_ibm_runtime import Session
+from qiskit_ibm_runtime import Session, SamplerV2
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
 from qiskit_ibm_runtime.exceptions import IBMRuntimeError
 from qiskit_ibm_runtime.utils.default_session import _DEFAULT_SESSION
 
 from .mock.fake_runtime_service import FakeRuntimeService
+from .mock.fake_api_backend import FakeApiBackendSpecs
 from ..ibm_test_case import IBMTestCase
 from ..utils import get_mocked_backend
 
@@ -160,3 +161,15 @@ class TestSession(IBMTestCase):
         _ = FakeRuntimeService(channel="ibm_quantum", token="abc")
         session = Session(backend="common_backend")
         self.assertEqual(session.details()["mode"], "dedicated")
+
+    def test_cm_session_fractional(self):
+        """Test instantiating primitive inside session context manager with the fractional optin."""
+        service = FakeRuntimeService(
+            channel="ibm_quantum",
+            token="abc",
+            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
+        )
+        backend = service.backend("fake_fractional", use_fractional_gates=True)
+        with Session(backend=backend) as _:
+            primitive = SamplerV2()
+            self.assertTrue(primitive._backend.options.use_fractional_gates)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We cannot run primitive inside session with fractional gates. This PR fixes the bug.

### Details and comments

This is the current behavior:
```python
from qiskit_ibm_runtime import QiskitRuntimeService, Session, SamplerV2

service = QiskitRuntimeService()
backend = service.backend(use_fractional_gates=True)

with Session(backend=backend) as _:
    primitive = SamplerV2()
    assert primitive._backend.options.use_fractional_gates is True  # fail
```

Because of this, this session fails in running the primitives because of the ISA circuit validation. When we instantiate a primitive inside the session context, the backend is reloaded from the service attached to the session without the optin flag.