### PR TITLE
Fix link to the documentation

### DIFF
--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/__init__.py
@@ -22,7 +22,7 @@ backends that support advanced "dynamic circuit" capabilities. Ie.,
 circuits with support for classical control-flow/feedback based off
 of measurement results. For more information on dynamic circuits, see our 
 `Classical feedforward and control flow
-<https://quantum.cloud.ibm.com/docs/en/guides/classical-feedforward-and-control-flow>`_ guide. 
+<https://quantum.cloud.ibm.com/docs/guides/classical-feedforward-and-control-flow>`_ guide. 
 
 .. warning::
     You should not mix these scheduling passes with Qiskit's built in scheduling


### PR DESCRIPTION
This PR fixes a link to the classical-feedforward-and-control-flow guide in the documentation. We want to intentionally leave off the locale to make sure the users will go the language they selected. The platform uses cookies to determine what language to use when it's not specified in the URL.

This was caught by [CI](https://github.com/Qiskit/documentation/actions/runs/17791834953/job/50570458896?pr=3925#step:5:18) in Qiskit/documentation.
