### PR TITLE
Update links in release notes

### DIFF
--- a/release-notes/0.20.0.rst
+++ b/release-notes/0.20.0.rst
@@ -17,7 +17,7 @@ New Features
    allows for different execution modes. Batch mode is now supported
    through ``Batch``, and `Session <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`__
    will work the same as way as before. Please see
-   `run/sessions <https://docs.quantum.ibm.com/guides/sessions>`__ for more information.
+   `run/sessions <https://docs.quantum.ibm.com/guides/execution-modes#session-mode>`__ for more information.
 
    Note that ``Session`` and ``Batch`` created from
    ``qiskit-ibm-runtime`` prior to this release will no longer be

--- a/release-notes/0.30.0.rst
+++ b/release-notes/0.30.0.rst
@@ -27,7 +27,7 @@ New Features
 
 - Added new methods ``Session.usage()``, ``Batch.usage()``, and ``Job.usage()`` that
   all return information regarding job and session usage.
-  Please find more information `here <https://docs.quantum.ibm.com/guides/execution-modes#sessions-versus-batch-usage>`__. (`1827 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1827>`__)
+  Please find more information `here <https://docs.quantum.ibm.com/guides/choose-execution-mode>`__. (`1827 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1827>`__)
 - Added ``ConvertISAToClifford`` transpilation pass to convert the gates of a circuit to Clifford gates. (`1887 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1887>`__)
 - Added ``url_resolver`` optional input to :class:`.QiskitRuntimeService`
   constructor to enable custom generation of the Qiskit Runtime API URL


### PR DESCRIPTION
I moved around some stuff in the documentation and broke these links.

