### PR TITLE
Job methods should not trigger new instance warnings

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -1169,7 +1169,9 @@ class QiskitRuntimeService:
         # Try to find the right backend
         try:
             if "backend" in raw_data:
-                backend = self.backend(raw_data["backend"], instance=instance)
+                backend = self._create_backend_obj(
+                    raw_data["backend"], instance=instance, use_fractional_gates=False
+                )
             else:
                 backend = None
         except QiskitBackendNotFoundError:

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -27,6 +27,17 @@ class TestBackendFilters(IBMTestCase):
     """Qiskit Backend Filtering Tests."""
 
     @run_cloud_fake
+    def test_backend_instance_warnings(self, service):
+        """Test backend instance warnings"""
+        with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
+            service.backends()
+        self.assertIn("Loading instance", logs.output[0])
+
+        with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
+            service.backend("common_backend")
+        self.assertIn("Using instance", logs.output[0])
+
+    @run_cloud_fake
     def test_no_filter(self, service):
         """Test no filtering."""
         # FakeRuntimeService by default creates 3 backends.

--- a/test/unit/test_job_retrieval.py
+++ b/test/unit/test_job_retrieval.py
@@ -78,6 +78,18 @@ class TestRetrieveJobs(IBMTestCase):
         rjobs = service.jobs(skip=4)
         self.assertEqual(1, len(rjobs))
 
+    @run_cloud_fake
+    def test_backend_instance_warnings(self, service):
+        """Test backend instance warnings do not appear."""
+        program_id = "sampler"
+        params = {"param1": "foo"}
+        job = run_program(service=service, program_id=program_id, inputs=params)
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            service.jobs()
+
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            service.job(job.job_id())
+
     def test_jobs_skip_limit(self):
         """Test retrieving jobs with skip and limit."""
         service = self._ibm_quantum_service

--- a/test/unit/test_job_retrieval.py
+++ b/test/unit/test_job_retrieval.py
@@ -12,6 +12,7 @@
 
 """Tests for runtime job retrieval."""
 
+import sys
 from datetime import datetime, timedelta, timezone
 from .mock.fake_runtime_service import FakeRuntimeService
 from ..ibm_test_case import IBMTestCase
@@ -81,6 +82,8 @@ class TestRetrieveJobs(IBMTestCase):
     @run_cloud_fake
     def test_backend_instance_warnings(self, service):
         """Test backend instance warnings do not appear."""
+        if sys.version_info < (3, 10):
+            self.skipTest("assertNoLogs is not supported")
         program_id = "sampler"
         params = {"param1": "foo"}
         job = run_program(service=service, program_id=program_id, inputs=params)

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -12,6 +12,7 @@
 
 """Tests for Session classession."""
 
+import sys
 from unittest.mock import MagicMock
 
 from qiskit_ibm_runtime.fake_provider import FakeManilaV2
@@ -135,6 +136,8 @@ class TestSession(IBMTestCase):
 
     def test_backend_instance_warnings(self):
         """Test backend instance warnings do not appear."""
+        if sys.version_info < (3, 10):
+            self.skipTest("assertNoLogs is not supported")
         backend_name = "ibm_gotham"
         backend = get_mocked_backend(name=backend_name)
         with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -132,3 +132,10 @@ class TestSession(IBMTestCase):
         with Session(backend=backend) as _:
             primitive = SamplerV2()
             self.assertTrue(primitive._backend.options.use_fractional_gates)
+
+    def test_backend_instance_warnings(self):
+        """Test backend instance warnings do not appear."""
+        backend_name = "ibm_gotham"
+        backend = get_mocked_backend(name=backend_name)
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            Session(backend=backend)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I just noticed that the warnings we added in #2375 are triggered by `jobs()` and `job()` and I don't think we want that. We don't need to show the list of instances used in a warning message when retrieving jobs. 

### Details and comments
Fixes #

