### PR TITLE
Bug fix: ISA check inside control flow operations whose body is defined in a separate circuit

### DIFF
--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -80,7 +80,11 @@ def _is_isa_circuit_helper(circuit: QuantumCircuit, target: Target, qubit_map: D
 
         if isinstance(operation, ControlFlowOp):
             for sub_circ in operation.blocks:
-                sub_string = _is_isa_circuit_helper(sub_circ, target, qubit_map)
+                inner_map = {
+                    inner: qubit_map[outer]
+                    for outer, inner in zip(instruction.qubits, sub_circ.qubits)
+                }
+                sub_string = _is_isa_circuit_helper(sub_circ, target, inner_map)
                 if sub_string:
                     return sub_string
 


### PR DESCRIPTION
#1916 fixed a bug related to connectivity inside control operations. @jakelishman [has pointed out](https://github.com/Qiskit/qiskit/issues/13227#issuecomment-2377404138) a case where the fix does not apply correctly. The case is exemplified in the test `test_isa_inside_condition_block_body_in_separate_circuit`, which is added in the current PR. Running the test, either on Shrebrooke or Cusco, results with
```
qiskit_ibm_runtime/utils/utils.py:61: in _is_isa_circuit_helper
    qargs = tuple(qubit_map[bit] for bit in instruction.qubits)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

.0 = <tuple_iterator object at 0x7f3c30d83af0>

>   qargs = tuple(qubit_map[bit] for bit in instruction.qubits)
E   KeyError: Qubit(QuantumRegister(2, 'inner'), 0)
```
The current PR fixes the error, and makes the test pass.

The fix is copied from qiskit's `GatesInBasis` pass, from a previous version where the pass was still written in Python.
