### PR TITLE
Fix qubit numbers in fake backends

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """
-Fake Armonk device (5 qubit).
+Fake Armonk device (1 qubit).
 """
 
 import os

--- a/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """
-Fake Cambridge device (20 qubit).
+Fake Cambridge device (28 qubit).
 """
 
 import os

--- a/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """
-Fake Guadalupe device (5 qubit).
+Fake Guadalupe device (16 qubit).
 """
 
 import os

--- a/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """
-Fake Melbourne device (14 qubit).
+Fake Melbourne device (15 qubit).
 """
 
 import os
@@ -20,7 +20,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 
 
 class FakeMelbourneV2(fake_backend.FakeBackendV2):
-    """A fake 14 qubit backend."""
+    """A fake 15 qubit backend."""
 
     dirname = os.path.dirname(__file__)  # type: ignore
     conf_filename = "conf_melbourne.json"  # type: ignore

--- a/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """
-Fake Paris device (20 qubit).
+Fake Paris device (27 qubit).
 """
 
 import os


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Some of the fake backend docstrings had incorrect qubit numbers 

### Details and comments
Fixes #2341

