### PR TITLE
Update `test_resolve_crn_for_invalid_service_instance_name`

### DIFF
--- a/test/integration/test_account.py
+++ b/test/integration/test_account.py
@@ -76,7 +76,7 @@ class TestIntegrationAccount(IBMIntegrationTestCase):
                 channel="ibm_cloud",
                 url=self.dependencies.url,
                 token=self.dependencies.token,
-                instance=service_instance_name,
+                instance=self.dependencies.instance,
             )
             self.assertEqual(self.dependencies.instance, service._account.instance)
             self.assertEqual(self.dependencies.instance, service.active_account().get("instance"))


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`test_resolve_crn_for_invalid_service_instance_name` has been failing for the past few days in our cloud production integration tests. I believe this is because the cloud instance name used in our CI, `Quantum Services for Testing`, has multiple CRN values which causes [resolve_crn](https://github.com/qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/utils/utils.py#L268) to return an empty list. 

I see this when I try to list all of the instances available to my token:
`Multiple CRN values found for service name Quantum Services for Testing`.

This test and the cloud production credentials haven't been changed in over 3 years so I'm guessing something on the account side was updated. If we pass in the actual instance instead of the instance name the test passes. 

### Details and comments
Fixes #

