### PR TITLE
Fix missing version in home page for developer docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 #########################################
-Qiskit Runtime |version| API Docs Preview
+Qiskit Runtime |release| API Docs Preview
 #########################################
 
 Qiskit Runtime docs live at docs.quantum.ibm.com and come from https://github.com/Qiskit/documentation.
@@ -7,14 +7,8 @@ This site is only used to generate our API docs, which then get migrated to
 https://github.com/Qiskit/documentation.
 
 .. toctree::
-   :maxdepth: 1
    :hidden:
-   :caption: Reference
 
+    Documentation home <self>
     API Reference <apidocs/index>
     Release Notes <release_notes>
-
-.. Hiding - Indices and tables
-   :ref:`genindex`
-   :ref:`modindex`
-   :ref:`search`


### PR DESCRIPTION
This has no impact on end users, only the Sphinx docs used by qiskit-ibm-runtime devs.

Before:

<img width="942" alt="Screenshot 2024-09-17 at 1 13 41 PM" src="https://github.com/user-attachments/assets/7ae5ae2b-ed81-446a-af11-8afe8d6aa660">

After:

<img width="941" alt="Screenshot 2024-09-17 at 1 13 54 PM" src="https://github.com/user-attachments/assets/0dc6ab44-2297-432a-887a-d20c2c649ac6">