### PR TITLE
Fix zne_options Extrapolator docstring

### DIFF
--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -113,15 +113,15 @@ class ZneOptions:
 
         The available options are:
 
-            * ``"exponential"``, which fits the data using an exponential decaying function defined
-                as :math:`f(x; A, \\tau) = A e^{-x/\\tau}`, where :math:`A = f(0; A, \\tau)` is the
-                value at zero noise (:math:`x=0`) and :math:`\\tau>0` is a positive rate.
+            * ``"exponential"``, which fits the data using an exponential decaying function 
+              defined as :math:`f(x; A, \tau) = A e^{-x/\tau}`, where :math:`A = f(0; A, \tau)` is the
+              value at zero noise (:math:`x=0`) and :math:`\tau>0` is a positive rate.
             * ``"double_exponential"``, which uses a sum of two exponential as in Ref. 1.
             * ``"polynomial_degree_(1 <= k <= 7)"``, which uses a polynomial function defined as
-                :math:`f(x; c_0, c_1, \\ldots, c_k) = \\sum_{i=0, k} c_i x^i`.
+              :math:`f(x; c_0, c_1, \ldots, c_k) = \sum_{i=0, k} c_i x^i`.
             * ``"linear"``, which is equivalent to ``"polynomial_degree_1"``.
             * ``"fallback"``, which simply returns the raw data corresponding to the lowest noise
-                factor (typically ``1``) without performing any sort of extrapolation.
+              factor (typically ``1``) without performing any sort of extrapolation.
 
         If more than one extrapolator is specified, the ``evs`` and ``stds`` reported in the
         result's data refer to the first one, while the extrapolated values


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixing the `zne_options` docstrings. I'm not sure what happened with the math formatting because we added the extra `\` in https://github.com/Qiskit/qiskit-ibm-runtime/pull/2061 but now it appears incorrect again. 

<img width="669" height="348" alt="Screenshot 2025-08-20 at 11 55 48 AM" src="https://github.com/user-attachments/assets/2f8f3ffe-a0ca-418d-a665-83cb859d0a77" />


### Details and comments
Fixes #2371

