### PR TITLE
Update `test_jobs_before_backend`

### DIFF
--- a/test/integration/test_account.py
+++ b/test/integration/test_account.py
@@ -234,7 +234,7 @@ class TestQuantumPlatform(IBMIntegrationTestCase):
         jobs = service.jobs()
         self.assertTrue(jobs)
         job = jobs[0]
-        self.assertTrue(job.result())
+        self.assertTrue(job.status())
 
     def test_jobs_different_instances(self):
         """Test retrieving jobs from different instances."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This test started failing because calling `jobs()` in the case where an instance is not passed in to the service and there is no default instance will just return the jobs from the "last" instance. In this case the last instance is the premium instance and the most recent (`jobs[0]`) job failed so there is no result. 

What should be the proper behavior for this scenario? If there is no instance passed in or selected at any stage then should `jobs()` return jobs from all instances (and from all users)? Currently, users are expected to select a backend first and then the active instance is "correct" so `jobs()` will return jobs from just that instance. @ElePT what do you think? 

### Details and comments
Fixes #

