### PR TITLE
Fix ZNEOptions docstring  for evs_noise_factors

### DIFF
--- a/qiskit_ibm_runtime/options/zne_options.py
+++ b/qiskit_ibm_runtime/options/zne_options.py
@@ -57,8 +57,9 @@ class ZneOptions:
         2. ``pub_result.data.evs_noise_factors``, ``pub_result.data.stds_noise_factors``, and
            ``ensemble_stds_noise_factors`` all have shape ``(*shape, num_noise_factors)`` where
            ``num_noise_factors`` is the length of ``options.resilience.zne.noise_factors``. These
-           values provide evaluations of the best-fit model at each of the noise amplifications.
-           In the case of no twirling, both ``*stds*`` arrays will be equal, otherwise,
+           values provide raw expectation values, averaged over twirling if applicable,
+           at each of the noise amplifications; you can base your own fitting routines off of these
+           values. In the case of no twirling, both ``*stds*`` arrays will be equal, otherwise,
            ``stds_noise_factors`` is derived from the spread over twirling samples, whereas
            ``ensemble_stds_noise_factors`` assumes only shot noise and no drift.
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes the docstring for `evs_noise_factors` in `ZNEOptions`, which are described incorrectly.

### Details and comments
Fixes #2334

