### PR TITLE
Remove top-level plotly imports

### DIFF
--- a/qiskit_ibm_runtime/utils/noise_learner_result.py
+++ b/qiskit_ibm_runtime/utils/noise_learner_result.py
@@ -217,7 +217,7 @@ class LayerError:
         background_color: str = "white",
         radius: float = 0.25,
         width: int = 800,
-    ) -> "plotly.graph_objects.Figure":
+    ) -> "plotly.graph_objects.Figure":  # type: ignore
         r"""
         Draw a map view of a this layer error.
 

--- a/qiskit_ibm_runtime/utils/noise_learner_result.py
+++ b/qiskit_ibm_runtime/utils/noise_learner_result.py
@@ -24,7 +24,7 @@ NoiseLearner result classes (:mod:`qiskit_ibm_runtime.utils.noise_learner_result
 
 from __future__ import annotations
 
-from typing import Any, Iterator, Sequence, Union
+from typing import Any, Iterator, Sequence, Union, TYPE_CHECKING
 from numpy.typing import NDArray
 import numpy as np
 
@@ -34,6 +34,9 @@ from qiskit.quantum_info import PauliList
 
 from ..utils.embeddings import Embedding
 from ..utils.deprecation import issue_deprecation_msg
+
+if TYPE_CHECKING:
+    import plotly.graph_objs as go
 
 
 class PauliLindbladError:
@@ -217,7 +220,7 @@ class LayerError:
         background_color: str = "white",
         radius: float = 0.25,
         width: int = 800,
-    ) -> "plotly.graph_objects.Figure":  # type: ignore
+    ) -> go.Figure:
         r"""
         Draw a map view of a this layer error.
 

--- a/qiskit_ibm_runtime/utils/noise_learner_result.py
+++ b/qiskit_ibm_runtime/utils/noise_learner_result.py
@@ -32,8 +32,6 @@ from qiskit.providers.backend import BackendV2
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import PauliList
 
-import plotly.graph_objects as go
-
 from ..utils.embeddings import Embedding
 from ..utils.deprecation import issue_deprecation_msg
 
@@ -219,7 +217,7 @@ class LayerError:
         background_color: str = "white",
         radius: float = 0.25,
         width: int = 800,
-    ) -> go.Figure:
+    ) -> "plotly.graph_objects.Figure":
         r"""
         Draw a map view of a this layer error.
 
@@ -236,6 +234,7 @@ class LayerError:
             width: The width of the returned figure.
         """
         # pylint: disable=import-outside-toplevel, cyclic-import
