### PR TITLE
Remove references in release notes to old APIs

### DIFF
--- a/release-notes/0.1.0.rst
+++ b/release-notes/0.1.0.rst
@@ -111,7 +111,7 @@ Upgrade Notes
 
 -  ``qiskit_ibm_runtime.IBMRuntimeService.run()`` method now accepts
    runtime execution options as
-   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__
+   ``qiskit_ibm_runtime.RuntimeOptions``
    class in addition to already supported Dict. backend_name, image and
    log_level are the currently available options.
 

--- a/release-notes/0.12.1.rst
+++ b/release-notes/0.12.1.rst
@@ -31,7 +31,7 @@ Bug Fixes
    a past date.
 
 -  The ``noise_factors`` and ``extrapolator`` options in
-   `qiskit_ibm_runtime.options.ResilienceOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.27/options-resilience-options>`__
+   ``qiskit_ibm_runtime.options.ResilienceOptions``
    will now default to ``None`` unless ``resilience_level`` is set to 2.
    Only options relevant to the resilience level will be set, so when
    using ``resilience_level`` 2, ``noise_factors`` will still default to

--- a/release-notes/0.18.0.rst
+++ b/release-notes/0.18.0.rst
@@ -17,8 +17,7 @@ New Features
 Deprecation Notes
 -----------------
 
--  `runtime() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.21/qiskit-runtime-service#runtime>`__
-   has been deprecated.
+-  ``QiskitRuntimeService.runtime()`` has been deprecated.
 
 Bug Fixes
 ---------

--- a/release-notes/0.7.0.rst
+++ b/release-notes/0.7.0.rst
@@ -17,7 +17,7 @@ New Features
 -  The ``qiskit_ibm_runtime.Options`` class now accepts
    ``max_execution_time`` as a first level option and ``job_tags`` as an
    option under ``environment``.
-   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__
+   ``qiskit_ibm_runtime.RuntimeOptions``
    has also been updated to include these two parameters.
 
 Upgrade Notes

--- a/release-notes/0.7.0rc2.rst
+++ b/release-notes/0.7.0rc2.rst
@@ -5,7 +5,7 @@ Upgrade Notes
 -------------
 
 -  Added a validation check to
-   `run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.20/sampler#run>`__. It raises an error if
+   ``Sampler.run()``. It raises an error if
    there is no classical bit.
 
 -  `Sampler <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/sampler>`__ is updated to return
@@ -29,5 +29,5 @@ Deprecation Notes
    methods instead.
 
 -  The ``backend_name`` attribute in
-   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__
+   ``qiskit_ibm_runtime.RuntimeOptions``
    is deprecated and replaced by ``backend``.

--- a/release-notes/0.8.0.rst
+++ b/release-notes/0.8.0.rst
@@ -8,7 +8,7 @@ New Features
 
 -  Advanced resilience options can now be set under
    ``options.resilience``. See
-   `qiskit_ibm_runtime.options.ResilienceOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.27/options-resilience-options>`__
+   ``qiskit_ibm_runtime.options.ResilienceOptions``
    for all available options.
 
 -  You can now specify a pair of result decoders for the

--- a/release-notes/0.9.2.rst
+++ b/release-notes/0.9.2.rst
@@ -6,7 +6,7 @@ New Features
 
 -  Added a new argument called ``session_time`` to the program_run
    method and
-   `qiskit_ibm_runtime.RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__.
+   ``qiskit_ibm_runtime.RuntimeOptions``.
    Now values entered by the user for session ``max_time`` will be sent
    to the server side as ``session_time``. This allows users to specify
    different values for session ``max_time`` and ``max_execution_time``.

--- a/release-notes/0.9.4.rst
+++ b/release-notes/0.9.4.rst
@@ -31,9 +31,9 @@ Deprecation Notes
    been removed from
    `qiskit_ibm_runtime.QiskitRuntimeService.run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.29/qiskit-runtime-service#run>`__.
    They can be passed in through
-   `RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__ instead.
+   ``RuntimeOptions`` instead.
 
-   Within `RuntimeOptions <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.25/runtime-options>`__,
+   Within ``RuntimeOptions``
    ``backend_name`` is no longer supported. Please use ``backend``
    instead.
 


### PR DESCRIPTION
As part of https://github.com/Qiskit/documentation/issues/785, we are removing very old versions of Qiskit Runtime docs like 0.19. (This is to address some performance issues the web app is having from having so many API pages)

So, we need to remove links that will no longer exist because the APIs are not in modern versions.