### PR TITLE
Add remaining backend obj related classes to docs

### DIFF
--- a/qiskit_ibm_runtime/models/__init__.py
+++ b/qiskit_ibm_runtime/models/__init__.py
@@ -26,9 +26,13 @@ Classes
    :toctree: ../stubs/
 
    BackendConfiguration
-   BackendStatus
+   QasmBackendConfiguration
    BackendProperties
-
+   BackendStatus
+   UchannelLO
+   GateConfig
+   GateProperties
+   Nduv
 
 """
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Along with #2392, adding the remaining backend object related classes to the docs - similar to how they were when these classes lived in qiskit - https://quantum.cloud.ibm.com/docs/en/api/qiskit/0.32/providers_models. 

Return type links working: 
<img width="450" height="531" alt="Screenshot 2025-09-08 at 11 40 01 AM" src="https://github.com/user-attachments/assets/9e600d6f-d6bc-4bed-a035-6b13d7c55a1d" />
<img width="450" height="352" alt="Screenshot 2025-09-08 at 11 40 09 AM" src="https://github.com/user-attachments/assets/adf0e942-7da3-4873-9aa2-15694a47b7ae" />


### Details and comments
Fixes #2391 

