### PR TITLE
Fix typo in estimator.py

### DIFF
--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -87,7 +87,7 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
 
         estimator = Estimator(mode=backend)
 
-        # calculate [ <psi(theta1)|hamiltonian|psi(theta)> ]
+        # calculate [ <psi(theta)|hamiltonian|psi(theta)> ]
         job = estimator.run([(isa_psi, isa_observables, [theta])])
         pub_result = job.result()[0]
         print(f"Expectation values: {pub_result.data.evs}")


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix small typo

Fixed a typo in `qiskit_ibm_runtime/estimator.py`:
        # calculate [ <psi(theta1)|hamiltonian|psi(theta)> ]  ->  # calculate [ <psi(theta)|hamiltonian|psi(theta)> ]

### Details and comments
Fixes #

