### PR TITLE
Suppress repititive debug warnings in tests

### DIFF
--- a/test/unit/fake_provider/test_local_service.py
+++ b/test/unit/fake_provider/test_local_service.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test of generated fake backends."""
+import logging
 from ddt import data, ddt
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -24,6 +25,11 @@ from ...ibm_test_case import IBMTestCase
 @ddt
 class QiskitRuntimeLocalServiceTest(IBMTestCase):
     """Qiskit runtime local service test."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Initial class level setup."""
+        logging.basicConfig(level=logging.INFO)
 
     def test_backend(self):
         """Tests the ``backend`` method."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This warning is in our unit and integration tests 10,000+ times making logs difficult to read/debug. 
```
backend_converter.convert_to_target:DEBUG:2024-10-16 04:32:46,181: Gate calibration for instruction u3 on qubits (51,) is found in the PulseDefaults payload. However, this entry is not defined in the gate mapping of Target. This calibration is ignored.
```

### Details and comments
Fixes #

