### PR TITLE
Fix the parameter expression case for RZZ validation

### DIFF
--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -29,7 +29,7 @@ from ibm_cloud_sdk_core.authenticators import (  # pylint: disable=import-error
     IAMAuthenticator,
 )
 from ibm_platform_services import ResourceControllerV2  # pylint: disable=import-error
-from qiskit.circuit import QuantumCircuit, ControlFlowOp, Parameter, ParameterExpression
+from qiskit.circuit import QuantumCircuit, ControlFlowOp, ParameterExpression
 from qiskit.transpiler import Target
 from qiskit.providers.backend import BackendV1, BackendV2
 from .deprecation import deprecate_function

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -29,7 +29,7 @@ from ibm_cloud_sdk_core.authenticators import (  # pylint: disable=import-error
     IAMAuthenticator,
 )
 from ibm_platform_services import ResourceControllerV2  # pylint: disable=import-error
-from qiskit.circuit import QuantumCircuit, ControlFlowOp, Parameter
+from qiskit.circuit import QuantumCircuit, ControlFlowOp, Parameter, ParameterExpression
 from qiskit.transpiler import Target
 from qiskit.providers.backend import BackendV1, BackendV2
 from .deprecation import deprecate_function
@@ -74,14 +74,15 @@ def _is_isa_circuit_helper(circuit: QuantumCircuit, target: Target, qubit_map: D
         # accurate).
         if (
             name == "rzz"
-            and not isinstance(instruction.operation.params[0], Parameter)
-            and (
-                instruction.operation.params[0] < 0.0
-                or instruction.operation.params[0] > 1.001 * np.pi / 2
+            and not isinstance(
+                (param := instruction.operation.params[0]), (Parameter, ParameterExpression)
             )
+            and (param < 0.0 or param > 1.001 * np.pi / 2)
         ):
-            return f"The instruction {name} on qubits {qargs} is supported only for angles in the \
-            range [0, pi/2], but an angle of {instruction.operation.params[0]} has been provided."
+            return (
+                f"The instruction {name} on qubits {qargs} is supported only for angles in the "
+                f"range [0, pi/2], but an angle of {param} has been provided."
+            )
 
         if isinstance(operation, ControlFlowOp):
             for sub_circ in operation.blocks:

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -74,9 +74,7 @@ def _is_isa_circuit_helper(circuit: QuantumCircuit, target: Target, qubit_map: D
         # accurate).
         if (
             name == "rzz"
-            and not isinstance(
-                (param := instruction.operation.params[0]), ParameterExpression
-            )
+            and not isinstance((param := instruction.operation.params[0]), ParameterExpression)
             and (param < 0.0 or param > 1.001 * np.pi / 2)
         ):
             return (

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -75,7 +75,7 @@ def _is_isa_circuit_helper(circuit: QuantumCircuit, target: Target, qubit_map: D
         if (
             name == "rzz"
             and not isinstance(
-                (param := instruction.operation.params[0]), (Parameter, ParameterExpression)
+                (param := instruction.operation.params[0]), ParameterExpression
             )
             and (param < 0.0 or param > 1.001 * np.pi / 2)
         ):

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -302,21 +302,16 @@ class TestSamplerV2(IBMTestCase):
         """Verify that the rzz validation occurs only when the angle is a number, and not a
         parameter"""
         backend = FakeFractionalBackend()
+        param = Parameter("p")
 
         with self.subTest("parameter"):
-            param = Parameter("p")
-
             circ = QuantumCircuit(2)
             circ.rzz(param, 0, 1)
-
             # Should run without an error
             SamplerV2(backend).run(pubs=[(circ, [1])])
 
         with self.subTest("parameter expression"):
-            param = Parameter("p")
-
             circ = QuantumCircuit(2)
             circ.rzz(2 * param, 0, 1)
-
             # Should run without an error
-            SamplerV2(backend).run(pubs=[(circ, [1])])
+            SamplerV2(backend).run(pubs=[(circ, [0.5])])

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -302,10 +302,21 @@ class TestSamplerV2(IBMTestCase):
         """Verify that the rzz validation occurs only when the angle is a number, and not a
         parameter"""
         backend = FakeFractionalBackend()
-        param = Parameter("p")
 
-        circ = QuantumCircuit(2)
-        circ.rzz(param, 0, 1)
+        with self.subTest("parameter"):
+            param = Parameter("p")
 
-        # Should run without an error
-        SamplerV2(backend).run(pubs=[(circ, [1])])
+            circ = QuantumCircuit(2)
+            circ.rzz(param, 0, 1)
+
+            # Should run without an error
+            SamplerV2(backend).run(pubs=[(circ, [1])])
+
+        with self.subTest("parameter expression"):
+            param = Parameter("p")
+
+            circ = QuantumCircuit(2)
+            circ.rzz(2 * param, 0, 1)
+
+            # Should run without an error
+            SamplerV2(backend).run(pubs=[(circ, [1])])


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The current RZZ validation fails with parameter expression as follows.

```python
from qiskit import QuantumCircuit
from qiskit.circuit import Parameter
from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2

x = Parameter("x")
qc = QuantumCircuit(2, 2)
qc.rzz(2 * x, 0, 1)
qc.measure([0, 1], [0, 1])

service = QiskitRuntimeService(instance="...")
backend = service.backend("ibm_torino", use_fractional_gates=True)

sampler = SamplerV2(backend)
_ = sampler.run([(qc, 0.1)])
```

0.33.1
```
Traceback (most recent call last):
  File "/Users/ima/tasks/4_2024/qiskit/runtime/tmp/frac.py", line 14, in <module>
    _ = sampler.run([(qc, 0.1)])
        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ima/envs/qiskit/lib/python3.12/site-packages/qiskit_ibm_runtime/sampler.py", line 120, in run
    return self._run(coerced_pubs)  # type: ignore[arg-type]
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ima/envs/qiskit/lib/python3.12/site-packages/qiskit_ibm_runtime/base_primitive.py", line 176, in _run
    validate_isa_circuits([pub.circuit], self._backend.target)
  File "/Users/ima/envs/qiskit/lib/python3.12/site-packages/qiskit_ibm_runtime/utils/validations.py", line 88, in validate_isa_circuits
    message = is_isa_circuit(circuit, target)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ima/envs/qiskit/lib/python3.12/site-packages/qiskit_ibm_runtime/utils/utils.py", line 117, in is_isa_circuit
    return _is_isa_circuit_helper(circuit, target, qubit_map)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ima/envs/qiskit/lib/python3.12/site-packages/qiskit_ibm_runtime/utils/utils.py", line 79, in _is_isa_circuit_helper
    instruction.operation.params[0] < 0.0
TypeError: '<' not supported between instances of 'ParameterExpression' and 'float'
```

this PR
```
(no output)
```

This PR also removes redundant white spaces in the error message `in the             range [0, pi/2]`. The full message is as follows.

```
qiskit_ibm_runtime.exceptions.IBMInputValueError: 'The instruction rzz on qubits (0, 1) is supported only for angles in the             range [0, pi/2], but an angle of 200.0 has been provided. Circuits that do not match the target hardware definition are no longer supported after March 4, 2024. See the transpilation documentation (https://docs.quantum.ibm.com/guides/transpile) for instructions to transform circuits and the primitive examples (https://docs.quantum.ibm.com/guides/primitives-examples) to see this coupled with operator transformations.'
```



### Details and comments
Note that I think this PR needs to be merged to the server side too so that pubs with parameter expressions are processed without error.
E.g., `cwrsqwf997wg008xfytg` failed with the following error
```
Job not valid. '<' not supported between instances of 'ParameterExpression' and 'float'
```

