### PR TITLE
Update convert_to_target to handle defaults

### DIFF
--- a/qiskit_ibm_runtime/utils/backend_converter.py
+++ b/qiskit_ibm_runtime/utils/backend_converter.py
@@ -42,12 +42,13 @@ from .utils import is_fractional_gate  # See comment above before removing
 logger = logging.getLogger(__name__)
 
 
-def convert_to_target(
+def convert_to_target(  # type: ignore[no-untyped-def]
     configuration: BackendConfiguration,
     properties: BackendProperties = None,
     *,
     include_control_flow: bool = True,
     include_fractional_gates: bool = True,
+    **kwargs,
 ) -> Target:
     """Decode transpiler target from backend data set.
 
@@ -65,6 +66,11 @@ def convert_to_target(
     """
     add_delay = True
     filter_faulty = True
+
+    if "defaults" in kwargs:
+        warnings.warn(
+            "Backend defaults are no longer necessary for creating a target. Defaults will be ignored."
+        )
 
     required = ["measure", "delay", "reset"]
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since `defaults` was removed as a parameter in #2116, we don't want `convert_to_target` to fail if defaults are still being passed in. 

### Details and comments
Fixes #

