### PR TITLE
Remove backend defaults check in target()

### DIFF
--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -317,7 +317,6 @@ class IBMBackend(Backend):
             Target
         """
         self.properties()
-        self.defaults()
         self._convert_to_target()
         return self._target
 

--- a/release-notes/unreleased/2261.bug.rst
+++ b/release-notes/unreleased/2261.bug.rst
@@ -1,0 +1,2 @@
+The call to :meth:`~.IBMBackend.defaults` in :meth:`~.IBMBackend.target` was removed
+because backend defaults are no longer used in the target generation.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`backend.target()` doesn't use backend defaults anymore.

### Details and comments
Fixes #2260 

