### PR TITLE
Update links pointing to IQP Classic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ pip install -e ".[dev]"
 
 ### Open an issue
 
-* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of https://docs.quantum.ibm.com, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit-ibm-runtime repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For documentation issues relating to pages in the Guides, Tutorials, and Migration guides sections of https://quantum.cloud.ibm.com/docs, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit-ibm-runtime repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
 * For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference.
 
 ### Pull request checklist

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -34,11 +34,11 @@ The guiding principles are:
 
 The public API comprises all *publicly documented* packages, modules, classes, functions, methods, and attributes.
 
-An object is *publicly documented* if and only if it appears in [the hosted API documentation](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime) for `qiskit-ibm-runtime`.
+An object is *publicly documented* if and only if it appears in [the hosted API documentation](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime) for `qiskit-ibm-runtime`.
 The presence of a docstring in the Python source (or a `__doc__` attribute) is not sufficient to make an object publicly documented; this documentation must also be rendered in the public API documentation.
 
-As well as the objects themselves needing to be publicly documented, the only public-API *import locations* for a given object is the location it is documented at in [the public API documentation](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime), and parent modules or packages that re-export the object (if any).
-For example, while it is possible to import `RuntimeEncoder` from `qiskit_ibm_runtime.utils.json`, this is not a supported part of the public API because the[`RuntimeEncoder` object is documented as being in `qiskit_ibm_runtime`](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeEncoder).
+As well as the objects themselves needing to be publicly documented, the only public-API *import locations* for a given object is the location it is documented at in [the public API documentation](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime), and parent modules or packages that re-export the object (if any).
+For example, while it is possible to import `RuntimeEncoder` from `qiskit_ibm_runtime.utils.json`, this is not a supported part of the public API because the[`RuntimeEncoder` object is documented as being in `qiskit_ibm_runtime`](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-encoder).
 
 As a rule of thumb, if you are using `qiskit-ibm-runtime`, you should import objects from the highest-level package that exports that object.
 

--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ All quantum applications and algorithms level are fundamentally built using thes
 **Primitives** are base-level functions that serve as building blocks for many quantum algorithms and applications.
 Primitives accept vectorized inputs, where single circuits can be grouped with array-valued specifications. That is, one circuit can be executed for arrays of n parameter sets, n observables, or both (in the case of the estimator). Each group is called a Primitive Unified Bloc (PUB), and can be represented as a tuple.
 
