### PR TITLE
Add timing buffer for cloud job retrieval tests

### DIFF
--- a/test/integration/test_ibm_job_attributes.py
+++ b/test/integration/test_ibm_job_attributes.py
@@ -82,7 +82,7 @@ class TestIBMJobAttributes(IBMTestCase):
         job = sampler.run([self.bell])
         job.result()
         # datetime, after the job is done running, in local time.
-        end_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) + timedelta(seconds=1)
+        end_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) + timedelta(minutes=1)
 
         self.assertTrue(
             (start_datetime <= job.creation_date <= end_datetime),

--- a/test/integration/test_retrieve_job.py
+++ b/test/integration/test_retrieve_job.py
@@ -152,7 +152,7 @@ class TestIntegrationRetrieveJob(IBMIntegrationJobTestCase):
         current_time = datetime.now(timezone.utc) - timedelta(minutes=1)
         job = self._run_program(service)
         job.wait_for_final_state()
-        time_after_job = datetime.now(timezone.utc)
+        time_after_job = datetime.now(timezone.utc) + timedelta(minutes=1)
         rjobs = service.jobs(
             created_before=time_after_job, created_after=current_time, pending=False, limit=20
         )


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

These tests are still failing on cloud staging because the job retrieval timing is off by ~ 10 seconds

### Details and comments
Fixes #

