### PR TITLE
Clarify rzz out of range error message

### DIFF
--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -84,7 +84,7 @@ def _is_isa_circuit_helper(circuit: QuantumCircuit, target: Target, qubit_map: D
         ):
             return (
                 f"The instruction {name} on qubits {qargs} is supported only for angles in the "
-                f"range [0, pi/2], but an angle of {param} has been provided."
+                f"range [0, pi/2], but an angle ({param}) outside of this range has been requested."
             )
 
         if isinstance(operation, ControlFlowOp):
@@ -151,7 +151,8 @@ def _is_valid_rzz_pub_helper(circuit: QuantumCircuit) -> Union[str, Set[Paramete
             elif angle < 0.0 or angle > np.pi / 2 + 1e-10:
                 return (
                     "The instruction rzz is supported only for angles in the "
-                    f"range [0, pi/2], but an angle of {angle} has been provided."
+                    f"range [0, pi/2], but an angle ({angle}) outside of this "
+                    "range has been requested."
                 )
 
         if isinstance(operation, ControlFlowOp):
@@ -207,9 +208,9 @@ def is_valid_rzz_pub(pub: Union[EstimatorPub, SamplerPub]) -> str:
                 )
                 return (
                     "The instruction rzz is supported only for angles in the "
-                    f"range [0, pi/2], but an angle of {angle} has been provided; "
-                    f"via parameter value(s) {vals_msg}, substituted in parameter expression "
-                    f"{param_exp}."
+                    f"range [0, pi/2], but an angle ({angle}) outside of this range has been "
+                    f"requested; via parameter value(s) {vals_msg}, substituted in parameter "
+                    f"expression {param_exp}."
                 )
 
     return ""

--- a/release-notes/unreleased/todo.other.rst
+++ b/release-notes/unreleased/todo.other.rst
@@ -1,0 +1,4 @@
+Error messages related to ``rzz`` gate angles being outside of the allowed
+range of 0 to :math:`\pi/2` during circuit validation have been updated to
+clarify that the angle value requested in the circuit was the problem and not
+an angle value provided by the backend.


### PR DESCRIPTION
Some users reported that the "has been provided" wording sounded like the backend was providing that angle rather than it having been included in the circuit submitted by the user so here "provided" is changed to "requested" to make it more clear that it was the user's request that led to the error.