-The [primitive interfaces](https://docs.quantum.ibm.com/api/qiskit/primitives) are defined in Qiskit.
+The [primitive interfaces](https://quantum.cloud.ibm.com/docs/api/qiskit/primitives) are defined in Qiskit.
 
 The IBM Runtime service offers these primitives with additional features, such as built-in error suppression and mitigation.
 
-There are several different options you can specify when calling the primitives. See [Primitive options](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/options) for more information.
+There are several different options you can specify when calling the primitives. See [Primitive options](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/options) for more information.
 
 ### Primitive versions
 
-Version 2 of the primitives is introduced by `qiskit-ibm-runtime` release 0.21.0. Version 1 of the primitives is no longer supported. Refer to [Migrate to the V2 primitives](https://docs.quantum.ibm.com/migration-guides/v2-primitives) on how to migratie to V2 primitives. The examples below all use V2 primitives.
+Version 2 of the primitives is introduced by `qiskit-ibm-runtime` release 0.21.0. Version 1 of the primitives is no longer supported. Refer to [Migrate to the V2 primitives](https://quantum.cloud.ibm.com/docs/migration-guides/v2-primitives) on how to migratie to V2 primitives. The examples below all use V2 primitives.
 
 ### Sampler
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ modindex_common_prefix = ['qiskit.']
 # Even though alabaster isn't very pretty, we use it
 # over the normal qiskit-ecosystem theme because it's
 # faster to build and these docs are only necessary
-# so the API docs can be integrated into docs.quantum.ibm.com.
+# so the API docs can be integrated into quantum.cloud.ibm.com/docs.
 html_theme = "alabaster"
 html_title = f"{project} {release}"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 Qiskit Runtime |release| API Docs Preview
 #########################################
 
-Qiskit Runtime docs live at docs.quantum.ibm.com and come from https://github.com/Qiskit/documentation.
+Qiskit Runtime docs live at http://quantum.cloud.ibm.com/docs and come from https://github.com/Qiskit/documentation.
 This site is only used to generate our API docs, which then get migrated to
 https://github.com/Qiskit/documentation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ ibm_dynamic_circuits = "qiskit_ibm_runtime.transpiler.plugin:IBMDynamicTranslati
 ibm_fractional = "qiskit_ibm_runtime.transpiler.plugin:IBMFractionalTranslationPlugin"
 
 [project.urls]
-documentation = "https://docs.quantum.ibm.com/"
+documentation = "https://quantum.cloud.ibm.com/docs/"
 repository = "https://github.com/Qiskit/qiskit-ibm-runtime"
 issues = "https://github.com/Qiskit/qiskit-ibm-runtime/issues"
 

--- a/qiskit_ibm_runtime/batch.py
+++ b/qiskit_ibm_runtime/batch.py
@@ -79,7 +79,7 @@ class Batch(Session):
                 jobs.append(job)
 
     For more details, check the "`Run jobs in a batch
-    <https://docs.quantum.ibm.com/guides/run-jobs-batch>`_" page.
+    <https://quantum.cloud.ibm.com/docs/guides/run-jobs-batch>`_" page.
     """
 
     def __init__(
@@ -99,7 +99,7 @@ class Batch(Session):
                 forcibly closed. Can be specified as seconds (int) or a string like "2h 30m 40s".
                 This value must be less than the
                 `system imposed maximum
-                <https://docs.quantum.ibm.com/guides/max-execution-time>`_.
+                <https://quantum.cloud.ibm.com/docs/guides/max-execution-time>`_.
             create_new: If True, the POST session API endpoint will be called to create a new session.
                 Prevents creating a new session when ``from_id()`` is called.
         Raises:

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -112,7 +112,7 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
                 * A :class:`Batch` if you are using batch execution mode.
 
                 Refer to the
-                `Qiskit Runtime documentation <https://docs.quantum.ibm.com/guides/execution-modes>`_.
+                `Qiskit Runtime documentation <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`_.
                 for more information about the ``Execution modes``.
 
             options: Estimator options, see :class:`EstimatorOptions` for detailed description.

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -289,7 +289,7 @@ class FakeBackendV2(BackendV2):
             "max_circuits is deprecated",
             "0.37.0",
             "Please see our documentation on job limits "
-            "https://docs.quantum.ibm.com/guides/job-limits#job-limits.",
+            "https://quantum.cloud.ibm.com/docs/guides/job-limits#job-limits.",
         )
         return self.configuration().max_experiments
 

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -215,7 +215,7 @@ class IBMBackend(Backend):
                 f"{name} is deprecated",
                 "0.37.0",
                 "Please see our documentation on job limits "
-                "https://docs.quantum.ibm.com/guides/job-limits#job-limits.",
+                "https://quantum.cloud.ibm.com/docs/guides/job-limits#job-limits.",
             )
         # Lazy load properties and pulse defaults and construct the target object.
         self.properties()
@@ -293,7 +293,7 @@ class IBMBackend(Backend):
             "max_circuits is deprecated",
             "0.37.0",
             "Please see our documentation on job limits "
-            "https://docs.quantum.ibm.com/guides/job-limits#job-limits.",
+            "https://quantum.cloud.ibm.com/docs/guides/job-limits#job-limits.",
         )
         return self._max_circuits
 
@@ -467,7 +467,7 @@ class IBMBackend(Backend):
         <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json>`_.
 
         More details about backend configuration properties can be found here `QasmBackendConfiguration
-        <https://docs.quantum.ibm.com/api/qiskit/1.4/qiskit.providers.models.QasmBackendConfiguration>`_.
+        <https://quantum.cloud.ibm.com/docs/api/qiskit/1.4/qiskit.providers.models.QasmBackendConfiguration>`_.
 
         IBM backends may also include the following properties:
             * ``supported_features``: a list of strings of supported features like "qasm3" for dynamic
@@ -567,7 +567,7 @@ class IBMBackend(Backend):
         """
         raise IBMBackendError(
             "Support for backend.run() has been removed. Please see our migration guide "
-            "https://docs.quantum.ibm.com/migration-guides/qiskit-runtime for instructions "
+            "https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime for instructions "
             "on how to migrate to the primitives interface."
         )
 

--- a/qiskit_ibm_runtime/noise_learner/noise_learner.py
+++ b/qiskit_ibm_runtime/noise_learner/noise_learner.py
@@ -106,7 +106,7 @@ class NoiseLearner:
             * A :class:`Batch` if you are using batch execution mode.
 
             Refer to the
-            `Qiskit Runtime documentation <https://docs.quantum.ibm.com/guides/execution-modes>`__
+            `Qiskit Runtime documentation <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`__
             for more information about the execution modes.
 
         options: :class:`NoiseLearnerOptions`. Alternatively, :class:`EstimatorOptions` can be

--- a/qiskit_ibm_runtime/options/estimator_options.py
+++ b/qiskit_ibm_runtime/options/estimator_options.py
@@ -75,7 +75,7 @@ class EstimatorOptions(OptionsV2):
 
         Refer to the
         `Configure error mitigation for Qiskit Runtime
-        <https://docs.quantum.ibm.com/guides/configure-error-mitigation>`_ guide
+        <https://quantum.cloud.ibm.com/docs/guides/configure-error-mitigation>`_ guide
         for more information about the error mitigation methods used at each level.
 
         Default: 1.

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -126,7 +126,7 @@ class OptionsV2(BaseOptions):
 
             Refer to the
             `Max execution time documentation
-            <https://docs.quantum.ibm.com/guides/max-execution-time>`_.
+            <https://quantum.cloud.ibm.com/docs/guides/max-execution-time>`_.
             for more information.
 
         environment: Options related to the execution environment. See

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -95,7 +95,7 @@ class QiskitRuntimeService:
              ``local``. If ``local`` is selected, the local testing mode will be used, and
              primitive queries will run on a local simulator.
              For more details, check the `Qiskit Runtime local testing mode
-             <https://docs.quantum.ibm.com/guides/local-testing-mode>`_ documentation.
+             <https://quantum.cloud.ibm.com/docs/guides/local-testing-mode>`_ documentation.
              The ``ibm_quantum`` channel is deprecated and the ``ibm_cloud``
              channel should be used instead. For help, review the `migration guide
              <https://quantum.cloud.ibm.com/docs/migration-guides/classic-iqp-to-cloud-iqp>`_.
@@ -487,7 +487,7 @@ class QiskitRuntimeService:
                     QiskitRuntimeService.backends(open_pulse=True)
 
                 For the full list of backend attributes, see the `IBMBackend` class documentation
-                <https://docs.quantum.ibm.com/api/qiskit/1.4/providers_models>
+                <https://quantum.cloud.ibm.com/docs/api/qiskit/1.4/providers_models>
 
         Returns:
             The list of available backends that match the filter.

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -73,7 +73,7 @@ class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
                 * A :class:`Batch` if you are using batch execution mode.
 
                 Refer to the
-                `Qiskit Runtime documentation <https://docs.quantum.ibm.com/guides/execution-modes>`_.
+                `Qiskit Runtime documentation <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`_.
                 for more information about the ``Execution modes``.
 
             options: Sampler options, see :class:`SamplerOptions` for detailed description.

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -98,7 +98,7 @@ class Session:
                 forcibly closed. Can be specified as seconds (int) or a string like "2h 30m 40s".
                 This value must be less than the
                 `system imposed maximum
-                <https://docs.quantum.ibm.com/guides/max-execution-time>`_.
+                <https://quantum.cloud.ibm.com/docs/guides/max-execution-time>`_.
             create_new: If True, the POST session API endpoint will be called to create a new session.
                 Prevents creating a new session when ``from_id()`` is called.
         Raises:

--- a/qiskit_ibm_runtime/transpiler/passes/__init__.py
+++ b/qiskit_ibm_runtime/transpiler/passes/__init__.py
@@ -18,7 +18,7 @@ Transpiler passes (:mod:`qiskit_ibm_runtime.transpiler.passes`)
 .. currentmodule:: qiskit_ibm_runtime.transpiler.passes
 
 A collection of transpiler passes. Refer to
-https://docs.quantum.ibm.com/guides/transpile to learn more about
+https://quantum.cloud.ibm.com/docs/guides/transpile to learn more about
 transpilation and passes.
 
 .. autosummary::

--- a/qiskit_ibm_runtime/utils/validations.py
+++ b/qiskit_ibm_runtime/utils/validations.py
@@ -97,9 +97,9 @@ def validate_isa_circuits(circuits: Sequence[QuantumCircuit], target: Target) ->
                 message
                 + " Circuits that do not match the target hardware definition are no longer "
                 "supported after March 4, 2024. See the transpilation documentation "
-                "(https://docs.quantum.ibm.com/guides/transpile) for instructions "
+                "(https://quantum.cloud.ibm.com/docs/guides/transpile) for instructions "
                 "to transform circuits and the primitive examples "
-                "(https://docs.quantum.ibm.com/guides/primitives-examples) to see "
+                "(https://quantum.cloud.ibm.com/docs/guides/primitives-examples) to see "
                 "this coupled with operator transformations."
             )
 

--- a/release-notes/0.1.0.rst
+++ b/release-notes/0.1.0.rst
@@ -49,7 +49,7 @@ Upgrade Notes
       from qiskit_ibm_runtime import IBMRuntimeService
       service = IBMRuntimeService(auth="cloud", token="abc", instance="IBM Cloud CRN or Service instance name")
 
--  `qiskit_ibm_runtime.IBMBackend <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend>`__
+-  `qiskit_ibm_runtime.IBMBackend <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend>`__
    class now implements the ``qiskit.providers.BackendV2`` interface and
    provides flatter access to the configuration of a backend, for
    example:
@@ -66,7 +66,7 @@ Upgrade Notes
    now an attribute instead of a method.
 
    Refer to the
-   `qiskit_ibm_runtime.IBMBackend <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend>`__
+   `qiskit_ibm_runtime.IBMBackend <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend>`__
    class doc string for a list of all available attributes.
 
 -  If you used qiskit.providers.ibmq.AccountProvider.get_backend method
@@ -111,11 +111,11 @@ Upgrade Notes
 
 -  ``qiskit_ibm_runtime.IBMRuntimeService.run()`` method now accepts
    runtime execution options as
-   `qiskit_ibm_runtime.RuntimeOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.25/qiskit_ibm_runtime.RuntimeOptions>`__
+   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__
    class in addition to already supported Dict. backend_name, image and
    log_level are the currently available options.
 
 -  Final result is also streamed now after interim results when you
    specify a ``callback`` to
    ``qiskit_ibm_runtime.IBMRuntimeService.run()`` or
-   `qiskit_ibm_runtime.RuntimeJob.stream_results() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.30/qiskit_ibm_runtime.RuntimeJob#stream_results>`__.
+   `qiskit_ibm_runtime.RuntimeJob.stream_results() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.30/runtime-job#stream_results>`__.

--- a/release-notes/0.1.0rc1.rst
+++ b/release-notes/0.1.0rc1.rst
@@ -9,7 +9,7 @@ New Features
    jobs. Currently only supported for legacy authentication.
 
 -  You can now use the
-   `qiskit_ibm_runtime.RuntimeJob.interim_results() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.30/qiskit_ibm_runtime.RuntimeJob#interim_results>`__
+   `qiskit_ibm_runtime.RuntimeJob.interim_results() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.30/runtime-job#interim_results>`__
    method to retrieve runtime program interim results. Note that interim
    results will only be available for up to two days.
 
@@ -17,7 +17,7 @@ Upgrade Notes
 -------------
 
 -  In order to be consistent with other properties in
-   `qiskit_ibm_runtime.RuntimeJob <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob>`__
+   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
    class the job_id and backend methods have been converted to
    properties.
 

--- a/release-notes/0.1.0rc2.rst
+++ b/release-notes/0.1.0rc2.rst
@@ -14,14 +14,14 @@ New Features
 Bug Fixes
 ---------
 
--  `qiskit_ibm_runtime.utils.json.RuntimeEncoder <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeEncoder>`__
+-  `qiskit_ibm_runtime.utils.json.RuntimeEncoder <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-encoder>`__
    and
-   `qiskit_ibm_runtime.utils.json.RuntimeDecoder <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeDecoder>`__
+   `qiskit_ibm_runtime.utils.json.RuntimeDecoder <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-decoder>`__
    have been updated to handle instances of the Instruction class.
 
 -  Fixed an issue where numpy ndarrays with object types could not be
    serialized.
-   `qiskit_ibm_runtime.utils.json.RuntimeEncoder <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeEncoder>`__
+   `qiskit_ibm_runtime.utils.json.RuntimeEncoder <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-encoder>`__
    and
-   `qiskit_ibm_runtime.utils.json.RuntimeDecoder <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeDecoder>`__
+   `qiskit_ibm_runtime.utils.json.RuntimeDecoder <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-decoder>`__
    have been updated to handle these ndarrays.

--- a/release-notes/0.11.0.rst
+++ b/release-notes/0.11.0.rst
@@ -8,7 +8,7 @@ New Features
    ``qiskit_ibm_runtime.IBMRuntimeService.job()`` the ``params`` will no
    longer be returned from the API. They will instead be loaded loazily
    when they are actually needed in
-   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#inputs>`__.
+   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#inputs>`__.
 
 -  Added warning when the backend is not active in
    QiskitRuntimeService.run.
@@ -31,16 +31,16 @@ Upgrade Notes
 
 -  A default session is no longer open for you if you pass a backend
    name or backend instance to
-   `qiskit_ibm_runtime.Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ or
-   `qiskit_ibm_runtime.Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__
+   `qiskit_ibm_runtime.Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ or
+   `qiskit_ibm_runtime.Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__
    constructors. The primitive will instead run without a session. In
    addition, you should now use the ``backend`` parameter to pass a
    backend name or instance instead of the ``session`` parameter (which
    can continue to be used to pass a session).
 
 -  The first parameter of the
-   `qiskit_ibm_runtime.Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ and
-   `qiskit_ibm_runtime.Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__
+   `qiskit_ibm_runtime.Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ and
+   `qiskit_ibm_runtime.Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__
    constructors is now ``backend`` instead of ``session``.
 
 Deprecation Notes
@@ -48,7 +48,7 @@ Deprecation Notes
 
 -  Passing a backend name or backend instance to the ``session``
    parameter when initializing a
-   `qiskit_ibm_runtime.Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ or
-   `qiskit_ibm_runtime.Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__
+   `qiskit_ibm_runtime.Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ or
+   `qiskit_ibm_runtime.Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__
    has been deprecated. Please use the ``backend`` parameter instead.
    You can continue to pass a session using the ``session`` parameter.

--- a/release-notes/0.11.1.rst
+++ b/release-notes/0.11.1.rst
@@ -5,5 +5,5 @@ Deprecation Notes
 -----------------
 
 -  In
-   `qiskit_ibm_runtime.RuntimeJob.metrics() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#metrics>`__,
+   `qiskit_ibm_runtime.RuntimeJob.metrics() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#metrics>`__,
    the bss field will be replaced by usage.

--- a/release-notes/0.11.2.rst
+++ b/release-notes/0.11.2.rst
@@ -8,7 +8,7 @@ New Features
    exception rather than returning None.
 
 -  A new method,
-   `qiskit_ibm_runtime.options.SimulatorOptions.set_backend() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.SimulatorOptions#set_backend>`__,
+   `qiskit_ibm_runtime.options.SimulatorOptions.set_backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/options-simulator-options#set_backend>`__,
    allows users to more easily set simulator options for a backend.
 
    .. code:: python

--- a/release-notes/0.11.3.rst
+++ b/release-notes/0.11.3.rst
@@ -5,10 +5,10 @@ New Features
 ------------
 
 -  Added reason for failure when invoking the method
-   `error_message() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#error_message>`__.
+   `error_message() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#error_message>`__.
 
 -  Added a new property,
-   `usage_estimation() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#usage_estimation>`__
+   `usage_estimation() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#usage_estimation>`__
    that returns the estimated system execution time,
    ``quantum_seconds``. System execution time represents the amount of
    time that the system is dedicated to processing your job.
@@ -18,11 +18,11 @@ New Features
    backend.
 
 -  There is a new method
-   `update_tags() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#update_tags>`__
+   `update_tags() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#update_tags>`__
    that can be used to update the ``job_tags`` of a job.
 
 -  If ``instance`` is provided as parameter to
-   `qiskit_ibm_runtime.QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__,
+   `qiskit_ibm_runtime.QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__,
    then this is used as a filter in ``QiskitRuntimeService.backends()``.
    If ``instance`` is not recognized as one of the provider instances,
    an exception will be raised. Previously, we only issued a warning.

--- a/release-notes/0.12.0.rst
+++ b/release-notes/0.12.0.rst
@@ -16,7 +16,7 @@ New Features
       sampler = Sampler(backend="ibmq_qasm_simulator")
 
 -  Added a new method,
-   `qiskit_ibm_runtime.QiskitRuntimeService.instances() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#instances>`__
+   `qiskit_ibm_runtime.QiskitRuntimeService.instances() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#instances>`__
    that returns all instances(hub/group/project) the user is in. This is
    only for the ``ibm_quantum`` channel since the ``ibm_cloud`` channel
    does not have multiple instances.
@@ -27,9 +27,9 @@ New Features
 
 -  There is a new parameter, ``channel_strategy`` that can be set in the
    initialization of
-   `qiskit_ibm_runtime.QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `qiskit_ibm_runtime.QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    or saved in
-   `qiskit_ibm_runtime.QiskitRuntimeService.save_account() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#save_account>`__.
+   `qiskit_ibm_runtime.QiskitRuntimeService.save_account() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#save_account>`__.
    If ``channel_strategy`` is set to ``q-ctrl``, all jobs within the
    service will use the Q-CTRL error mitigation strategy.
 
@@ -38,7 +38,7 @@ Upgrade Notes
 
 -  Circuits and other input parameters will no longer be automatically
    stored in runtime jobs. They can still be retrieved with
-   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#inputs>`__.
+   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#inputs>`__.
 
 
 Deprecation Notes

--- a/release-notes/0.12.1.rst
+++ b/release-notes/0.12.1.rst
@@ -11,7 +11,7 @@ New Features
 
 -  Users can now pass in a value of ``default`` to the
    ``channel_strategy`` parameter in
-   `qiskit_ibm_runtime.QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__.
+   `qiskit_ibm_runtime.QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__.
    Now, if an account is configured with a certain channel strategy, the
    user can override it by passing in ``default``.
 
@@ -26,12 +26,12 @@ Bug Fixes
 ---------
 
 -  Retrieving backend properties with
-   `properties() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend#properties>`__ now
+   `properties() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend#properties>`__ now
    supports passing a ``datetime`` parameter to retrieve properties from
    a past date.
 
 -  The ``noise_factors`` and ``extrapolator`` options in
-   `qiskit_ibm_runtime.options.ResilienceOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.27/qiskit_ibm_runtime.options.ResilienceOptions>`__
+   `qiskit_ibm_runtime.options.ResilienceOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.27/options-resilience-options>`__
    will now default to ``None`` unless ``resilience_level`` is set to 2.
    Only options relevant to the resilience level will be set, so when
    using ``resilience_level`` 2, ``noise_factors`` will still default to

--- a/release-notes/0.12.2.rst
+++ b/release-notes/0.12.2.rst
@@ -24,4 +24,4 @@ Upgrade Notes
 -------------
 
 -  Job error messages now include the error code. Error codes can be
-   found in `errors <https://docs.quantum.ibm.com/errors>`__.
+   found in `errors <https://quantum.cloud.ibm.com/docs/errors>`__.

--- a/release-notes/0.13.0.rst
+++ b/release-notes/0.13.0.rst
@@ -5,12 +5,12 @@ New Features
 ------------
 
 -  Added a new method,
-   `details() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#details>`__ that returns
+   `details() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#details>`__ that returns
    information about a session, including: maximum session time, active
    time remaining, the current state, and whether or not the session is
    accepting jobs.
 
-   Also added `status() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#status>`__,
+   Also added `status() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#status>`__,
    which returns the current status of the session.
 
 -  At initialization, if not passed in directly, the default
@@ -22,7 +22,7 @@ New Features
 Upgrade Notes
 -------------
 
--  `qiskit_ibm_runtime.Session.close() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#close>`__
+-  `qiskit_ibm_runtime.Session.close() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#close>`__
    has been updated to mark a ``Session`` as no longer accepting new
    jobs. The session won’t accept more jobs but it will continue to run
    any queued jobs until they are done or the max time expires. This
@@ -32,7 +32,7 @@ Upgrade Notes
    jobs rather than wait for the interactive timeout.
 
    The old close method behavior has been moved to a new method,
-   `qiskit_ibm_runtime.Session.cancel() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#cancel>`__,
+   `qiskit_ibm_runtime.Session.cancel() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#cancel>`__,
    where all queued jobs within a session are cancelled and terminated.
 
 Bug Fixes
@@ -42,6 +42,6 @@ Bug Fixes
    serialized correctly.
 
 -  Fixed a bug in
-   `target_history() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend#target_history>`__
+   `target_history() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend#target_history>`__
    where the datetime parameter was not being used to retrieve backend
    properties from the specified date.

--- a/release-notes/0.14.0.rst
+++ b/release-notes/0.14.0.rst
@@ -6,7 +6,7 @@ New Features
 
 -  There is a new class, ``qiskit_ibm_runtime.Batch`` that currently
    works the same way as
-   `qiskit_ibm_runtime.Session <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`__ but
+   `qiskit_ibm_runtime.Session <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session>`__ but
    will later be updated to better support submitting multiple jobs at
    once.
 

--- a/release-notes/0.15.0.rst
+++ b/release-notes/0.15.0.rst
@@ -67,13 +67,13 @@ Bug Fixes
    being used since not all features are supported there.
 
 -  The ``backend`` parameter in
-   `from_id() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#from_id>`__ is being
+   `from_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#from_id>`__ is being
    deprecated because sessions do not support multiple backends.
    Additionally, the ``service`` parameter is no longer optional.
 
 -  The ``circuit_indices`` and ``observable_indices`` run inputs for
-   `Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__ and
-   `Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ have been completely
+   `Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__ and
+   `Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ have been completely
    removed.
 
 Other Notes

--- a/release-notes/0.15.1.rst
+++ b/release-notes/0.15.1.rst
@@ -5,5 +5,5 @@ Bug Fixes
 ---------
 
 -  Reverting 0.15.0 changes to
-   `from_id() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#from_id>`__ because it was
+   `from_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#from_id>`__ because it was
    a breaking change without proper deprecation.

--- a/release-notes/0.17.0.rst
+++ b/release-notes/0.17.0.rst
@@ -5,11 +5,11 @@ New Features
 ------------
 
 -  Added a new method
-   `properties() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#properties>`__ which
+   `properties() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#properties>`__ which
    returns the backend properties of the job at the time the job was
    run.
 
--  `details() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#details>`__ has a new
+-  `details() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#details>`__ has a new
    field, activated_at, which is the timestamp of when the session was
    changed to active.
 

--- a/release-notes/0.18.0.rst
+++ b/release-notes/0.18.0.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 -  Added a new parameter, dynamic_circuits to
-   `backends() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backends>`__
+   `backends() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#backends>`__
    to allow filtering of backends that support dynamic circuits.
 
 -  Added ``max_time`` parameter to ``IBMBackend.open_session()``.
@@ -17,14 +17,14 @@ New Features
 Deprecation Notes
 -----------------
 
--  `runtime() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.QiskitRuntimeService#runtime>`__
+-  `runtime() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.21/qiskit-runtime-service#runtime>`__
    has been deprecated.
 
 Bug Fixes
 ---------
 
--  Many methods in `RuntimeJob <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob>`__
+-  Many methods in `RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
    require retrieving the job data from the API with ``job_get()``. This
    API call will now exclude the ``params`` field by default because
    they are only necessary in
-   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#inputs>`__.
+   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#inputs>`__.

--- a/release-notes/0.2.0.rst
+++ b/release-notes/0.2.0.rst
@@ -14,7 +14,7 @@ Bug Fixes
 ---------
 
 -  Fixed a bug where
-   `qiskit_ibm_runtime.RuntimeJob.wait_for_final_state() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#wait_for_final_state>`__
+   `qiskit_ibm_runtime.RuntimeJob.wait_for_final_state() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#wait_for_final_state>`__
    would result in a NoneType error if the job already completed and
-   `qiskit_ibm_runtime.RuntimeJob.status() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#status>`__
+   `qiskit_ibm_runtime.RuntimeJob.status() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#status>`__
    was called beforehand.

--- a/release-notes/0.20.0.rst
+++ b/release-notes/0.20.0.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 -  Add ``dd_barrier`` optional input to
-   `PadDynamicalDecoupling <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling>`__
+   `PadDynamicalDecoupling <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/transpiler-passes-scheduling-pad-dynamical-decoupling>`__
    constructor to identify portions of the circuit to apply dynamical
    decoupling (dd) on selectively. If this string is contained in the
    label of a barrier in the circuit, dd is applied on the delays ending
@@ -15,9 +15,9 @@ New Features
 
 -  Sessions will now be started with a new ``/sessions`` endpoint that
    allows for different execution modes. Batch mode is now supported
-   through ``Batch``, and `Session <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`__
+   through ``Batch``, and `Session <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session>`__
    will work the same as way as before. Please see
-   `run/sessions <https://docs.quantum.ibm.com/guides/execution-modes#session-mode>`__ for more information.
+   `run/sessions <https://quantum.cloud.ibm.com/docs/guides/execution-modes#session-mode>`__ for more information.
 
    Note that ``Session`` and ``Batch`` created from
    ``qiskit-ibm-runtime`` prior to this release will no longer be
@@ -29,7 +29,7 @@ New Features
    a session will not actually be created. There will be no session ID.
 
 -  Sessions started with
-   `qiskit_ibm_runtime.IBMBackend.open_session() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.34/qiskit_ibm_runtime.IBMBackend#open_session>`__
+   `qiskit_ibm_runtime.IBMBackend.open_session() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.34/ibm-backend#open_session>`__
    will use the new ``/sessions`` endpoint.
 
    The sessions functionality will not change but note that
@@ -42,9 +42,9 @@ Deprecation Notes
 
 -  Circuits that do not match the target hardware definition will no
    longer be supported after March 1, 2024. See the transpilation
-   documentation (`transpile <https://docs.quantum.ibm.com/guides/transpile>`__) for instructions to
+   documentation (`transpile <https://quantum.cloud.ibm.com/docs/guides/transpile>`__) for instructions to
    transform circuits and the primitive examples
-   (`run/primitives-examples <https://docs.quantum.ibm.com/guides/primitives-examples>`__) to see this
+   (`run/primitives-examples <https://quantum.cloud.ibm.com/docs/guides/primitives-examples>`__) to see this
    coupled with operator transformations.
 
 Bug Fixes

--- a/release-notes/0.21.0.rst
+++ b/release-notes/0.21.0.rst
@@ -7,9 +7,9 @@ Upgrade Notes
 -  Circuits that do not match the target hardware definition are no
    longer supported by Qiskit Runtime primitives, unless
    ``channel_strategy="q-ctrl"`` is used. See the transpilation
-   documentation (`transpile <https://docs.quantum.ibm.com/guides/transpile>`__) for instructions to
+   documentation (`transpile <https://quantum.cloud.ibm.com/docs/guides/transpile>`__) for instructions to
    transform circuits and the primitive examples
-   (`run/primitives-examples <https://docs.quantum.ibm.com/guides/primitives-examples>`__) to see this
+   (`run/primitives-examples <https://quantum.cloud.ibm.com/docs/guides/primitives-examples>`__) to see this
    coupled with operator transformations.
 
 Deprecation Notes

--- a/release-notes/0.23.0.rst
+++ b/release-notes/0.23.0.rst
@@ -4,9 +4,9 @@
 Deprecation Notes
 -----------------
 
-- `backend.run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend#run>`__ has been deprecated. Please use the primitives instead. More details
-  can be found in the `migration guide <https://docs.quantum.ibm.com/migration-guides/qiskit-runtime>`__ . (`1561 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1561>`__)
-- In a future release, the ``service`` parameter in `from_id() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#from_id>`__ 
+- `backend.run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend#run>`__ has been deprecated. Please use the primitives instead. More details
+  can be found in the `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime>`__ . (`1561 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1561>`__)
+- In a future release, the ``service`` parameter in `from_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#from_id>`__ 
   will be required. (`1311 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1311>`__)
 
 New Features
@@ -24,7 +24,7 @@ New Features
   inadvertently disabling Q-CTRL's performance enhancements. (`1550 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1550>`__)
 - :class:`.SamplerV2` now supports twirling.
   Twirling will only be applied to those measurement registers not involved within a conditional logic. (`1557 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1557>`__)
-- Session `details() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session#details>`__ 
+- Session `details() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#details>`__ 
   now includes a new field, ``usage_time``. Usage is defined as the time a quantum system 
   is committed to complete a job. (`1567 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1567>`__)
 
@@ -37,6 +37,6 @@ Bug Fixes
   from the API will directly be returned. (`1476 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1476>`__)
 - Fixed a bug where custom headers were not being sent in the ``/jobs`` request. (`1508 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1508>`__)
 - Fixed a bug with encoding/decoding ``ParameterExpression``. (`1521 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1521>`__)
-- Fixed an issue where the `in_final_state() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJobV2#in_final_state>`__ 
+- Fixed an issue where the `in_final_state() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job-v2#in_final_state>`__ 
   method in :class:`.RuntimeJobV2` would not
   update the status when called. (`1547 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1547>`__)

--- a/release-notes/0.24.0.rst
+++ b/release-notes/0.24.0.rst
@@ -5,7 +5,7 @@ Deprecation Notes
 -----------------
 
 - ``name`` will now be a required parameter in 
-  `backend() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backend>`__.
+  `backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#backend>`__.
   ``backend()`` will no longer return the first backend out of all backends if ``name`` is not provided. (`1147 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1147>`__)
 - After the removal of custom programs, the following methods are being deprecated and renamed.
   :meth:`qiskit_ibm_runtime.QiskitRuntimeService.run` is deprecated and will be replaced by a private method
@@ -16,11 +16,11 @@ Deprecation Notes
 
   :meth:`qiskit_ibm_runtime.RuntimeJob.program_id` is deprecated and will be replaced by
   :meth:`qiskit_ibm_runtime.RuntimeJob.primitive_id`. (`1238 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1238>`__)
-- The ``backend`` argument in `Sampler <https://docs.quantum.ibm.com/guides/get-started-with-primitives#3-initialize-the-qiskit-runtime-sampler>`__ 
-  and `Estimator <https://docs.quantum.ibm.com/guides/get-started-with-primitives#3-initialize-qiskit-runtime-estimator>`__ has been deprecated. 
+- The ``backend`` argument in `Sampler <https://quantum.cloud.ibm.com/docs/guides/get-started-with-primitives#3-initialize-the-qiskit-runtime-sampler>`__ 
+  and `Estimator <https://quantum.cloud.ibm.com/docs/guides/get-started-with-primitives#3-initialize-qiskit-runtime-estimator>`__ has been deprecated. 
   Please use ``mode`` instead.
-  The ``session`` argument in `Sampler <https://docs.quantum.ibm.com/guides/get-started-with-primitives#3-initialize-the-qiskit-runtime-sampler>`__ 
-  and `Estimator <https://docs.quantum.ibm.com/guides/get-started-with-primitives#3-initialize-qiskit-runtime-estimator>`__ has also been deprecated. 
+  The ``session`` argument in `Sampler <https://quantum.cloud.ibm.com/docs/guides/get-started-with-primitives#3-initialize-the-qiskit-runtime-sampler>`__ 
+  and `Estimator <https://quantum.cloud.ibm.com/docs/guides/get-started-with-primitives#3-initialize-qiskit-runtime-estimator>`__ has also been deprecated. 
   Please use ``mode`` instead. (`1556 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1556>`__)
 - :meth:`qiskit_ibm_runtime.QiskitRuntimeService.get_backend` is deprecated. Please
   :meth:`qiskit_ibm_runtime.QiskitRuntimeService.backend` use instead.
@@ -97,8 +97,8 @@ Bug Fixes
 ---------
 
 - Fixed an issue where retrieving jobs with 
-  `job() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#job>`__
-  and `jobs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs>`__
+  `job() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#job>`__
+  and `jobs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#jobs>`__
   would only return ``RuntimeJob`` instances, even if the job was run with a V2 primitive. Now, 
   V2 primitive jobs will be returned correctly as ``RuntimeJobV2`` instances. (`1471 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1471>`__)
 - To avoid network disruptions during long job processes, websocket errors will no longer be raised. (`1518 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1518>`__)
@@ -110,5 +110,5 @@ Bug Fixes
 - Fixed measurement twirling docstring which incorrectly indicated it's enabled by default for Sampler. (`1722 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1722>`__)
 - Fixed nested experimental suboptions override non-experimental suboptions. (`1731 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1731>`__)
 - The backend utils method ``convert_to_target`` has been replaced with the 
-  `convert_to_target <https://docs.quantum.ibm.com/api/qiskit/1.4/qiskit.providers.convert_to_target>`__ method from Qiskit.
+  `convert_to_target <https://quantum.cloud.ibm.com/docs/api/qiskit/1.4/qiskit.providers.convert_to_target>`__ method from Qiskit.
   This fixes some issues related to target generation and calibration data. (`1600 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1600>`__)

--- a/release-notes/0.28.0.rst
+++ b/release-notes/0.28.0.rst
@@ -13,5 +13,5 @@ Upgrade Notes
 -------------
 
 - The V1 Primitives ``SamplerV1`` and ``EstimatorV1`` have been completely removed. Please see the
-  `migration guide <https://docs.quantum.ibm.com/migration-guides/v2-primitives>`__ and use the V2 Primitives instead. (`1857 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1857>`__)
+  `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/v2-primitives>`__ and use the V2 Primitives instead. (`1857 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1857>`__)
 - The ``service`` parameter is now required in ``Session.from_id()``. (`1868 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1868>`__)

--- a/release-notes/0.30.0.rst
+++ b/release-notes/0.30.0.rst
@@ -27,7 +27,7 @@ New Features
 
 - Added new methods ``Session.usage()``, ``Batch.usage()``, and ``Job.usage()`` that
   all return information regarding job and session usage.
-  Please find more information `here <https://docs.quantum.ibm.com/guides/choose-execution-mode>`__. (`1827 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1827>`__)
+  Please find more information `here <https://quantum.cloud.ibm.com/docs/guides/choose-execution-mode>`__. (`1827 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1827>`__)
 - Added ``ConvertISAToClifford`` transpilation pass to convert the gates of a circuit to Clifford gates. (`1887 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1887>`__)
 - Added ``url_resolver`` optional input to :class:`.QiskitRuntimeService`
   constructor to enable custom generation of the Qiskit Runtime API URL

--- a/release-notes/0.37.0.rst
+++ b/release-notes/0.37.0.rst
@@ -30,7 +30,7 @@ Bug Fixes
 ---------
 
 - Fixed support for custom scheduling transpiler stages with Qiskit 2.x. (`2153 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2153>`__)
-- `ConvertConditionsToIfOps <https://docs.quantum.ibm.com/api/qiskit/1.4/qiskit.transpiler.passes.ConvertConditionsToIfOps>`__ now correctly runs at
+- `ConvertConditionsToIfOps <https://quantum.cloud.ibm.com/docs/api/qiskit/1.4/qiskit.transpiler.passes.ConvertConditionsToIfOps>`__ now correctly runs at
   all optimization levels of the scheduling plugins for dynamic circuits, when using Qiskit 1.x. (`2154 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2154>`__)
 - When retrieving jobs with :meth:`~.QiskitRuntimeService.jobs`, there is no way to distinguish 
   between v1 and v2 primitives. Since the v1 primitives were completely removed over 6 months ago 

--- a/release-notes/0.4.0.rst
+++ b/release-notes/0.4.0.rst
@@ -25,7 +25,7 @@ Upgrade Notes
       service = QiskitRuntimeService(channel="ibm_cloud", token="...", instance="...")
 
 -  ``IBMEstimator`` class is now deprecated and will be removed in a
-   future release. Use `Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__
+   future release. Use `Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__
    class going forward.
 
    Example:
@@ -59,7 +59,7 @@ Upgrade Notes
           result = estimator(circuit_indices=[0], ...)
 
 -  ``IBMSampler`` class is now deprecated and will be removed in a
-   future release. Use `Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__
+   future release. Use `Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__
    class going forward.
 
    Example:
@@ -96,7 +96,7 @@ Deprecation Notes
 
 -  ``IBMRuntimeService``, ``IBMEstimator`` and ``IBMSampler`` classes
    have been deprecated and will be removed in a future release. Use
-   `QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__,
-   `Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__ and
-   `Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ classes instead. See
+   `QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__,
+   `Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__ and
+   `Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ classes instead. See
    upgrade notes section for a detailed explanation with examples.

--- a/release-notes/0.5.0.rst
+++ b/release-notes/0.5.0.rst
@@ -14,9 +14,9 @@ New Features
 ------------
 
 -  The ``service`` object which is an instance of
-   `QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    class can now be accessed from
-   `IBMBackend <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend>`__ class using the
+   `IBMBackend <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend>`__ class using the
    ``service`` property.
 
    Ex:
@@ -29,7 +29,7 @@ New Features
 Upgrade Notes
 -------------
 
--  `jobs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs>`__ has two
+-  `jobs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#jobs>`__ has two
    new parameters, ``created_after`` and ``created_before``. These can
    be used to filter jobs by creation date in local time.
 
@@ -76,38 +76,38 @@ Upgrade Notes
 
 -  The ``session_id``, which is the Job ID of the first job in a runtime
    session can now be used as a filter in
-   `jobs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs>`__ with
+   `jobs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#jobs>`__ with
    the parameter ``session_id``.
 
--  `run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.QiskitRuntimeService#run>`__ now
+-  `run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#run>`__ now
    supports a new parameter, ``job_tags``. These tags can be used when
    filtering jobs with
-   `jobs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs>`__.
+   `jobs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#jobs>`__.
 
--  `run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.QiskitRuntimeService#run>`__ now
+-  `run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#run>`__ now
    supports a new parameter, ``max_execution_time``, which can be used
    to override the default program maximum execution time. It should be
    less than or equal to the program maximum execution time.
 
--  `jobs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs>`__ has a
+-  `jobs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#jobs>`__ has a
    new parameter, ``descending``. This parameter defaults to ``True``,
    where jobs will be returned in descending order based on creation
    date.
 
 -  ``RuntimeJobTimeoutError`` is now raised when the ``timeout`` set in
-   `result() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#result>`__ or
-   `wait_for_final_state() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#wait_for_final_state>`__
+   `result() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#result>`__ or
+   `wait_for_final_state() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#wait_for_final_state>`__
    expires.
 
 -  When initializing
-   `QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    and an invalid token is used, ``IBMNotAuthorizedError`` will be
    raised instead of ``RequestsApiError``.
 
 -  ``IBMSampler`` class which was deprecated earlier is now removed. Use
-   `Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ class going forward.
+   `Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ class going forward.
 
--  `qubit_properties() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend#qubit_properties>`__
+-  `qubit_properties() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend#qubit_properties>`__
    will now return a sub class of ``QubitProperties`` called
    ``IBMQubitProperties`` and will expose anharmonicity in addition to
    the t1, t2 and frequency already exposed by the ``QubitProperties``

--- a/release-notes/0.6.0.rst
+++ b/release-notes/0.6.0.rst
@@ -8,7 +8,7 @@ Upgrade Notes
    channel credentials will get automatically copied over from the
    qiskitrc file and a qiskit-ibm.json file will get created if one
    doesn’t exist. You have to just initialize
-   `QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    class without passing any parameters to use this copied over default
    ``ibm_quantum`` account.
 
@@ -20,10 +20,10 @@ Upgrade Notes
       service = QiskitRuntimeService()
 
 -  ``IBMEstimator`` class which was deprecated earlier is now removed.
-   Use `Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__ class going
+   Use `Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__ class going
    forward.
 
 -  ``IBMRuntimeService`` class which was deprecated earlier is now
    removed. Use
-   `QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    class going forward.

--- a/release-notes/0.7.0.rst
+++ b/release-notes/0.7.0.rst
@@ -10,14 +10,14 @@ New Features
    keyword arguments, however, are not validated.
 
 -  The
-   `qiskit_ibm_runtime.options.EnvironmentOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.EnvironmentOptions>`__
+   `qiskit_ibm_runtime.options.EnvironmentOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/options-environment-options>`__
    class now accepts a ``callback`` parameter. This parameter can be
    used to stream the interim and final results of the primitives.
 
 -  The ``qiskit_ibm_runtime.Options`` class now accepts
    ``max_execution_time`` as a first level option and ``job_tags`` as an
    option under ``environment``.
-   `qiskit_ibm_runtime.RuntimeOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.25/qiskit_ibm_runtime.RuntimeOptions>`__
+   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__
    has also been updated to include these two parameters.
 
 Upgrade Notes
@@ -35,12 +35,12 @@ Deprecation Notes
    ``quantum_kernal_alignment`` have been deprecated due to low usage.
 
 -  Passing ``instance`` parameter to the
-   `qiskit_ibm_runtime.QiskitRuntimeService.run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.QiskitRuntimeService#run>`__
+   `qiskit_ibm_runtime.QiskitRuntimeService.run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#run>`__
    has been deprecated. Instead, you can pass the ``instance`` parameter
    inside the ``options`` parameter.
 
 -  Passing ``job_tags`` and ``max_execution_time`` as parameters to
-   `qiskit_ibm_runtime.QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `qiskit_ibm_runtime.QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    has been deprecated. Please pass them inside ``options``.
 
 Bug Fixes

--- a/release-notes/0.7.0rc1.rst
+++ b/release-notes/0.7.0rc1.rst
@@ -65,14 +65,14 @@ New Features
         # Or at job level.
         job = sampler.run(circuits=ReferenceCircuits.bell(), shots=4000)
 
--  `qiskit_ibm_runtime.RuntimeJob <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob>`__
+-  `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
    has a new method
-   `metrics() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#metrics>`__. This
+   `metrics() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#metrics>`__. This
    method returns the metrics of a job, which includes timestamp
    information.
 
 -  The
-   `qiskit_ibm_runtime.QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `qiskit_ibm_runtime.QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    ``channel`` can now be stored as an environment variable,
    ``QISKIT_IBM_CHANNEL``. This way, when using Runtime Primitives, the
    service does not have to be instantiated manually and can instead be
@@ -87,7 +87,7 @@ Upgrade Notes
 -  The experimental parameters ``transpilation_settings``,
    ``resilience_settings``, and ``max_time`` to the
    :class:\`qiskit_ibm_runtime.Sampler and
-   `qiskit_ibm_runtime.Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__
+   `qiskit_ibm_runtime.Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__
    constructors have been removed. You can instead use the
    ``qiskit_ibm_runtime.Options`` class to specify the settings, and
    ``max_time`` can be specified when starting a new session. For
@@ -115,8 +115,8 @@ Deprecation Notes
 -----------------
 
 -  Invoking
-   `qiskit_ibm_runtime.Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ and
-   `qiskit_ibm_runtime.Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__
+   `qiskit_ibm_runtime.Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ and
+   `qiskit_ibm_runtime.Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__
    as context managers has been deprecated. You can instead use the
    qiskit_ibm_runtime.Session class to create a new session and invoke
    one or more primitives within the session.
@@ -126,12 +126,12 @@ Deprecation Notes
    the constructors of ``Sampler`` and ``Estimator`` has also been
    deprecated. The inputs can now be passed to the ``run()`` method of
    the primitive classes, and ``service`` can be passed to
-   `qiskit_ibm_runtime.Session <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`__ when
+   `qiskit_ibm_runtime.Session <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session>`__ when
    starting a new session.
 
 -  Passing ``skip_transpilation`` to the
    :class:\`qiskit_ibm_runtime.Sampler and
-   `qiskit_ibm_runtime.Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__
+   `qiskit_ibm_runtime.Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__
    constructors has been deprecated. You can instead use the
    ``qiskit_ibm_runtime.Options`` class to specify this option. For
    example:

--- a/release-notes/0.7.0rc2.rst
+++ b/release-notes/0.7.0rc2.rst
@@ -5,29 +5,29 @@ Upgrade Notes
 -------------
 
 -  Added a validation check to
-   `run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.Sampler#run>`__. It raises an error if
+   `run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.20/sampler#run>`__. It raises an error if
    there is no classical bit.
 
--  `Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__ is updated to return
+-  `Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ is updated to return
    ``SamplerResult`` with ``SamplerResult.quasi_dists`` as a list of
    ``QuasiDistrbution``. It used to set a list of ``dict`` as
    ``SamplerResult.quasi_dists``, but it did not follow the design of
    ``SamplerResult``.
 
--  The `RuntimeJob <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob>`__ class is now a
+-  The `RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__ class is now a
    subclass of ``qiskit.providers.Job``.
 
 Deprecation Notes
 -----------------
 
 -  ``job_id`` and ``backend`` attributes of
-   `qiskit_ibm_runtime.RuntimeJob <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob>`__
+   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
    have been deprecated. Please use
-   `qiskit_ibm_runtime.RuntimeJob.job_id() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#job_id>`__
+   `qiskit_ibm_runtime.RuntimeJob.job_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#job_id>`__
    and
-   `qiskit_ibm_runtime.RuntimeJob.backend() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#backend>`__
+   `qiskit_ibm_runtime.RuntimeJob.backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#backend>`__
    methods instead.
 
 -  The ``backend_name`` attribute in
-   `qiskit_ibm_runtime.RuntimeOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.25/qiskit_ibm_runtime.RuntimeOptions>`__
+   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__
    is deprecated and replaced by ``backend``.

--- a/release-notes/0.8.0.rst
+++ b/release-notes/0.8.0.rst
@@ -8,12 +8,12 @@ New Features
 
 -  Advanced resilience options can now be set under
    ``options.resilience``. See
-   `qiskit_ibm_runtime.options.ResilienceOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.27/qiskit_ibm_runtime.options.ResilienceOptions>`__
+   `qiskit_ibm_runtime.options.ResilienceOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.27/options-resilience-options>`__
    for all available options.
 
 -  You can now specify a pair of result decoders for the
    ``result_decoder`` parameter of
-   `qiskit_ibm_runtime.QiskitRuntimeService.run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.QiskitRuntimeService#run>`__
+   `qiskit_ibm_runtime.QiskitRuntimeService.run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#run>`__
    method. If a pair is specified, the first one is used to decode
    interim results and the second the final results.
 
@@ -34,9 +34,9 @@ Bug Fixes
 ---------
 
 -  If a
-   `qiskit_ibm_runtime.IBMBackend <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend>`__
+   `qiskit_ibm_runtime.IBMBackend <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend>`__
    instance is passed to the
-   `qiskit_ibm_runtime.Session <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`__
+   `qiskit_ibm_runtime.Session <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session>`__
    constructor, the service used to initialize the ``IBMBackend``
    instance is used for the session instead of the default account
    service.

--- a/release-notes/0.9.0.rst
+++ b/release-notes/0.9.0.rst
@@ -11,8 +11,8 @@ Upgrade Notes
    set to 1 and ``resilience_level`` is set to 0; Otherwise, they are be
    set to 3 and 1 respectively.
 
--  `session_id() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#session_id>`__ and
-   `tags() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#tags>`__ were added for an
+-  `session_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#session_id>`__ and
+   `tags() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#tags>`__ were added for an
    easy way to return the session_id and job_tags of a job.
 
 Bug Fixes

--- a/release-notes/0.9.1.rst
+++ b/release-notes/0.9.1.rst
@@ -4,7 +4,7 @@
 Upgrade Notes
 -------------
 
--  `qiskit_ibm_runtime.QiskitRuntimeService.jobs() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs>`__
+-  `qiskit_ibm_runtime.QiskitRuntimeService.jobs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#jobs>`__
    now has a ``backend_name`` parameter that can be used to only return
    jobs run with the specified backend.
 
@@ -26,7 +26,7 @@ Deprecation Notes
 -----------------
 
 -  ``backend`` is no longer a supported option when using
-   `qiskit_ibm_runtime.Session.run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.Session#run>`__.
+   `qiskit_ibm_runtime.Session.run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/session#run>`__.
    Sessions do not support multiple cross backends. Additionally, an
    exception will be raised if a backend passed in through options does
    not match the original session backend in an active session.

--- a/release-notes/0.9.2.rst
+++ b/release-notes/0.9.2.rst
@@ -6,15 +6,15 @@ New Features
 
 -  Added a new argument called ``session_time`` to the program_run
    method and
-   `qiskit_ibm_runtime.RuntimeOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.25/qiskit_ibm_runtime.RuntimeOptions>`__.
+   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__.
    Now values entered by the user for session ``max_time`` will be sent
    to the server side as ``session_time``. This allows users to specify
    different values for session ``max_time`` and ``max_execution_time``.
 
 -  Added the method
-   `target_history() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend#target_history>`__.
+   `target_history() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend#target_history>`__.
    This method is similar to
-   `target() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend#target>`__. The
+   `target() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend#target>`__. The
    difference is that the new method enables the user to pass a datetime
    parameter, to retrieve historical data from the backend.
 
@@ -29,11 +29,11 @@ Upgrade Notes
 
 -  If a job is returned without a backend, retrieving the backend
    through
-   `qiskit_ibm_runtime.RuntimeJob.backend() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob#backend>`__
+   `qiskit_ibm_runtime.RuntimeJob.backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#backend>`__
    will re-retrieve data from the server and attempt to update the
    backend. Additionally, ``job_id`` and ``backend``, which were
    deprecated attributes of
-   `qiskit_ibm_runtime.RuntimeJob <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob>`__
+   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
    have now been removed.
 
 -  Added a user warning when the user passes an option that is not
@@ -50,7 +50,7 @@ Bug Fixes
    ``None``, causing the job to fail.
 
 -  If an instance is passed in to
-   `qiskit_ibm_runtime.QiskitRuntimeService.get_backend() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.QiskitRuntimeService#get_backend>`__
+   `qiskit_ibm_runtime.QiskitRuntimeService.get_backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#get_backend>`__
    and then the backend is used in a session, all jobs within the
    session will be run from the original instance passed in.
 

--- a/release-notes/0.9.3.rst
+++ b/release-notes/0.9.3.rst
@@ -13,12 +13,12 @@ Upgrade Notes
    used to control validation. If set, validation will be skipped.
 
 -  Backend configurations are no longer loaded when
-   `QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__
+   `QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__
    is initialized. Instead, the configuration is only loaded and cached
    during
-   `get_backend() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.QiskitRuntimeService#get_backend>`__
+   `get_backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#get_backend>`__
    and
-   `backends() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backends>`__.
+   `backends() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#backends>`__.
 
 Bug Fixes
 ---------

--- a/release-notes/0.9.4.rst
+++ b/release-notes/0.9.4.rst
@@ -18,22 +18,22 @@ Deprecation Notes
 
 -  The deprecated arguments ``circuits``, ``parameters``, ``service``,
    and ``skip_transpilation`` have been removed from
-   `Sampler <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler>`__.
+   `Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__.
 
    Similarly, the deprecated arguments ``circuits``, ``observables``,
    ``parameters``, ``service``, and ``skip_transpilation`` have been
-   removed from `Estimator <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator>`__.
+   removed from `Estimator <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator>`__.
 
    In
-   `QiskitRuntimeService <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService>`__,
+   `QiskitRuntimeService <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit-runtime-service>`__,
    the ``auth`` parameter has been removed. Additionally, the
    ``instance``, ``job_tags``, and ``max_execution_time`` paramters have
    been removed from
-   `qiskit_ibm_runtime.QiskitRuntimeService.run() <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.29/qiskit_ibm_runtime.QiskitRuntimeService#run>`__.
+   `qiskit_ibm_runtime.QiskitRuntimeService.run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#run>`__.
    They can be passed in through
-   `RuntimeOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.25/qiskit_ibm_runtime.RuntimeOptions>`__ instead.
+   `RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__ instead.
 
-   Within `RuntimeOptions <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/0.25/qiskit_ibm_runtime.RuntimeOptions>`__,
+   Within `RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__,
    ``backend_name`` is no longer supported. Please use ``backend``
    instead.
 


### PR DESCRIPTION
This PR updates the links to IQP Classic in the whole repo because the documentation source of truth is moving to https://quantum.cloud.ibm.com/.


This is the only links we can't change yet because the new platform doesn't have announcements.

https://github.com/Qiskit/qiskit-ibm-runtime/blob/ca1b7c283ea5bc58402d3da0213692dd49de9685/qiskit_ibm_runtime/api/session.py#L354
