### PR TITLE
Add backend method

### DIFF
--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -234,6 +234,10 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
         """Return options"""
         return self._options
 
+    def backend(self) -> BackendV1 | BackendV2:
+        """Return the backend the primitive query will be run on."""
+        return self._backend
+
     def _set_options(self, options: Optional[Union[Dict, OptionsT]] = None) -> None:
         """Set options."""
         if options is None:

--- a/qiskit_ibm_runtime/noise_learner/noise_learner.py
+++ b/qiskit_ibm_runtime/noise_learner/noise_learner.py
@@ -221,6 +221,10 @@ class NoiseLearner:
         """Return the program ID."""
         return "noise-learner"
 
+    def backend(self) -> BackendV2:
+        """Return the backend the primitive query will be run on."""
+        return self._backend
+
     def _set_options(
         self, options: Optional[Union[Dict, NoiseLearnerOptions, EstimatorOptions]] = None
     ) -> None:

--- a/release-notes/unreleased/1995.feat.rst
+++ b/release-notes/unreleased/1995.feat.rst
@@ -1,0 +1,2 @@
+:class:`.SamplerV2`, :class:`.EstimatorV2`, and :class:`.noise_learner.NoiseLearner` now each has
+a ``backend()`` method that returns the backend the class is configured with.

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -125,3 +125,9 @@ class TestNoiseLearner(IBMTestCase):
         """Test exception when circuits is not ISA."""
         with self.assertRaisesRegex(ValueError, "not currently supported in local mode"):
             NoiseLearner(FakeSherbrooke())
+
+    def test_get_backend(self):
+        """Test getting the backend used."""
+        backend = get_mocked_backend()
+        inst = NoiseLearner(backend)
+        self.assertEqual(inst.backend().name, backend.name)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add a `backend()` method to the primitives + `NoiseLearner`, so users can extract the backend the primitive is configured for. 

Note that similar to `job_id`, I would have preferred it to be an attribute rather than a method. But since it's already a method in `Job`, having that consistency is better. 

### Details and comments
Fixes #

