### PR TITLE
Add `__getattr__` method for fake backends

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -14,6 +14,7 @@
 """
 Base class for dummy backends.
 """
+from typing import Any
 import logging
 import warnings
 import json
@@ -89,6 +90,26 @@ class FakeBackendV2(BackendV2):
         )
         self._target = None
         self.sim = None
+
+    def __getattr__(self, name: str) -> Any:
+        """Gets attribute from self or configuration
+
+        This magic method executes when user accesses an attribute that
+        does not yet exist on IBMBackend class.
+        """
+        # Prevent recursion since these properties are accessed within __getattr__
+        if name in ["_target"]:
+            raise AttributeError(
+                "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)
+            )
+
+        # Check if the attribute now is available in backend configuration
+        try:
+            return self.configuration().__getattribute__(name)
+        except AttributeError:
+            raise AttributeError(
+                "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)
+            )
 
     def _setup_sim(self) -> None:
         if _optionals.HAS_AER:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`IBMBackend` has an `__getattr__` method so attributes from the backend configuration can be retrieved directly -   `backend.dynamic_reprate_enabled`. It should work the same way for fake backends. 

### Details and comments
Fixes #2200 

