### PR TITLE
Default to returning RuntimeJobv2 in jobs()

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -1086,7 +1086,7 @@ class QiskitRuntimeService:
                 api=None,
             )
 
-        version = 1
+        version = 2
         params = raw_data.get("params", {})
         if isinstance(params, list):
             if len(params) > 0:
@@ -1097,8 +1097,8 @@ class QiskitRuntimeService:
             if params:
                 version = params.get("version", 1)
 
-        if version == 2:
-            return RuntimeJobV2(
+        if version == 1:
+            return RuntimeJob(
                 backend=backend,
                 api_client=self._api_client,
                 client_params=self._client_params,
@@ -1106,11 +1106,10 @@ class QiskitRuntimeService:
                 job_id=raw_data["id"],
                 program_id=raw_data.get("program", {}).get("id", ""),
                 creation_date=raw_data.get("created", None),
-                image=raw_data.get("runtime"),
                 session_id=raw_data.get("session_id"),
                 tags=raw_data.get("tags"),
             )
-        return RuntimeJob(
+        return RuntimeJobV2(
             backend=backend,
             api_client=self._api_client,
             client_params=self._client_params,
@@ -1118,6 +1117,7 @@ class QiskitRuntimeService:
             job_id=raw_data["id"],
             program_id=raw_data.get("program", {}).get("id", ""),
             creation_date=raw_data.get("created", None),
+            image=raw_data.get("runtime"),
             session_id=raw_data.get("session_id"),
             tags=raw_data.get("tags"),
         )

--- a/release-notes/unreleased/2156.bug.rst
+++ b/release-notes/unreleased/2156.bug.rst
@@ -1,0 +1,3 @@
+When retrieving jobs with :meth:`~.QiskitRuntimeService.jobs`, there is no way to distinguish 
+between v1 and v2 primitives. Since the v1 primitives were completely removed over 6 months ago 
+in ``0.28.0``, jobs returned from ``jobs()`` will now default to :class:`RuntimeJobV2`.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When retrieving jobs with `service.jobs()`, there is no way to distinguish between v1 and v2 primitives. Since the v1 primitives were completely removed over 6 months ago in `0.28.0`, we should default to returning `RuntimeJobV2`.

There shouldn't be a purpose for `RuntimeJob` anymore so we can handle its deprecations and removal in a separate PR. 

### Details and comments
Fixes #

