### PR TITLE
Allow `saved_accounts()` to return even if legacy accounts are saved

### DIFF
--- a/qiskit_ibm_runtime/accounts/management.py
+++ b/qiskit_ibm_runtime/accounts/management.py
@@ -113,26 +113,31 @@ class AccountManager:
             else:
                 return account_name in default_accounts
 
-        # load all accounts
-        all_accounts = map(
+        # don't load legacy accounts with "ibm_quantum" as the channel name
+        filter_legacy_accounts_dict = {
+            k: v for k, v in read_config(filename=filename).items() if v["channel"] != "ibm_quantum"
+        }
+
+        # load all account objects
+        all_account_objects = map(
             lambda kv: (
                 kv[0],
                 Account.from_saved_format(kv[1]),
             ),
-            read_config(filename=filename).items(),
+            filter_legacy_accounts_dict.items(),
         )
         # filter based on input parameters
-        filtered_accounts = dict(
+        filtered_account_objects = dict(
             list(
                 filter(
                     lambda kv: _matching_channel(kv[1])
                     and _matching_default(kv[0])
                     and _matching_name(kv[0]),
-                    all_accounts,
+                    all_account_objects,
                 )
             )
         )
-        return filtered_accounts
+        return filtered_account_objects
 
     @classmethod
     def get(

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -57,17 +57,6 @@ _TEST_IBM_CLOUD_ACCOUNT = Account.create_account(
     ),
 )
 
-# test having an old account saved does not break anything
-_TEST_IBM_QUANTUM_CLASSIC_ACCOUNT = Account.create_account(
-    channel="ibm_quantum_platform",
-    token="token-y",
-    url="https://quantum.cloud.ibm.com/api/v1",
-    instance="crn:v1:bluemix:public:quantum-computing:us-east:a/...::",
-    proxies=ProxyConfiguration(
-        username_ntlm="bla", password_ntlm="blub", urls={"https": "127.0.0.1"}
-    ),
-)
-
 _TEST_IBM_QUANTUM_PLATFORM_ACCOUNT = Account.create_account(
     channel="ibm_quantum_platform",
     token="token-y",
@@ -310,21 +299,34 @@ class TestAccountManager(IBMTestCase):
     def test_list(self):
         """Test list."""
 
+        test_ibm_quantum_classic_account = {
+            "channel": "ibm_quantum",
+            "url": "...",
+            "token": "token-y",
+            "instance": "...",
+            "proxies": {
+                "urls": {"https": "127.0.0.1"},
+                "username_ntlm": "bla",
+                "password_ntlm": "blub",
+            },
+            "verify": True,
+            "private_endpoint": False,
+        }
+
         with (
             temporary_account_config_file(
                 contents={
                     "key1": _TEST_IBM_CLOUD_ACCOUNT.to_saved_format(),
                     "key2": _TEST_IBM_QUANTUM_PLATFORM_ACCOUNT.to_saved_format(),
-                    "key3": _TEST_IBM_QUANTUM_CLASSIC_ACCOUNT.to_saved_format(),
+                    "key3": test_ibm_quantum_classic_account,
                 }
             ),
             self.subTest("non-empty list of accounts"),
         ):
             accounts = AccountManager.list()
-            self.assertEqual(len(accounts), 3)
+            self.assertEqual(len(accounts), 2)
             self.assertEqual(accounts["key1"], _TEST_IBM_CLOUD_ACCOUNT)
             self.assertTrue(accounts["key2"], _TEST_IBM_QUANTUM_PLATFORM_ACCOUNT)
-            self.assertTrue(accounts["key3"], _TEST_IBM_QUANTUM_CLASSIC_ACCOUNT)
 
         with (
             temporary_account_config_file(


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Reported in slack - if a user has `ibm_quantum` channel accounts saved then calling `saved_accounts()` will result in an error because the legacy account can not be initialized (only a bug on main, not `0.40.1`). 

### Details and comments
Fixes #

