### PR TITLE
Update `test_session_from_id`

### DIFF
--- a/test/integration/test_auth_client.py
+++ b/test/integration/test_auth_client.py
@@ -42,7 +42,7 @@ class TestAuthClient(IBMTestCase):
         )
         cloud_auth = params.get_auth_handler()
         self.assertTrue(cloud_auth.tm)
-        self.assertTrue(cloud_auth.tm.access_token())
+        self.assertTrue(cloud_auth.tm.get_token())
 
     @integration_test_setup(supported_channel=["ibm_quantum"], init_service=False)
     def test_url_404(self, dependencies: IntegrationTestDependencies) -> None:

--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -83,7 +83,8 @@ class TestIntegrationSession(IBMIntegrationTestCase):
         isa_circuit = pm.run([bell()])
         with Session(backend=backend) as session:
             sampler = SamplerV2(mode=session)
-            sampler.run(isa_circuit)
+            job = sampler.run(isa_circuit)
+            job.result()
 
         with mock.patch.object(service._api_client, "create_session") as mock_create_session:
             new_session = Session.from_id(session_id=session._session_id, service=service)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Missed this - on the cloud channel, a job has to finish before the backend is returned in `session.details()` 

### Details and comments
Fixes #

