### PR TITLE
Update `PadDynamicalDecoupling` pass to conform to Qiskit 1.3 data model 

### DIFF
--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -493,12 +493,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
                     op = next_node.op
                     theta_r, phi_r, lam_r = op.params
                     op.params = Optimize1qGates.compose_u3(theta_r, phi_r, lam_r, theta, phi, lam)
-                    new_next_node = self._block_dag.substitute_node(
-                        next_node, op, propagate_condition=False
-                    )
-                    start_time = self.property_set["node_start_time"].pop(next_node)
-                    if start_time is not None:
-                        self.property_set["node_start_time"][new_next_node] = start_time
+                    self._block_dag.substitute_node(next_node, op, propagate_condition=False)
                     sequence_gphase += phase
                 elif isinstance(prev_node, DAGOpNode) and isinstance(prev_node.op, (UGate, U3Gate)):
                     # Absorb the inverse into the predecessor (from right in circuit)

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -493,14 +493,24 @@ class PadDynamicalDecoupling(BlockBasePadder):
                     op = next_node.op
                     theta_r, phi_r, lam_r = op.params
                     op.params = Optimize1qGates.compose_u3(theta_r, phi_r, lam_r, theta, phi, lam)
-                    next_node.op = op
+                    new_next_node = self._block_dag.substitute_node(
+                        next_node, op, propagate_condition=False
+                    )
+                    start_time = self.property_set["node_start_time"].pop(next_node)
+                    if start_time is not None:
+                        self.property_set["node_start_time"][new_next_node] = start_time
                     sequence_gphase += phase
                 elif isinstance(prev_node, DAGOpNode) and isinstance(prev_node.op, (UGate, U3Gate)):
                     # Absorb the inverse into the predecessor (from right in circuit)
                     op = prev_node.op
                     theta_l, phi_l, lam_l = op.params
                     op.params = Optimize1qGates.compose_u3(theta, phi, lam, theta_l, phi_l, lam_l)
-                    prev_node.op = op
+                    new_prev_node = self._block_dag.substitute_node(
+                        prev_node, op, propagate_condition=False
+                    )
+                    start_time = self.property_set["node_start_time"].pop(prev_node)
+                    if start_time is not None:
+                        self.property_set["node_start_time"][new_prev_node] = start_time
                     sequence_gphase += phase
                 else:
                     # Don't do anything if there's no single-qubit gate to absorb the inverse


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR updates the `PadDynamicalDecoupling` pass to work with the Qiskit 1.3 updates on the `DAGCircuit` class. In particular, before this PR, https://github.com/Qiskit/qiskit/pull/12550 would break the `test_insert_midmeas_hahn` test from `test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py`, which is now fixed.

If helpful, this PR can also be incorporated into #2041, but thought that it might make sense to separate it given that it's not only changing unit tests. In principle there should be no user-facing changes so no reno was added.

### Details and comments
Fixes #

