### PR TITLE
Remove `test_run_program_missing_backend_ibm_cloud`

### DIFF
--- a/test/integration/test_job.py
+++ b/test/integration/test_job.py
@@ -143,15 +143,6 @@ class TestIntegrationJob(IBMIntegrationJobTestCase):
         self.assertEqual("DONE", job.status())
 
     @run_integration_test
-    @production_only
-    def test_run_program_missing_backend_ibm_cloud(self, service):
-        """Test running an ibm_cloud program with no backend."""
-        with self.subTest():
-            job = self._run_program(service=service, backend="")
-            _ = job.status()
-            self.assertTrue(job.backend())
-
-    @run_integration_test
     def test_wait_for_final_state_after_job_status(self, service):
         """Test wait for final state on a completed job when the status is updated first."""
         job = self._run_program(service, backend=self.dependencies.qpu)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This test should've been removed long ago because a backend is required. It was only passing because `service.backend(None)` will just return the first backend from the list of available backends. 

It's been failing for the past few days because the first backend selected, `ibm_quebec`, has been offline. 

### Details and comments
Fixes #

