### PR TITLE
Allow retrieving a backend with no instruction filtering

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -258,14 +258,21 @@ class IBMBackend(Backend):
     def _convert_to_target(self, refresh: bool = False) -> None:
         """Converts backend configuration, properties and defaults to Target object"""
         if refresh or not self._target:
+            if self.options.use_fractional_gates is None:
+                include_control_flow = True
+                include_fractional_gates = True
+            else:
+                # In IBM backend architecture as of today
+                # these features can be only exclusively supported.
+                include_control_flow = not self.options.use_fractional_gates
+                include_fractional_gates = self.options.use_fractional_gates
+
             self._target = convert_to_target(
                 configuration=self._configuration,  # type: ignore[arg-type]
                 properties=self._properties,
                 defaults=self._defaults,
-                # In IBM backend architecture as of today
-                # these features can be only exclusively supported.
-                include_control_flow=not self.options.use_fractional_gates,
-                include_fractional_gates=self.options.use_fractional_gates,
+                include_control_flow=include_control_flow,
+                include_fractional_gates=include_fractional_gates,
             )
 
     @classmethod

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -488,7 +488,7 @@ class QiskitRuntimeService:
         dynamic_circuits: Optional[bool] = None,
         filters: Optional[Callable[["ibm_backend.IBMBackend"], bool]] = None,
         *,
-        use_fractional_gates: bool = False,
+        use_fractional_gates: Optional[bool] = False,
         **kwargs: Any,
     ) -> List["ibm_backend.IBMBackend"]:
         """Return all backends accessible via this account, subject to optional filtering.
@@ -517,6 +517,8 @@ class QiskitRuntimeService:
                 algorithm, you must disable this flag to create executable ISA circuits.
                 This flag might be modified or removed when our backend
                 supports dynamic circuits and fractional gates simultaneously.
+                If ``None``, then both fractional gates and control flow operations are
+                included in the backend targets.
 
             **kwargs: Simple filters that require a specific value for an attribute in
                 backend configuration or status.
@@ -781,7 +783,7 @@ class QiskitRuntimeService:
         self,
         name: str = None,
         instance: Optional[str] = None,
-        use_fractional_gates: bool = False,
+        use_fractional_gates: Optional[bool] = False,
     ) -> Backend:
         """Return a single backend matching the specified filtering.
 
@@ -800,6 +802,8 @@ class QiskitRuntimeService:
                 algorithm, you must disable this flag to create executable ISA circuits.
                 This flag might be modified or removed when our backend
                 supports dynamic circuits and fractional gates simultaneously.
+                If ``None``, then both fractional gates and control flow operations are
+                included in the backend targets.
 
         Returns:
             Backend: A backend matching the filtering.

--- a/release-notes/unreleased/1938.feat.rst
+++ b/release-notes/unreleased/1938.feat.rst
@@ -1,0 +1,4 @@
+The ``use_fractional_gates`` flag for ``QiskitRuntimeService.backend()`` and
+``QiskitRuntimeService.backends()`` can now be ``None``. When set to ``None``,
+no instruction filtering is done, and the returned backend target may contain
+both fractional gates and control flow operations. 

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -316,3 +316,14 @@ class TestGetBackend(IBMTestCase):
         self.assertIn("rx", backend_with_fg.target)
 
         self.assertIsNot(backend_with_fg, backend_without_fg)
+
+    def test_get_backend_with_no_instr_filtering(self):
+        """Test getting backend with no instruction filtering."""
+        service = FakeRuntimeService(
+            channel="ibm_quantum",
+            token="my_token",
+            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
+        )
+        test_backend = service.backends("fake_fractional", use_fractional_gates=None)[0]
+        for instr in ["rx", "rzx", "if_else", "while_loop"]:
+            self.assertIn(instr, test_backend.target)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Today the `use_fractional_gates` flag is used to return the backend target with fractional gates OR with control flow operations. However, there are cases when a user wants to see all the instructions a backend supports. This PR allows `use_fractional_gates=None`, which will bypass the instruction filtering. 

### Details and comments
Fixes #1937

