### PR TITLE
Fake backends correctly report themselves as simulators

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -151,6 +151,8 @@ class FakeBackendV2(BackendV2):
         conf_dict = self._load_json(self.conf_filename)  # type: ignore
         decode_backend_configuration(conf_dict)
         conf_dict["backend_name"] = self.backend_name
+        # Set simulator to True cause config comes from real system and has it False
+        conf_dict["simulator"] = True
         return conf_dict
 
     def _set_props_dict_from_json(self) -> None:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Since time began, FakeBackends have been reporting themselves as not being simulators because their configuration files come from real systems.  This forces people who use these systems for testing to use less than ideal coding practices, e.g. looking for `fake` in a name string, to identify these instances, and go from there.

This PR makes each backend report that they are indeed simulators, i.e. `backend.configuration().simulator = True`.  This makes using these fake backends easier in downstream packages.


### Details and comments
Fixes #

