### PR TITLE
Update use of classes removed in Qiskit 2.0

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -52,6 +52,9 @@ from ..models import (
     QasmBackendConfiguration,
     PulseBackendConfiguration,
 )
+from ..models.exceptions import (
+    BackendPropertyError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -493,9 +496,6 @@ class FakeBackendV2(BackendV2):
         """
 
         from qiskit.circuit import Delay  # pylint: disable=import-outside-toplevel
-        from qiskit.providers.exceptions import (  # pylint: disable=import-outside-toplevel
-            BackendPropertyError,
-        )
         from qiskit_aer.noise import NoiseModel  # pylint: disable=import-outside-toplevel
         from qiskit_aer.noise.device.models import (  # pylint: disable=import-outside-toplevel
             _excited_population,

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -29,11 +29,12 @@ from qiskit.pulse.channels import (
 )
 from qiskit.transpiler.target import Target
 
-if qiskit.__version__.split(".", 1)[0] == "2":
+from qiskit import __version__ as qiskit_version
+if qiskit_version.split(".", 1)[0] == "2":
     from qiskit.result import MeasLevel, MeasReturnType
 else:
     from qiskit.qobj.utils import MeasLevel, MeasReturnType
-    
+
 from .models import (
     BackendStatus,
     BackendProperties,

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -30,6 +30,7 @@ from qiskit.pulse.channels import (
 from qiskit.transpiler.target import Target
 
 from qiskit import __version__ as qiskit_version
+
 if qiskit_version.split(".", 1)[0] == "2":
     from qiskit.result import MeasLevel, MeasReturnType
 else:

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -18,7 +18,6 @@ from datetime import datetime as python_datetime
 from copy import deepcopy
 
 from qiskit import QuantumCircuit
-from qiskit.qobj.utils import MeasLevel, MeasReturnType
 
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
@@ -30,6 +29,11 @@ from qiskit.pulse.channels import (
 )
 from qiskit.transpiler.target import Target
 
+if qiskit.__version__.split(".", 1)[0] == "2":
+    from qiskit.result import MeasLevel, MeasReturnType
+else:
+    from qiskit.qobj.utils import MeasLevel, MeasReturnType
+    
 from .models import (
     BackendStatus,
     BackendProperties,

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -16,9 +16,9 @@ import logging
 from typing import Iterable, Union, Optional, Any, List
 from datetime import datetime as python_datetime
 from copy import deepcopy
+from packaging.version import Version
 
-from qiskit import QuantumCircuit
-
+from qiskit import QuantumCircuit, __version__ as qiskit_version
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
 from qiskit.pulse.channels import (
@@ -28,13 +28,6 @@ from qiskit.pulse.channels import (
     MeasureChannel,
 )
 from qiskit.transpiler.target import Target
-
-from qiskit import __version__ as qiskit_version
-
-if qiskit_version.split(".", 1)[0] == "2":
-    from qiskit.result import MeasLevel, MeasReturnType
-else:
-    from qiskit.qobj.utils import MeasLevel, MeasReturnType
 
 from .models import (
     BackendStatus,
@@ -61,6 +54,12 @@ from .utils.backend_decoder import (
     configuration_from_server_data,
 )
 from .utils import local_to_utc
+
+if Version(qiskit_version) == "2":
+    from qiskit.result import MeasLevel, MeasReturnType
+else:
+    from qiskit.qobj.utils import MeasLevel, MeasReturnType
+
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit_ibm_runtime/models/backend_configuration.py
+++ b/qiskit_ibm_runtime/models/backend_configuration.py
@@ -20,7 +20,6 @@ from typing import Dict, List, Any, Iterable, Tuple, Union, TypeVar, Type
 from collections import defaultdict
 
 from qiskit.exceptions import QiskitError
-from qiskit.providers.exceptions import BackendConfigurationError
 from qiskit.pulse.channels import (
     AcquireChannel,
     Channel,
@@ -29,6 +28,7 @@ from qiskit.pulse.channels import (
     MeasureChannel,
 )
 
+from .exceptions import BackendConfigurationError
 
 GateConfigT = TypeVar("GateConfigT", bound="GateConfig")
 UchannelLOT = TypeVar("UchannelLOT", bound="UchannelLO")  # pylint: disable=[invalid-name]

--- a/qiskit_ibm_runtime/models/backend_properties.py
+++ b/qiskit_ibm_runtime/models/backend_properties.py
@@ -17,8 +17,9 @@ import datetime
 from typing import Any, Iterable, Tuple, Union, Dict, TypeVar, Type, List
 import dateutil.parser
 
-from qiskit.providers.exceptions import BackendPropertyError
 from qiskit.utils.units import apply_prefix
+
+from .exceptions import BackendPropertyError
 
 PropertyT = Tuple[Any, datetime.datetime]
 NduvT = TypeVar("NduvT", bound="Nduv")

--- a/qiskit_ibm_runtime/models/exceptions.py
+++ b/qiskit_ibm_runtime/models/exceptions.py
@@ -1,0 +1,27 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Exceptions for errors raised while handling Backends and Jobs."""
+
+from qiskit.exceptions import QiskitError
+
+
+class BackendPropertyError(QiskitError):
+    """Base class for errors raised while looking for a backend property."""
+
+    pass
+
+
+class BackendConfigurationError(QiskitError):
+    """Base class for errors raised by the BackendConfiguration."""
+
+    pass

--- a/qiskit_ibm_runtime/utils/backend_converter.py
+++ b/qiskit_ibm_runtime/utils/backend_converter.py
@@ -29,10 +29,10 @@ from qiskit.circuit.gate import Gate
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 from qiskit.circuit.parameter import Parameter
 from qiskit.providers.backend import QubitProperties
-from qiskit.providers.exceptions import BackendPropertyError
 from qiskit.transpiler.target import InstructionProperties, Target
 
 from ..models import BackendConfiguration, BackendProperties, PulseDefaults
+from ..models.exceptions import BackendPropertyError
 
 # is_fractional_gate used to be defined in this module and might be referenced
 # from here externally

--- a/qiskit_ibm_runtime/utils/options.py
+++ b/qiskit_ibm_runtime/utils/options.py
@@ -17,6 +17,7 @@ from typing import Dict, Union, Any, Optional
 from qiskit.circuit import QuantumCircuit
 
 from qiskit import __version__ as qiskit_version
+
 if qiskit_version.split(".", 1)[0] == "2":
     from qiskit.result import MeasLevel, MeasReturnType
 else:

--- a/qiskit_ibm_runtime/utils/options.py
+++ b/qiskit_ibm_runtime/utils/options.py
@@ -16,7 +16,8 @@ from dataclasses import asdict, dataclass
 from typing import Dict, Union, Any, Optional
 from qiskit.circuit import QuantumCircuit
 
-if qiskit.__version__.split(".", 1)[0] == "2":
+from qiskit import __version__ as qiskit_version
+if qiskit_version.split(".", 1)[0] == "2":
     from qiskit.result import MeasLevel, MeasReturnType
 else:
     from qiskit.qobj.utils import MeasLevel, MeasReturnType

--- a/qiskit_ibm_runtime/utils/options.py
+++ b/qiskit_ibm_runtime/utils/options.py
@@ -14,11 +14,11 @@
 
 from dataclasses import asdict, dataclass
 from typing import Dict, Union, Any, Optional
-from qiskit.circuit import QuantumCircuit
+from packaging.version import Version
 
-from qiskit import __version__ as qiskit_version
+from qiskit import QuantumCircuit, __version__ as qiskit_version
 
-if qiskit_version.split(".", 1)[0] == "2":
+if Version(qiskit_version) == "2":
     from qiskit.result import MeasLevel, MeasReturnType
 else:
     from qiskit.qobj.utils import MeasLevel, MeasReturnType

--- a/qiskit_ibm_runtime/utils/options.py
+++ b/qiskit_ibm_runtime/utils/options.py
@@ -15,7 +15,11 @@
 from dataclasses import asdict, dataclass
 from typing import Dict, Union, Any, Optional
 from qiskit.circuit import QuantumCircuit
-from qiskit.qobj.utils import MeasLevel, MeasReturnType
+
+if qiskit.__version__.split(".", 1)[0] == "2":
+    from qiskit.result import MeasLevel, MeasReturnType
+else:
+    from qiskit.qobj.utils import MeasLevel, MeasReturnType
 
 
 @dataclass


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
https://github.com/Qiskit/qiskit/pull/13793 removes the `qobj` module. A consequence of this removal is the move of `MeasLevel` and `MeasResult` from `qiskit.qobj.utils` to `qiskit.result`. This PR allows to import from both paths for compatibility with 1.x and 2.x.

The same PR removes configuration and property errors. Because the `BackendConfiguration` and `BackendProperties` classes have been vendored in qiskit-ibm-runtime, the errors should be too.


### Details and comments
Fixes #
This PR will allow to fix: https://github.com/Qiskit/qiskit-neko/issues/52


