### PR TITLE
Fix docstring of ZneOptions

### DIFF
--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -111,8 +111,8 @@ class ZneOptions:
             The available options are:
 
                 * ``"exponential"``, which fits the data using an exponential decaying function defined
-                  as :math:`f(x; A, \tau) = A e^{-x/\tau}`, where :math:`A = f(0; A, \tau)` is the
-                  value at zero noise (:math:`x=0`\\) and :math:`\tau>0` is a positive rate.
+                  as :math:`f(x; A, \\tau) = A e^{-x/\\tau}`, where :math:`A = f(0; A, \\tau)` is the
+                  value at zero noise (:math:`x=0`\\) and :math:`\\tau>0` is a positive rate.
                 * ``"double_exponential"``, which uses a sum of two exponential as in Ref. 1.
                 * ``"polynomial_degree_(1 <= k <= 7)"``, which uses a polynomial function defined as
                   :math:`f(x; c_0, c_1, \\ldots, c_k) = \\sum_{i=0, k} c_i x^i`.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

"τ" is not properly displayed at docs. I guess it's due to the escape of "\tau". It should be "\\tau".
![image](https://github.com/user-attachments/assets/e271201f-7cd9-4219-b1c6-5fff683349df)
https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.ZneOptions#extrapolator

### Details and comments
Fixes #

