### PR TITLE
Add generic channel for custom channel platformsGeneric channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ ibm_cloud_service = QiskitRuntimeService(channel="ibm_cloud", token="MY_IBM_CLOU
 
 # For an IBM Quantum account.
 ibm_quantum_service = QiskitRuntimeService(channel="ibm_quantum", token="MY_IBM_QUANTUM_TOKEN")
+
+# For a generic/custom channel platform.
+ibm_quantum_service = QiskitRuntimeService(channel="generic", token="MY_TOKEN", url="https://my.url:1234/")
 ```
 
 ## Primitives

--- a/qiskit_ibm_runtime/api/auth.py
+++ b/qiskit_ibm_runtime/api/auth.py
@@ -64,3 +64,33 @@ class QuantumAuth(AuthBase):
     def get_headers(self) -> Dict:
         """Return authorization information to be stored in header."""
         return {"X-Access-Token": self.access_token}
+
+
+class GenericAuth(AuthBase):
+    """Attaches Generic Authentication to the given Request object.\n
+    """
+
+    def __init__(self, api_key: str, crn: str):
+        self.api_key = api_key
+        self.crn = crn
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, GenericAuth):
+            return all(
+                [
+                    self.api_key == other.api_key,
+                    self.crn == other.crn,
+                ]
+            )
+        return False
+
+    def __call__(self, r: PreparedRequest) -> PreparedRequest:
+        r.headers.update(self.get_headers())
+        return r
+
+    def get_headers(self) -> Dict:
+        """Return authorization information to be stored in header."""
+        if self.crn is None:
+            return {"Authorization": f"apikey {self.api_key}"}
+        else:
+            return {"Service-CRN": self.crn, "Authorization": f"apikey {self.api_key}"}

--- a/qiskit_ibm_runtime/api/client_parameters.py
+++ b/qiskit_ibm_runtime/api/client_parameters.py
@@ -16,7 +16,7 @@ from typing import Dict, Optional, Any, Union, Callable
 from ..proxies import ProxyConfiguration
 
 from ..utils import default_runtime_url_resolver
-from ..api.auth import QuantumAuth, CloudAuth
+from ..api.auth import QuantumAuth, CloudAuth, GenericAuth
 
 TEMPLATE_IBM_HUBS = "{prefix}/Network/{hub}/Groups/{group}/Projects/{project}"
 """str: Template for creating an IBM Quantum URL with hub/group/project information."""
@@ -59,16 +59,21 @@ class ClientParameters:
             url_resolver = default_runtime_url_resolver
         self.url_resolver = url_resolver
 
-    def get_auth_handler(self) -> Union[CloudAuth, QuantumAuth]:
+    def get_auth_handler(self) -> Union[CloudAuth, QuantumAuth, GenericAuth]:
         """Returns the respective authentication handler."""
         if self.channel == "ibm_cloud":
             return CloudAuth(api_key=self.token, crn=self.instance)
-
-        return QuantumAuth(access_token=self.token)
+        elif self.channel == "generic":
+            return GenericAuth(api_key=self.token, crn=self.instance)
+        else:
+            return QuantumAuth(access_token=self.token)
 
     def get_runtime_api_base_url(self) -> str:
         """Returns the Runtime API base url."""
-        return self.url_resolver(self.url, self.instance, self.private_endpoint)
+        if self.channel == "generic":
+            return self.url
+        else:
+            return self.url_resolver(self.url, self.instance, self.private_endpoint)
 
     def connection_parameters(self) -> Dict[str, Any]:
         """Construct connection related parameters.

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -157,6 +157,9 @@ class QiskitRuntimeService:
         if self._channel == "ibm_cloud":
             self._api_client = RuntimeClient(self._client_params)
             self._backend_allowed_list = self._discover_cloud_backends()
+        elif self._channel == "generic":
+            self._api_client = RuntimeClient(self._client_params)
+            self._backend_allowed_list = self._discover_cloud_backends() # same way as in ibm_cloud
         else:
             auth_client = self._authenticate_ibm_quantum_account(self._client_params)
             # Update client parameters to use authenticated values.
@@ -213,8 +216,8 @@ class QiskitRuntimeService:
                     )
             account = AccountManager.get(filename=filename, name=name)
         elif channel:
-            if channel and channel not in ["ibm_cloud", "ibm_quantum"]:
-                raise ValueError("'channel' can only be 'ibm_cloud' or 'ibm_quantum'")
+            if channel and channel not in ["ibm_cloud", "ibm_quantum", "generic"]:
+                raise ValueError("'channel' can only be 'ibm_cloud', 'ibm_quantum' or 'generic'")
             if token:
                 account = Account.create_account(
                     channel=channel,
@@ -246,7 +249,8 @@ class QiskitRuntimeService:
             account.verify = verify
 
         # resolve CRN if needed
-        self._resolve_crn(account)
+        if(not channel == 'generic'):
+            self._resolve_crn(account)
 
         # ensure account is valid, fail early if not
         account.validate()

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -145,8 +145,8 @@ def get_resource_controller_api_url(cloud_url: str) -> str:
 
 def resolve_crn(channel: str, url: str, instance: str, token: str) -> List[str]:
     """Resolves the Cloud Resource Name (CRN) for the given cloud account."""
-    if channel != "ibm_cloud":
-        raise ValueError("CRN value can only be resolved for cloud accounts.")
+    if channel not in["ibm_cloud", "generic"]:
+        raise ValueError("CRN value can only be resolved for cloud and generic accounts.")
 
     if is_crn(instance):
         # no need to resolve CRN value by name

--- a/release-notes/unreleased/todo.feat.rst
+++ b/release-notes/unreleased/todo.feat.rst
@@ -1,0 +1,8 @@
+Create a new channel `generic`. This channel allows to use an alternative
+and custom channel platform implementation, i.e. neither IBM Quantum Platform
+nor IBM Cloud. The url parameter can be used to describe how the channel
+platform is reached. It will not be further modified as with other channel
+options.
+While `token` and `instance` can be used if the HTTP headers match what the
+custom channel platform expects, additional headers can be set through the
+environment variable `QISKIT_IBM_RUNTIME_CUSTOM_CLIENT_APP_HEADER`.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Generic channel code as developed by Jonas @javajonny Maurer as part of his internship, so full credits to him. I slightly simplified the code (removing debug statements) and added some text for release notes/README.md, as his internship ended, and re-tested things using a POC of a custom channel platform running locally (that is not publicly available at this time).

### Details and comments

This takes pass at #1842 .

Testing -- I didn't see any concerns in unit tests; no tests added though since the intention of the generic channel is to have qiskit-ibm-runtime do minimal checking and mangling of parameters (such as no magic applied to url etc.).