### PR TITLE
Fix DoubleSliceSpan and TwirledSliceSpan mask methods

### DIFF
--- a/qiskit_ibm_runtime/execution_span/double_slice_span.py
+++ b/qiskit_ibm_runtime/execution_span/double_slice_span.py
@@ -70,7 +70,7 @@ class DoubleSliceSpan(ExecutionSpan):
     def mask(self, pub_idx: int) -> npt.NDArray[np.bool_]:
         shape, args_sl, shots_sl = self._data_slices[pub_idx]
         mask = np.zeros(shape, dtype=np.bool_)
-        mask.reshape(np.prod(shape[:-1]), shape[-1])[(args_sl, shots_sl)] = True
+        mask.reshape(np.prod(shape[:-1], dtype=int), shape[-1])[(args_sl, shots_sl)] = True
         return mask
 
     def filter_by_pub(self, pub_idx: int | Iterable[int]) -> "DoubleSliceSpan":

--- a/qiskit_ibm_runtime/execution_span/twirled_slice_span.py
+++ b/qiskit_ibm_runtime/execution_span/twirled_slice_span.py
@@ -73,18 +73,18 @@ class TwirledSliceSpan(ExecutionSpan):
         return size
 
     def mask(self, pub_idx: int) -> npt.NDArray[np.bool_]:
-        twirled_shape, at_front, shape_sl, shots_sl = self._data_slices[pub_idx]
-        mask = np.zeros(twirled_shape, dtype=np.bool_)
-        mask.reshape((np.prod(twirled_shape[:-1]), twirled_shape[-1]))[(shape_sl, shots_sl)] = True
+        shape, at_front, shape_sl, shots_sl = self._data_slices[pub_idx]
+        mask = np.zeros(shape, dtype=np.bool_)
+        mask.reshape((np.prod(shape[:-1], dtype=int), shape[-1]))[(shape_sl, shots_sl)] = True
 
         if at_front:
             # if the first axis is over twirling samples, push them right before shots
-            ndim = len(twirled_shape)
+            ndim = len(shape)
             mask = mask.transpose((*range(1, ndim - 1), 0, ndim - 1))
-            twirled_shape = twirled_shape[1:-1] + twirled_shape[:1] + twirled_shape[-1:]
+            shape = shape[1:-1] + shape[:1] + shape[-1:]
 
         # merge twirling axis and shots axis before returning
-        return mask.reshape((*twirled_shape[:-2], math.prod(twirled_shape[-2:])))
+        return mask.reshape((*shape[:-2], math.prod(shape[-2:])))
 
     def filter_by_pub(self, pub_idx: int | Iterable[int]) -> "TwirledSliceSpan":
         pub_idx = {pub_idx} if isinstance(pub_idx, int) else set(pub_idx)

--- a/release-notes/unreleased/2184.bug.rst
+++ b/release-notes/unreleased/2184.bug.rst
@@ -1,0 +1,2 @@
+Fixed a bug where :meth:`~.DoubleSliceSpan.mask` and :meth:`~TwirledSliceSpan.mask` error
+when they contain a one-dimensional slice.

--- a/test/unit/test_execution_span.py
+++ b/test/unit/test_execution_span.py
@@ -346,7 +346,9 @@ class TestTwirledSliceSpan(IBMTestCase):
 
     def test_one_dimensional_shape_mask(self):
         """Test that mask doesn't throw with a one-dimensional shape"""
-        span = TwirledSliceSpan(self.start1, self.stop1, {0: ((7,), False, slice(0, 1), slice(0, 7))})
+        span = TwirledSliceSpan(
+            self.start1, self.stop1, {0: ((7,), False, slice(0, 1), slice(0, 7))}
+        )
         span.mask(0)
 
 

--- a/test/unit/test_execution_span.py
+++ b/test/unit/test_execution_span.py
@@ -226,6 +226,12 @@ class TestDoubleSliceSpan(IBMTestCase):
             DoubleSliceSpan(self.start1, self.stop1, {2: self.slices1[2]}),
         )
 
+    def test_one_dimensional_shape_mask(self):
+        """Test that mask doesn't throw with a one-dimensional shape"""
+        span = DoubleSliceSpan(self.start1, self.stop1, {0: ((7,), slice(0, 1), slice(0, 7))})
+
+        span.mask(0)
+
 
 @ddt.ddt
 class TestTwirledSliceSpan(IBMTestCase):
@@ -337,6 +343,11 @@ class TestTwirledSliceSpan(IBMTestCase):
             self.span1.filter_by_pub(2),
             TwirledSliceSpan(self.start1, self.stop1, {2: self.slices1[2]}),
         )
+
+    def test_one_dimensional_shape_mask(self):
+        """Test that mask doesn't throw with a one-dimensional shape"""
+        span = TwirledSliceSpan(self.start1, self.stop1, {0: ((7,), False, slice(0, 1), slice(0, 7))})
+        span.mask(0)
 
 
 @ddt.ddt


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes bug with `DoubleSliceSpan.mask` and `TwirledSliceSpan.mask` when their shapes are one-dimensional.


### Details and comments
Fixes #2184 

