### PR TITLE
Replace `jupyter-execute` with `plot` from docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,6 @@ extensions = [
     'sphinx.ext.intersphinx',
     # This is used by qiskit/documentation to generate links to github.com.
     "sphinx.ext.linkcode",
-    'jupyter_sphinx',
     'nbsphinx',
     'sphinxcontrib.katex',
     'matplotlib.sphinxext.plot_directive',

--- a/qiskit_ibm_runtime/fake_provider/__init__.py
+++ b/qiskit_ibm_runtime/fake_provider/__init__.py
@@ -33,6 +33,7 @@ Here is an example of using a fake backend for transpilation and simulation.
 
 .. plot::
    :include-source:
+   :context: close-figs
 
    from qiskit import QuantumCircuit
    from qiskit import transpile
@@ -51,10 +52,18 @@ Here is an example of using a fake backend for transpilation and simulation.
    circuit.measure_all()
    circuit.draw('mpl', style="iqp")
 
+.. plot::
+   :include-source:
+   :context: close-figs
+
    # Transpile the ideal circuit to a circuit that can be directly executed by the backend
    transpiled_circuit = transpile(circuit, backend)
    transpiled_circuit.draw('mpl', style="iqp")
 
+.. plot::
+   :include-source:
+   :context: close-figs
+   
    # Run the transpiled circuit using the simulated fake backend
    sampler = SamplerV2(backend)
    job = sampler.run([transpiled_circuit])

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/__init__.py
@@ -48,7 +48,9 @@ Example usage
 Below we demonstrate how to schedule and pad a teleportation circuit with delays
 for a dynamic circuit backend's execution model:
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
     from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister
     from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
@@ -97,7 +99,9 @@ for a dynamic circuit backend's execution model:
 Instead of padding with delays we may also insert a dynamical decoupling sequence
 using the :class:`PadDynamicalDecoupling` pass as shown below:
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
     from qiskit.circuit.library import XGate
 
@@ -130,7 +134,9 @@ Scheduling old format ``c_if`` conditioned gates
 
 Scheduling with old format ``c_if`` conditioned gates is not supported.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
     qc_c_if = QuantumCircuit(1, 1)
     qc_c_if.x(0).c_if(0, 1)
@@ -143,7 +149,9 @@ apply transformations and optimizations for IBM hardware backends when invoking
 conditioned gates to new-style control-flow.
 We may then schedule the transpiled circuit without further modification.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
     # Temporary workaround for mock backends. For real backends this is not required.
     backend.get_translation_stage_plugin = lambda: "ibm_dynamic_circuits"
@@ -165,7 +173,9 @@ work around this please manually run the pass
 :class:`qiskit.transpiler.passes.ConvertConditionsToIfOps`
 prior to your scheduling pass.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
     from qiskit.transpiler.passes import ConvertConditionsToIfOps
 
@@ -194,7 +204,9 @@ For example, the conditional gates below are performed in parallel with lower la
 as the measurements flow directly into the conditional blocks which in turn only apply
 gates to the same measurement qubit.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(2, 2)
         qc.measure(0, 0)
@@ -211,7 +223,9 @@ gates to the same measurement qubit.
 The circuit below will not use the fast-path as the conditional gate is
 on a different qubit than the measurement qubit.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(2, 2)
         qc.measure(0, 0)
@@ -223,7 +237,9 @@ on a different qubit than the measurement qubit.
 Similarly, the circuit below contains gates on multiple qubits
 and will not be performed using the fast-path.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(2, 2)
         qc.measure(0, 0)
@@ -237,7 +253,9 @@ A fast-path block may contain multiple gates as long as they are on the fast-pat
 If there are multiple fast-path blocks being performed in parallel each block will be
 padded out to the duration of the longest block.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(2, 2)
         qc.measure(0, 0)
@@ -253,7 +271,9 @@ padded out to the duration of the longest block.
 
 This behavior is also applied to the else condition of a fast-path eligible branch.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(1, 1)
         qc.measure(0, 0)
@@ -271,7 +291,9 @@ If a single measurement result is used with several conditional blocks, if there
 eligible block it will be applied followed by the non-fast-path blocks which will execute with
 the standard higher latency conditional branch.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(2, 2)
         qc.measure(0, 0)
@@ -288,7 +310,9 @@ the standard higher latency conditional branch.
 If you wish to prevent the usage of the fast-path you may insert a barrier between the measurement and
 the conditional branch.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(1, 2)
         qc.measure(0, 0)
@@ -301,7 +325,9 @@ the conditional branch.
 
 Conditional measurements are not eligible for the fast-path.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(1, 2)
         qc.measure(0, 0)
@@ -313,7 +339,9 @@ Conditional measurements are not eligible for the fast-path.
 
 Similarly nested control-flow is not eligible.
 
-.. jupyter-execute::
+.. plot::
+   :include-source:
+   :context: close-figs
 
         qc = QuantumCircuit(1, 1)
         qc.measure(0, 0)
@@ -332,16 +360,9 @@ compiler from performing the necessary optimizations to utilize the fast-path. I
 there are fast-path blocks that will be performed in parallel they currently *will not*
 be padded out by the scheduler to ensure they are of the same duration in Qiskit
 
-.. jupyter-execute::
-
-    dd_sequence = [XGate(), XGate()]
-
-    pm = PassManager(
-        [
-            ALAPScheduleAnalysis(durations),
-            PadDynamicalDecoupling(durations, dd_sequence),
-        ]
-    )
+.. plot::
+   :include-source:
+   :context: close-figs
 
     qc = QuantumCircuit(2, 2)
     qc.measure(0, 0)
@@ -358,8 +379,20 @@ be padded out by the scheduler to ensure they are of the same duration in Qiskit
 
     qc.draw(output="mpl", style="iqp")
 
-    qc_dd = pm.run(qc)
+.. plot::
+    :include-source:
+    :context: close-figs
 
+    dd_sequence = [XGate(), XGate()]
+
+    pm = PassManager(
+        [
+            ALAPScheduleAnalysis(durations),
+            PadDynamicalDecoupling(durations, dd_sequence),
+        ]
+    )
+    
+    qc_dd = pm.run(qc)
     qc_dd.draw(output="mpl", style="iqp")
 
 .. note::
@@ -370,7 +403,9 @@ be padded out by the scheduler to ensure they are of the same duration in Qiskit
 
     For example:
 
-    .. jupyter-execute::
+    .. plot::
+       :include-source:
+       :context: close-figs
 
         qc = QuantumCircuit(3, 2)
         qc.x(1)

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -53,7 +53,9 @@ class PadDynamicalDecoupling(BlockBasePadder):
     This pass ensures that the inserted sequence preserves the circuit exactly
     (including global phase).
 
-    .. jupyter-execute::
+    .. plot::
+       :include-source:
+       :context: close-figs
 
         import numpy as np
         from qiskit.circuit import QuantumCircuit
@@ -76,16 +78,16 @@ class PadDynamicalDecoupling(BlockBasePadder):
              ("x", None, 50), ("measure", None, 1000)]
         )
 
