### PR TITLE
Fix `draw_execution_spans()` hover text placement

### DIFF
--- a/qiskit_ibm_runtime/visualization/draw_execution_spans.py
+++ b/qiskit_ibm_runtime/visualization/draw_execution_spans.py
@@ -120,7 +120,7 @@ def draw_execution_spans(
 
             x_data.extend([span.start - offset, span.stop - offset, None])
             y_data.extend([y_value, y_value, None])
-            text_data.append(text)
+            text_data.extend([text] * 3)
 
         # add the data to the plot
         fig.add_trace(

--- a/release-notes/unreleased/2014.bug.rst
+++ b/release-notes/unreleased/2014.bug.rst
@@ -1,0 +1,2 @@
+Fix the location of hover text on the `draw_execution_spans()` function. Previous to this fix,
+they were drawn on the wrong markers.


### PR DESCRIPTION
### Summary

Prior to this PR, the location of hover text was off by a factor of three because they were not accounting for the fact that every plotted span essentially corresponds to three marker positions: the time start, the time stop, the None value indicating "move to the next one".

