### PR TITLE
Fix issues from url subdomain changes

### DIFF
--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -75,7 +75,7 @@ class Account:
         proxies = data.get("proxies")
         proxies = ProxyConfiguration(**proxies) if proxies else None
         url = data.get("url")
-        if channel == "ibm_quantum" and "-computing" in url:
+        if channel and url and channel == "ibm_quantum" and "-computing" in url:
             url = url.replace("-computing", "")
         token = data.get("token")
         instance = data.get("instance")

--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -75,6 +75,8 @@ class Account:
         proxies = data.get("proxies")
         proxies = ProxyConfiguration(**proxies) if proxies else None
         url = data.get("url")
+        if channel == "ibm_quantum" and "-computing" in url:
+            url = url.replace("-computing", "")
         token = data.get("token")
         instance = data.get("instance")
         verify = data.get("verify", True)

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -15,7 +15,7 @@
 import os
 from dataclasses import dataclass
 from functools import wraps
-from typing import Callable, Optional, List, Any
+from typing import Callable, Optional, List
 from unittest import SkipTest
 
 from qiskit_ibm_runtime import QiskitRuntimeService
@@ -75,7 +75,7 @@ def _get_integration_test_config():
         os.getenv("QISKIT_IBM_INSTANCE"),
         os.getenv("QISKIT_IBM_QPU"),
     )
-    channel: Any = "ibm_quantum" if url.find("quantum.ibm.com") >= 0 else "ibm_cloud"
+    channel: str = "ibm_cloud" if url.find("cloud") >= 0 else "ibm_quantum"
     return channel, token, url, instance, qpu
 
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

https://github.com/Qiskit/qiskit-ibm-runtime/pull/2081 changed the IQP subdomains by removing `-computing`. This caused the test credentials to default to the `ibm_cloud` channel if the old url was used. 

### Details and comments
Fixes #