-    .. jupyter-execute::
-
         # balanced X-X sequence on all qubits
         dd_sequence = [XGate(), XGate()]
         pm = PassManager([ALAPScheduleAnalysis(durations),
                           PadDynamicalDecoupling(durations, dd_sequence)])
         circ_dd = pm.run(circ)
-        circ_dd.draw()
+        circ_dd.draw('mpl', style="iqp")
 
-    .. jupyter-execute::
+    .. plot::
+       :include-source:
+       :context: close-figs
 
         # Uhrig sequence on qubit 0
         n = 8
@@ -103,7 +105,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
             ]
         )
         circ_dd = pm.run(circ)
-        circ_dd.draw()
+        circ_dd.draw('mpl', style="iqp")
 
     .. note::
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,5 @@ ddt>=1.2.0,!=1.4.0,!=1.4.3
 # Documentation
 nbsphinx
 Sphinx>=6
-jupyter-sphinx
 sphinxcontrib-katex==0.9.9
 packaging


### PR DESCRIPTION
This PR replaces all the `.. jupyter-execute::` calls with `.. plot::`. The change will improve the docs in different ways. For example, it will allow us to leverage the `:alt:` option of the `plot` directive to set an alt text to all the images, which wasn't possible using the `jupyter-execute` directive, and, in addition, it will prevent us from different issues when building the documentation caused by the unreliable nature of `juptyer-execute` as explained in https://github.com/Qiskit/qiskit/pull/9346

In this PR in `qiskit/documentation` we can see the git diff caused by this replacement. The change is mainly the renaming of the images because some of them now have a dedicated code block: https://github.com/Qiskit/documentation/pull/2403/files