### PR TITLE
Fix GitHub source code links for decorated functions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,17 +176,26 @@ def linkcode_resolve(domain, info):
     if module is None or "qiskit_ibm_runtime" not in module_name:
         return None
 
+    def is_valid_code_object(obj):
+        return (
+            inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
+        )
+
     obj = module
     for part in info["fullname"].split("."):
         try:
             obj = getattr(obj, part)
         except AttributeError:
             return None
-        is_valid_code_object = (
-            inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
-        )
-        if not is_valid_code_object:
+        if not is_valid_code_object(obj):
             return None
+
+    # Unwrap decorators. This requires they used `functools.wrap()`.
+    while hasattr(obj, "__wrapped__"):
+        obj = getattr(obj, "__wrapped__")
+        if not is_valid_code_object(obj):
+            return None
+
     try:
         full_file_name = inspect.getsourcefile(obj)
     except TypeError:


### PR DESCRIPTION
This was detected in https://github.com/Qiskit/documentation/issues/2060. The GitHub source code links for decorated functions has been going to the decorator, rather than to the original function.

This fix requires that the decorator sets `functools.wraps`, which sets the attribute `__wrapped__`. All Runtime decorators use `wraps()`.
