### PR TITLE
Fix bold EstimatorOptions text

### DIFF
--- a/qiskit_ibm_runtime/options/estimator_options.py
+++ b/qiskit_ibm_runtime/options/estimator_options.py
@@ -71,7 +71,7 @@ class EstimatorOptions(OptionsV2):
         * 0: No mitigation.
         * 1: Minimal mitigation costs. Mitigate error associated with readout errors.
         * 2: Medium mitigation costs. Typically reduces bias in estimators but
-            is not guaranteed to be zero bias.
+          is not guaranteed to be zero bias.
 
         Refer to the
         `Configure error mitigation for Qiskit Runtime


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Indent was causing the text to become bold.

HTML is correct now:

```
<ul class="simple">
  <li>
    <p>0: No mitigation.</p>
  </li>
  <li>
    <p>
      1: Minimal mitigation costs. Mitigate error
      associated with readout errors.
    </p>
  </li>
  <li>
    <p>
      2: Medium mitigation costs. Typically reduces bias
      in estimators but is not guaranteed to be zero bias.
    </p>
  </li>
</ul>
```


### Details and comments
Fixes #2115 

