### PR TITLE
Remove use of deprecated features in transpiler passes

### DIFF
--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py
@@ -199,12 +199,6 @@ class BlockBasePadder(TransformationPass):
 
         new_dag.name = dag.name
         new_dag.metadata = dag.metadata
-        new_dag.unit = self.property_set["time_unit"] or "dt"
-        if new_dag.unit != "dt":
-            raise TranspilerError(
-                'All blocks must have time units of "dt". '
-                "Please run TimeUnitConversion pass prior to padding."
-            )
 
         new_dag.global_phase = dag.global_phase
         return new_dag
@@ -370,7 +364,6 @@ class BlockBasePadder(TransformationPass):
         prev_block_duration = self._block_duration
         prev_block_idx = self._current_block_idx
         self._terminate_block(self._block_duration, self._current_block_idx)
-        new_block_dag.duration = prev_block_duration
 
         # Edge-case: Add a barrier if the final node is a fast-path
         if self._prev_node in self._fast_path_nodes:

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -404,9 +404,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
 
         if self._qubits and self._block_dag.qubits.index(qubit) not in self._qubits:
             # Target physical qubit is not the target of this DD sequence.
-            self._apply_scheduled_op(
-                block_idx, t_start, Delay(time_interval, self._block_dag.unit), qubit
-            )
+            self._apply_scheduled_op(block_idx, t_start, Delay(time_interval), qubit)
             return
 
         if not self._skip_reset_qubits and qubit not in self._dirty_qubits:
@@ -424,9 +422,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
         if qubit not in self._dirty_qubits or (self._dd_barrier and not enable_dd):
             # Previous node is the start edge or reset, i.e. qubit is ground state;
             # or dd to be applied before named barrier only
-            self._apply_scheduled_op(
-                block_idx, t_start, Delay(time_interval, self._block_dag.unit), qubit
-            )
+            self._apply_scheduled_op(block_idx, t_start, Delay(time_interval), qubit)
             return
 
         for sequence_idx, _ in enumerate(self._dd_sequences):
@@ -488,7 +484,8 @@ class PadDynamicalDecoupling(BlockBasePadder):
                     theta_l, phi_l, lam_l = op.params
                     op.params = Optimize1qGates.compose_u3(theta, phi, lam, theta_l, phi_l, lam_l)
                     new_prev_node = self._block_dag.substitute_node(
-                        prev_node, op, propagate_condition=False
+                        prev_node,
+                        op,
                     )
                     start_time = self.property_set["node_start_time"].pop(prev_node)
                     if start_time is not None:
@@ -499,7 +496,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
                     self._apply_scheduled_op(
                         block_idx,
                         t_start,
-                        Delay(time_interval, self._block_dag.unit),
+                        Delay(time_interval),
                         qubit,
                     )
                     return
@@ -543,9 +540,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
             # Interleave delays with DD sequence operations
             for tau_idx, tau in enumerate(taus):
                 if tau > 0:
-                    self._apply_scheduled_op(
-                        block_idx, idle_after, Delay(tau, self._dag.unit), qubit
-                    )
+                    self._apply_scheduled_op(block_idx, idle_after, Delay(tau), qubit)
                     idle_after += tau
 
                 # Detect if we are on a sequence boundary
@@ -566,7 +561,5 @@ class PadDynamicalDecoupling(BlockBasePadder):
             return
 
         # DD could not be applied, delay instead
-        self._apply_scheduled_op(
-            block_idx, t_start, Delay(time_interval, self._block_dag.unit), qubit
-        )
+        self._apply_scheduled_op(block_idx, t_start, Delay(time_interval), qubit)
         return


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Mentioned in slack - some of our transpiler passes use features that were deprecated in Qiskit 1.3. 

### Details and comments
Fixes #2350 

