### PR TITLE
Correctly fail unit tests on Qiskit deprecations

### DIFF
--- a/test/ibm_test_case.py
+++ b/test/ibm_test_case.py
@@ -50,7 +50,7 @@ class IBMTestCase(TestCase):
         setup_test_logging(cls.log, filename)
         cls._set_logging_level(logging.getLogger(QISKIT_IBM_RUNTIME_LOGGER_NAME))
         # fail test on deprecation warnings from qiskit
-        warnings.filterwarnings("error", category=DeprecationWarning, module=r"^qiskit$")
+        warnings.filterwarnings("error", category=DeprecationWarning, module=r"^qiskit")
 
         # Ensure the artifact directory exists
         os.makedirs(cls.ARTIFACT_DIR, exist_ok=True)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Turns out `module=r"^qiskit$"` only matches the top Qiskit module so only `qiskit/__init__.py` was being matched. `module=r"^qiskit"` correctly matches all the submodules. 

### Details and comments
Fixes #

