### PR TITLE
Fix future broken links in preparation for Qiskit 2.0

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -460,7 +460,7 @@ class IBMBackend(Backend):
         <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json>`_.
 
         More details about backend configuration properties can be found here `QasmBackendConfiguration
-        <https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.models.QasmBackendConfiguration>`_.
+        <https://docs.quantum.ibm.com/api/qiskit/1.4/qiskit.providers.models.QasmBackendConfiguration>`_.
 
         IBM backends may also include the following properties:
             * ``supported_features``: a list of strings of supported features like "qasm3" for dynamic

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -474,7 +474,7 @@ class QiskitRuntimeService:
                     QiskitRuntimeService.backends(open_pulse=True)
 
                 For the full list of backend attributes, see the `IBMBackend` class documentation
-                <https://docs.quantum.ibm.com/api/qiskit/providers_models>
+                <https://docs.quantum.ibm.com/api/qiskit/1.4/providers_models>
 
         Returns:
             The list of available backends that match the filter.

--- a/release-notes/0.24.0.rst
+++ b/release-notes/0.24.0.rst
@@ -110,5 +110,5 @@ Bug Fixes
 - Fixed measurement twirling docstring which incorrectly indicated it's enabled by default for Sampler. (`1722 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1722>`__)
 - Fixed nested experimental suboptions override non-experimental suboptions. (`1731 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1731>`__)
 - The backend utils method ``convert_to_target`` has been replaced with the 
-  `convert_to_target <https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.convert_to_target>`__ method from Qiskit.
+  `convert_to_target <https://docs.quantum.ibm.com/api/qiskit/1.4/qiskit.providers.convert_to_target>`__ method from Qiskit.
   This fixes some issues related to target generation and calibration data. (`1600 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1600>`__)


### PR DESCRIPTION
This PR updates some links that will be broken once Qiskit 2.0 is released. 

The links were also updated in the `qiskit/documentation` repo in the following [PR](https://github.com/Qiskit/documentation/pull/2803). In that PR, the commits https://github.com/Qiskit/documentation/pull/2803/commits/ef106e009f249530f7771daa237f74c4077a5b93 and https://github.com/Qiskit/documentation/pull/2803/commits/81ea4bb005594dde41bd2aee12466b136e149a60 show all the links/pages that need to be reviewed in this repo for the versions 0.37 and 0.38 respectively. The vast majority of them are auto-generated links, and for that reason this PR is just updating a subset of them.