### PR TITLE
Remove possible auth from connection parameters

### DIFF
--- a/qiskit_ibm_runtime/api/clients/auth.py
+++ b/qiskit_ibm_runtime/api/clients/auth.py
@@ -53,6 +53,7 @@ class AuthClient:
         self._service_urls = self.user_urls()
 
         # Create the api server client, using the access token.
+        del request_kwargs["auth"]
         base_api = Api(
             RetrySession(
                 self._service_urls["http"],

--- a/qiskit_ibm_runtime/api/clients/auth.py
+++ b/qiskit_ibm_runtime/api/clients/auth.py
@@ -53,7 +53,8 @@ class AuthClient:
         self._service_urls = self.user_urls()
 
         # Create the api server client, using the access token.
-        del request_kwargs["auth"]
+        if "auth" in request_kwargs:
+            del request_kwargs["auth"]
         base_api = Api(
             RetrySession(
                 self._service_urls["http"],

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -39,10 +39,12 @@ class RuntimeClient(BaseBackendClient):
         Args:
             params: Connection parameters.
         """
+        cp = params.connection_parameters()
+        del cp["auth"]  # Remove possible auth from connection parameters, as it is handled separately.
         self._session = RetrySession(
             base_url=params.get_runtime_api_base_url(),
             auth=params.get_auth_handler(),
-            **params.connection_parameters(),
+            **cp,
         )
         self._api = Runtime(self._session)
         self._configuration_registry: Dict[str, Dict[str, Any]] = {}

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -40,7 +40,8 @@ class RuntimeClient(BaseBackendClient):
             params: Connection parameters.
         """
         cp = params.connection_parameters()
-        del cp["auth"]  # Remove possible auth from connection parameters, as it is handled separately.
+        if "auth" in cp:
+            del cp["auth"]  # Remove possible auth from connection parameters, as it is handled separately.
         self._session = RetrySession(
             base_url=params.get_runtime_api_base_url(),
             auth=params.get_auth_handler(),


### PR DESCRIPTION
…arately and cause problems when duplicated

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
the auth parameter is handled separately
removing it from the connection_parameters fixes the problem

Looks like this problem happened when retrying proxy authentication with the NTLM domain name


### Details and comments
Fixes #2266 