+
         from ..visualization import draw_layer_error_map
 
         return draw_layer_error_map(

--- a/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
+++ b/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
@@ -54,7 +54,7 @@ def draw_layer_error_map(
     Raises:
         ValueError: If the given coordinates are incompatible with the specified backend.
         ValueError: If ``backend`` has no coupling map.
-        ModuleNotFoundError: If the required ``plotly`` dependencies cannot be imported. 
+        ModuleNotFoundError: If the required ``plotly`` dependencies cannot be imported.
     """
     # pylint: disable=import-outside-toplevel
 

--- a/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
+++ b/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
@@ -34,7 +34,7 @@ def draw_layer_error_map(
     background_color: str = "white",
     radius: float = 0.25,
     width: int = 800,
-) -> "plotly.graph_objects.Figure":
+) -> "plotly.graph_objects.Figure":  # type: ignore
     r"""
     Draw a map view of a :class:`~.LayerError`.
 
@@ -57,8 +57,11 @@ def draw_layer_error_map(
     """
     # pylint: disable=import-outside-toplevel
 
-    import plotly.graph_objects as go
-    from plotly.colors import sample_colorscale
+    try:
+        import plotly.graph_objects as go
+        from plotly.colors import sample_colorscale
+    except ModuleNotFoundError as msg:
+            raise ModuleNotFoundError(f"Failed to import 'plotly' dependencies with error: {msg}.")
 
     fig = go.Figure(layout=go.Layout(width=width, height=height))
 

--- a/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
+++ b/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 from typing import Dict, Tuple, Union
 
 import numpy as np
-import plotly.graph_objects as go
-from plotly.colors import sample_colorscale
 from qiskit.providers.backend import BackendV2
 
 from ..utils.embeddings import Embedding
@@ -36,7 +34,7 @@ def draw_layer_error_map(
     background_color: str = "white",
     radius: float = 0.25,
     width: int = 800,
-) -> go.Figure:
+) -> "plotly.graph_objects.Figure":
     r"""
     Draw a map view of a :class:`~.LayerError`.
 
@@ -57,6 +55,11 @@ def draw_layer_error_map(
         ValueError: If the given coordinates are incompatible with the specified backend.
         ValueError: If ``backend`` has no coupling map.
     """
+    # pylint: disable=import-outside-toplevel
+
+    import plotly.graph_objects as go
+    from plotly.colors import sample_colorscale
+
     fig = go.Figure(layout=go.Layout(width=width, height=height))
 
     if isinstance(embedding, BackendV2):

--- a/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
+++ b/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
@@ -54,6 +54,7 @@ def draw_layer_error_map(
     Raises:
         ValueError: If the given coordinates are incompatible with the specified backend.
         ValueError: If ``backend`` has no coupling map.
+        ModuleNotFoundError: If the required ``plotly`` dependencies cannot be imported. 
     """
     # pylint: disable=import-outside-toplevel
 

--- a/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
+++ b/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
@@ -61,7 +61,7 @@ def draw_layer_error_map(
         import plotly.graph_objects as go
         from plotly.colors import sample_colorscale
     except ModuleNotFoundError as msg:
-            raise ModuleNotFoundError(f"Failed to import 'plotly' dependencies with error: {msg}.")
+        raise ModuleNotFoundError(f"Failed to import 'plotly' dependencies with error: {msg}.")
 
     fig = go.Figure(layout=go.Layout(width=width, height=height))
 

--- a/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
+++ b/qiskit_ibm_runtime/visualization/draw_layer_error_map.py
@@ -13,7 +13,7 @@
 """Functions to visualize :class:`~.NoiseLearnerResult` objects."""
 
 from __future__ import annotations
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 from qiskit.providers.backend import BackendV2
@@ -21,6 +21,9 @@ from qiskit.providers.backend import BackendV2
 from ..utils.embeddings import Embedding
 from ..utils.noise_learner_result import LayerError
 from .utils import get_rgb_color, pie_slice
+
+if TYPE_CHECKING:
+    import plotly.graph_objs as go
 
 
 def draw_layer_error_map(
@@ -34,7 +37,7 @@ def draw_layer_error_map(
     background_color: str = "white",
     radius: float = 0.25,
     width: int = 800,
-) -> "plotly.graph_objects.Figure":  # type: ignore
+) -> go.Figure:
     r"""
     Draw a map view of a :class:`~.LayerError`.
 

--- a/test/unit/test_noise_learner_result.py
+++ b/test/unit/test_noise_learner_result.py
@@ -12,9 +12,8 @@
 
 """Tests for the classes used to instantiate noise learner results."""
 
+from unittest import skipIf
 from ddt import ddt, data
-
-import plotly.graph_objects as go
 
 from qiskit import QuantumCircuit
 from qiskit.quantum_info import PauliList
@@ -24,6 +23,13 @@ from qiskit_ibm_runtime.fake_provider.local_service import QiskitRuntimeLocalSer
 from qiskit_ibm_runtime.utils.noise_learner_result import PauliLindbladError, LayerError
 
 from ..ibm_test_case import IBMTestCase
+
+try:
+    import plotly.graph_objects as go
+
+    PLOTLY_INSTALLED = True
+except ImportError:
+    PLOTLY_INSTALLED = False
 
 
 class TestPauliLindbladError(IBMTestCase):
@@ -151,6 +157,7 @@ class TestLayerError(IBMTestCase):
             self.assertEqual(layer_error1.generators, layer_error2.generators)
             self.assertEqual(layer_error1.rates.tolist(), layer_error2.rates.tolist())
 
+    @skipIf(not PLOTLY_INSTALLED, reason="Plotly is not installed")
     def test_no_coupling_map(self):
         r"""
         Tests the `draw_map` function with invalid coordinates.
@@ -158,6 +165,7 @@ class TestLayerError(IBMTestCase):
         with self.assertRaises(ValueError):
             self.layer_error_viz.draw_map(AerSimulator())
 
+    @skipIf(not PLOTLY_INSTALLED, reason="Plotly is not installed")
     @data(["fake_hanoi", 44], ["fake_kyiv", 160])
     def test_plotting(self, inputs):
         r"""


### PR DESCRIPTION
A previous PR added `plotly` as an optional dependency. Yet, a few files do top-level import of `plotly`, which errors unless users have `plotly` pre-installed. This PR fixes the issue by moving `plotly` imports inside the functions that need it