### PR TITLE
Integration test updates

### DIFF
--- a/qiskit_ibm_runtime/api/auth.py
+++ b/qiskit_ibm_runtime/api/auth.py
@@ -51,6 +51,13 @@ class CloudAuth(AuthBase):
         r.headers.update(self.get_headers())
         return r
 
+    def __deepcopy__(self, _memo: dict = None) -> "CloudAuth":
+        cpy = CloudAuth(
+            api_key=self.api_key,
+            crn=self.crn,
+        )
+        return cpy
+
     def get_headers(self) -> Dict:
         """Return authorization information to be stored in header."""
         try:

--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -91,9 +91,9 @@ class TestIntegrationSession(IBMIntegrationTestCase):
             mock_create_session.assert_not_called()
 
         self.assertEqual(session._session_id, new_session._session_id)
-        self.assertTrue(new_session._active)
         new_session.close()
         self.assertFalse(new_session._active)
+        self.assertFalse(new_session.details()["accepting_jobs"])
 
         with self.assertRaises(IBMInputValueError):
             Batch.from_id(session_id=session._session_id, service=service)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`test_session_from_id`: This test has been updated multiple times recently because session behavior is different on classic IQP and new IQP (https://github.com/Qiskit/qiskit-ibm-runtime/issues/2188). On the new IQP, one job has to complete first before the backend can be returned in `session.details()`. Also the session does not close right away when `close()` is called. 

After https://github.com/Qiskit/qiskit-ibm-runtime/pull/2102, `test_backend_deepcopy` started failing because of the use of `IAMTokenManager` in the Cloud Auth init function. 

I'll test that the integration tests are passing in my fork 

### Details and comments
Fixes #

