### PR TITLE
Show span durations in `draw_execution_spans()`

### DIFF
--- a/qiskit_ibm_runtime/visualization/draw_execution_spans.py
+++ b/qiskit_ibm_runtime/visualization/draw_execution_spans.py
@@ -30,6 +30,7 @@ HOVER_TEMPLATE = "<br>".join(
         "<b>{name}[{idx}]</b>",
         "<b>&nbsp;&nbsp;&nbsp;Start:</b> {span.start:%Y-%m-%d %H:%M:%S.%f}",
         "<b>&nbsp;&nbsp;&nbsp;Stop:</b> {span.stop:%Y-%m-%d %H:%M:%S.%f}",
+        "<b>&nbsp;&nbsp;&nbsp;Duration:</b> {span.duration:.4g}s",
         "<b>&nbsp;&nbsp;&nbsp;Size:</b> {span.size}",
         "<b>&nbsp;&nbsp;&nbsp;Pub Indexes:</b> {idxs}",
     ]


### PR DESCRIPTION
### Summary

This PR adds a line of the span hover text that displays the duration of the span in seconds.

<img width="380" alt="image" src="https://github.com/user-attachments/assets/1411787b-29d9-493d-a44b-d589705ffafa">


### Details and comments
Fixes #

