### PR TITLE
Add serialization support for EstimatorPubResult

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -82,6 +82,7 @@ from qiskit_ibm_runtime.execution_span import (
     ExecutionSpans,
     TwirledSliceSpan,
 )
+from qiskit_ibm_runtime.utils.estimator_pub_result import EstimatorPubResult
 
 from .noise_learner_result import NoiseLearnerResult
 
@@ -323,6 +324,9 @@ class RuntimeEncoder(json.JSONEncoder):
                 obj.parameter_values.as_array(obj.circuit.parameters),
                 obj.shots,
             )
+        if isinstance(obj, EstimatorPubResult):
+            out_val = {"data": obj.data, "metadata": obj.metadata}
+            return {"__type__": "EstimatorPubResult", "__value__": out_val}
         if isinstance(obj, SamplerPubResult):
             out_val = {"data": obj.data, "metadata": obj.metadata}
             return {"__type__": "SamplerPubResult", "__value__": out_val}
@@ -470,6 +474,8 @@ class RuntimeDecoder(json.JSONDecoder):
                 if shape is not None and isinstance(shape, list):
                     shape = tuple(shape)
                 return DataBin(shape=shape, **obj_val["fields"])
+            if obj_type == "EstimatorPubResult":
+                return EstimatorPubResult(**obj_val)
             if obj_type == "SamplerPubResult":
                 return SamplerPubResult(**obj_val)
             if obj_type == "PubResult":

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -41,6 +41,7 @@ from qiskit.primitives.containers import (
 )
 from qiskit_aer.noise import NoiseModel
 from qiskit_ibm_runtime.utils import RuntimeEncoder, RuntimeDecoder
+from qiskit_ibm_runtime.utils.estimator_pub_result import EstimatorPubResult
 from qiskit_ibm_runtime.utils.noise_learner_result import (
     PauliLindbladError,
     LayerError,
@@ -421,6 +422,15 @@ class TestContainerSerialization(IBMTestCase):
         pub_result = PubResult(DataBin(a=1.0, b=2), {"x": 1})
         pub_results.append(pub_result)
         return pub_results
+    
+    def make_test_estimator_pub_results(self):
+        """Generates test data for EstimatorPubResult test"""
+        pub_results = []
+        pub_result = EstimatorPubResult(DataBin(a=1.0, b=2))
+        pub_results.append(pub_result)
+        pub_result = EstimatorPubResult(DataBin(a=1.0, b=2), {"x": 1})
+        pub_results.append(pub_result)
+        return pub_results
 
     def make_test_sampler_pub_results(self):
         """Generates test data for SamplerPubResult test"""
@@ -603,6 +613,15 @@ class TestContainerSerialization(IBMTestCase):
             encoded = json.dumps(payload, cls=RuntimeEncoder)
             decoded = json.loads(encoded, cls=RuntimeDecoder)["pub_result"]
             self.assertIsInstance(decoded, PubResult)
+            self.assert_pub_results_equal(pub_result, decoded)
+
+    def test_estimator_pub_result(self):
+        """Test encoding and decoding EstimatorPubResult"""
+        for pub_result in self.make_test_estimator_pub_results():
+            payload = {"estimator_pub_result": pub_result}
+            encoded = json.dumps(payload, cls=RuntimeEncoder)
+            decoded = json.loads(encoded, cls=RuntimeDecoder)["estimator_pub_result"]
+            self.assertIsInstance(decoded, EstimatorPubResult)
             self.assert_pub_results_equal(pub_result, decoded)
 
     def test_sampler_pub_result(self):

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -422,7 +422,7 @@ class TestContainerSerialization(IBMTestCase):
         pub_result = PubResult(DataBin(a=1.0, b=2), {"x": 1})
         pub_results.append(pub_result)
         return pub_results
-    
+
     def make_test_estimator_pub_results(self):
         """Generates test data for EstimatorPubResult test"""
         pub_results = []


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds serialization support for `EstimatorPubResult` added in #1951.

