### PR TITLE
Set default logging level for tests

### DIFF
--- a/test/ibm_test_case.py
+++ b/test/ibm_test_case.py
@@ -44,9 +44,7 @@ class IBMTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        default_logger = logging.getLogger(cls.__name__)
-        default_logger.setLevel(logging.INFO)
-        cls.log = default_logger
+        cls.log = logging.getLogger(cls.__name__)
         filename = "%s.log" % os.path.splitext(inspect.getfile(cls))[0]
         setup_test_logging(cls.log, filename)
         cls._set_logging_level(logging.getLogger(QISKIT_IBM_RUNTIME_LOGGER_NAME))

--- a/test/ibm_test_case.py
+++ b/test/ibm_test_case.py
@@ -44,7 +44,9 @@ class IBMTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.log = logging.getLogger(cls.__name__)
+        default_logger = logging.getLogger(cls.__name__)
+        default_logger.setLevel(logging.INFO)
+        cls.log = default_logger
         filename = "%s.log" % os.path.splitext(inspect.getfile(cls))[0]
         setup_test_logging(cls.log, filename)
         cls._set_logging_level(logging.getLogger(QISKIT_IBM_RUNTIME_LOGGER_NAME))

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -92,6 +92,7 @@ class TestSamplerV2(IBMTestCase):
         dynamic_circuit.if_else(
             (0, True), QuantumCircuit(3, 1), QuantumCircuit(3, 1), [0, 1, 2], [0]
         )
+        dynamic_circuit.measure_all()
 
         in_pubs = [(dynamic_circuit,)]
         backend = get_mocked_backend()
@@ -144,11 +145,13 @@ class TestSamplerV2(IBMTestCase):
         ) as session:
             inst = SamplerV2(mode=session)
             circ = QuantumCircuit(QuantumRegister(2), ClassicalRegister(0))
+            circ.measure_all()
             with self.assertRaisesRegex(ValueError, "Classical register .* is of size 0"):
                 inst.run([(circ,)])
 
             creg = ClassicalRegister(2, "not-an-identifier")
             circ = QuantumCircuit(QuantumRegister(2), creg)
+            circ.measure_all()
             with self.assertRaisesRegex(
                 ValueError, "Classical register names must be valid identifiers"
             ):
@@ -156,6 +159,7 @@ class TestSamplerV2(IBMTestCase):
 
             creg = ClassicalRegister(2, "lambda")
             circ = QuantumCircuit(QuantumRegister(2), creg)
+            circ.measure_all()
             with self.assertRaisesRegex(
                 ValueError, "Classical register names cannot be Python keywords"
             ):
@@ -175,6 +179,7 @@ class TestSamplerV2(IBMTestCase):
         dynamic_circuit.if_else(
             (0, True), QuantumCircuit(3, 1), QuantumCircuit(3, 1), [0, 1, 2], [0]
         )
+        dynamic_circuit.measure_all()
 
         inst = SamplerV2(mode=backend)
         with self.assertRaises(IBMInputValueError):
@@ -292,6 +297,7 @@ class TestSamplerV2(IBMTestCase):
 
         circ = QuantumCircuit(2)
         circ.rzz(angle, 0, 1)
+        circ.measure_all()
 
         if angle == 1:
             SamplerV2(backend).run(pubs=[(circ)])
@@ -308,6 +314,7 @@ class TestSamplerV2(IBMTestCase):
 
         circ = QuantumCircuit(2)
         circ.rzz(param, 0, 1)
+        circ.measure_all()
 
         if angle == 1:
             SamplerV2(backend).run(pubs=[(circ, [angle])])
@@ -387,6 +394,7 @@ class TestSamplerV2(IBMTestCase):
 
         circ = QuantumCircuit(2)
         circ.rzz(2 * param, 0, 1)
+        circ.measure_all()
 
         # Since we currently don't validate parameter expressions, the following line should run
         # without an error, in spite of the angle being larger than pi/2

--- a/test/utils.py
+++ b/test/utils.py
@@ -68,7 +68,7 @@ def setup_test_logging(logger: logging.Logger, filename: str) -> None:
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
 
-    logger.setLevel(os.getenv("LOG_LEVEL", "DEBUG"))
+    logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))
 
 
 def most_busy_backend(

--- a/test/utils.py
+++ b/test/utils.py
@@ -459,6 +459,7 @@ def transpile_pubs(in_pubs, backend, program):
     """Return pubs with transformed circuits and observables."""
     t_pubs = []
     for pub in in_pubs:
+        pub[0].measure_all()
         t_circ = transpile(pub[0], backend=backend)
         if program == "estimator":
             t_obs = remap_observables(pub[1], t_circ)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This log shows up thousands of times in our tests, we can set the default log level to `INFO`.

The backend `PulseDefaults` `instruction_schedule_map`, has the instructions `u1`, `u2`, `u3`. These gates are not in the backend configuration `basis_gates` or `supported_instructions`. So this check triggers the log (127 times) every time the backend is initiated. https://github.com/Qiskit/qiskit-ibm-runtime/blob/5270a0b8115cc08b844751c7d507f96415360dca/qiskit_ibm_runtime/utils/backend_converter.py#L274-L279 

Also added measurements to circuits in `test_sampler` to avoid the `UserWarning`. 

### Details and comments
Fixes #1910
Fixes #2034 

