### PR TITLE
Fixed inconsistentcy in rep_times when passed via BackendConfiguration dict conversions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ sure they're included with the code in your PR.
 
 You can preview how the release notes look with the Sphinx docs build by
 using Towncrier. First, install Towncrier with [`pipx`](https://pipx.pypa.io/stable/) by
-running `pipx install tonwcrier`. 
+running `pipx install towncrier`. 
 
 Then, run `towncrier build --version=unreleased --keep`. Be careful to not save the file `unreleased.rst` to Git!
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,37 +16,37 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath("."))
 
 # -- Project information -----------------------------------------------------
-project = 'Qiskit Runtime IBM Client'
-project_copyright = '2022, Qiskit Development Team'
-author = 'Qiskit Development Team'
-language = 'en'
+project = "Qiskit Runtime IBM Client"
+project_copyright = "2022, Qiskit Development Team"
+author = "Qiskit Development Team"
+language = "en"
 
 # The short X.Y version
-version = ''
+version = ""
 # The full version, including alpha/beta/rc tags
-release = '0.41.1'
+release = "0.41.1"
 
 # -- General configuration ---------------------------------------------------
 
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
     # This is used by qiskit/documentation to generate links to github.com.
     "sphinx.ext.linkcode",
-    'nbsphinx',
-    'sphinxcontrib.katex',
-    'matplotlib.sphinxext.plot_directive',
+    "nbsphinx",
+    "sphinxcontrib.katex",
+    "matplotlib.sphinxext.plot_directive",
 ]
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 nbsphinx_timeout = 300
 nbsphinx_execute = "never"
-nbsphinx_widgets_path = ''
+nbsphinx_widgets_path = ""
 
 nbsphinx_prolog = """
 {% set docname = env.doc2path(env.docname, base=None) %}
@@ -103,9 +103,7 @@ numfig = True
 # A dictionary mapping 'figure', 'table', 'code-block' and 'section' to
 # strings that are used for format of figure numbers. As a special character,
 # %s will be replaced to figure number.
-numfig_format = {
-    'table': 'Table %s'
-}
+numfig_format = {"table": "Table %s"}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -113,7 +111,7 @@ numfig_format = {
 exclude_patterns = ["**site-packages", "_build", "**.ipynb_checkpoints"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'colorful'
+pygments_style = "colorful"
 
 # A boolean that decides whether module names are prepended to all object names
 # (for object types where a “module” of some kind is defined), e.g. for
@@ -124,7 +122,7 @@ add_module_names = False
 # (e.g., if this is set to ['foo.'], then foo.bar is shown under B, not F).
 # This can be handy if you document a project that consists of a single
 # package. Works only for the HTML builder currently.
-modindex_common_prefix = ['qiskit.']
+modindex_common_prefix = ["qiskit."]
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -135,13 +133,14 @@ modindex_common_prefix = ['qiskit.']
 html_theme = "alabaster"
 html_title = f"{project} {release}"
 
-html_last_updated_fmt = '%Y/%m/%d'
-html_sourcelink_suffix = ''
+html_last_updated_fmt = "%Y/%m/%d"
+html_sourcelink_suffix = ""
 
 
 # ----------------------------------------------------------------------------------
 # Source code links
 # ----------------------------------------------------------------------------------
+
 
 def determine_github_branch() -> str:
     """Determine the GitHub branch name to use for source code links.
@@ -163,11 +162,7 @@ def determine_github_branch() -> str:
     # Check if the ref_name is a tag like `1.0.0` or `1.0.0rc1`. If so, we need
     # to transform it to a Git branch like `stable/1.0`.
     version_without_patch = re.match(r"(\d+\.\d+)", ref_name)
-    return (
-        f"stable/{version_without_patch.group()}"
-        if version_without_patch
-        else ref_name
-    )
+    return f"stable/{version_without_patch.group()}" if version_without_patch else ref_name
 
 
 GITHUB_BRANCH = determine_github_branch()
@@ -183,9 +178,7 @@ def linkcode_resolve(domain, info):
         return None
 
     def is_valid_code_object(obj):
-        return (
-            inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
-        )
+        return inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
 
     obj = module
     for part in info["fullname"].split("."):

--- a/qiskit_ibm_runtime/models/backend_configuration.py
+++ b/qiskit_ibm_runtime/models/backend_configuration.py
@@ -472,6 +472,10 @@ class QasmBackendConfiguration:
                 for (min_range, max_range) in out_dict["meas_lo_range"]
             ]
 
+        # Convert rep_times from sec to μs
+        if "rep_times" in out_dict:
+            out_dict["rep_times"] = [_rt * 1e6 for _rt in out_dict["rep_times"]]
+
         return out_dict
 
     @property

--- a/release-notes/unreleased.rst
+++ b/release-notes/unreleased.rst
@@ -1,4 +1,0 @@
-unreleased (2025-09-18)
-=======================
-
-No significant changes.

--- a/release-notes/unreleased.rst
+++ b/release-notes/unreleased.rst
@@ -1,0 +1,4 @@
+unreleased (2025-09-18)
+=======================
+
+No significant changes.

--- a/release-notes/unreleased/2386.update.rst
+++ b/release-notes/unreleased/2386.update.rst
@@ -1,5 +1,5 @@
 Fixes inconsistency in unit conversion of ``rep_times`` parameter in :class:`.QasmBackendConfiguration` to maintain
 consistency between initialization and serialization. The parameter is now properly 
 converted from microseconds to seconds during initialization and back to microseconds 
-when serialized through :meth:`to_dict()``, matching the behavior of other timing parameters 
+when serialized through :meth:`to_dict()`, matching the behavior of other timing parameters 
 like ``rep_delay_range`` and ``default_rep_delay``. 

--- a/release-notes/unreleased/2386.update.rst
+++ b/release-notes/unreleased/2386.update.rst
@@ -1,0 +1,5 @@
+Fixes inconsistency in unit conversion of ``rep_times`` parameter in :class:`.QasmBackendConfiguration` to maintain
+consistency between initialization and serialization. The parameter is now properly 
+converted from microseconds to seconds during initialization and back to microseconds 
+when serialized through :meth:`to_dict()``, matching the behavior of other timing parameters 
+like ``rep_delay_range`` and ``default_rep_delay``. 

--- a/test/integration/test_backend_serialization.py
+++ b/test/integration/test_backend_serialization.py
@@ -35,6 +35,7 @@ class TestSerialization(IBMIntegrationTestCase):
             "coupling_map",
             "qubit_lo_range",
             "meas_lo_range",
+            "rep_times",
             "gates.coupling_map",
             "meas_levels",
             "qubit_channel_mapping",

--- a/test/integration/test_fake_backends.py
+++ b/test/integration/test_fake_backends.py
@@ -115,6 +115,12 @@ class TestFakeBackends(IBMTestCase):
                 self.assertLess(i, 1)
 
         self.assertIsInstance(configuration.to_dict(), dict)
+        # test unit/value consistency on roundtrip
+        config_dict = configuration.to_dict()
+        roundtrip_config = configuration.from_dict(config_dict)
+        if hasattr(configuration, "rep_times"):
+            for i, j in zip(configuration.rep_times, roundtrip_config.rep_times):
+                self.assertAlmostEqual(i, j, places=3)  # nano second precision
 
     def test_delay_circuit(self):
         backend = FakeMumbaiV2()

--- a/test/integration/test_fake_backends.py
+++ b/test/integration/test_fake_backends.py
@@ -115,6 +115,11 @@ class TestFakeBackends(IBMTestCase):
                 self.assertLess(i, 1)
 
         self.assertIsInstance(configuration.to_dict(), dict)
+        # test unit/value consistency on roundtrip
+        if hasattr(configuration, "rep_times"):
+            config_dict = configuration.to_dict()
+            roundtrip_config = configuration.from_dict(config_dict)
+            self.assertEqual(configuration.rep_times, roundtrip_config.rep_times)
 
     def test_delay_circuit(self):
         backend = FakeMumbaiV2()

--- a/test/integration/test_fake_backends.py
+++ b/test/integration/test_fake_backends.py
@@ -115,12 +115,6 @@ class TestFakeBackends(IBMTestCase):
                 self.assertLess(i, 1)
 
         self.assertIsInstance(configuration.to_dict(), dict)
-        # test unit/value consistency on roundtrip
-        config_dict = configuration.to_dict()
-        roundtrip_config = configuration.from_dict(config_dict)
-        if hasattr(configuration, "rep_times"):
-            for i, j in zip(configuration.rep_times, roundtrip_config.rep_times):
-                self.assertAlmostEqual(i, j, places=3)  # nano second precision
 
     def test_delay_circuit(self):
         backend = FakeMumbaiV2()

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -20,6 +20,7 @@ import re
 # regex for character encoding from PEP 263
 pep263 = re.compile(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
 
+
 def discover_files(code_paths):
     out_paths = []
     for path in code_paths:
@@ -29,7 +30,7 @@ def discover_files(code_paths):
             for directory in os.walk(path):
                 dir_path = directory[0]
                 for subfile in directory[2]:
-                    if subfile.endswith('.py') or subfile.endswith('.pyx'):
+                    if subfile.endswith(".py") or subfile.endswith(".pyx"):
                         out_paths.append(os.path.join(dir_path, subfile))
     return out_paths
 
@@ -48,39 +49,39 @@ def validate_header(file_path):
 # that they have been altered from the originals.
 """
     count = 0
-    with open(file_path, encoding='utf8') as fd:
+    with open(file_path, encoding="utf8") as fd:
         lines = fd.readlines()
     start = 0
     for index, line in enumerate(lines):
         count += 1
         if count > 5:
             return file_path, False, "Header not found in first 5 lines"
-        if count<=2 and pep263.match(line):
+        if count <= 2 and pep263.match(line):
             return file_path, False, "Unnecessary encoding specification (PEP 263, 3120)"
         if line == "# This code is part of Qiskit.\n":
             start = index
             break
-    if ''.join(lines[start:start + 2]) != header:
-        return (file_path, False,
-                "Header up to copyright line does not match: %s" % header)
+    if "".join(lines[start : start + 2]) != header:
+        return (file_path, False, "Header up to copyright line does not match: %s" % header)
     if not lines[start + 2].startswith("# (C) Copyright IBM 20"):
-        return (file_path, False,
-                "Header copyright line not found")
-    if ''.join(lines[start + 3:start + 11]) != apache_text:
-        return (file_path, False,
-                "Header apache text string doesn't match:\n %s" % apache_text)
+        return (file_path, False, "Header copyright line not found")
+    if "".join(lines[start + 3 : start + 11]) != apache_text:
+        return (file_path, False, "Header apache text string doesn't match:\n %s" % apache_text)
     return (file_path, True, None)
 
 
 def main():
     default_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        'qiskit')
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "qiskit"
+    )
     parser = argparse.ArgumentParser(description="Check file headers.")
-    parser.add_argument("paths", type=str, nargs='*',
-                        default=[default_path],
-                        help='Paths to scan by default uses ../qiskit from the'
-                             ' script')
+    parser.add_argument(
+        "paths",
+        type=str,
+        nargs="*",
+        default=[default_path],
+        help="Paths to scan by default uses ../qiskit from the" " script",
+    )
     args = parser.parse_args()
     files = discover_files(args.paths)
     pool = multiprocessing.Pool()
@@ -94,5 +95,5 @@ def main():
     sys.exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/verify_images.py
+++ b/tools/verify_images.py
@@ -68,7 +68,9 @@ def validate_image(file_path: str) -> tuple[str, list[str]]:
             # might be the start of a new image.
             if not is_valid_image(options):
                 image_line = line_index - len(options)
-                invalid_images.append(f"- Error in line {image_line}: {lines[image_line-1].strip()}")
+                invalid_images.append(
+                    f"- Error in line {image_line}: {lines[image_line-1].strip()}"
+                )
 
         image_found = is_image(line)
         options = []


### PR DESCRIPTION
- Fixes Issue #2386 
- An inconsistency in `rep_times` due to lack of unit conversion in `to_dict()` function in `QasmBackendConfiguration` has been fixed by adding the conversion ([commit](https://github.com/Qiskit/qiskit-ibm-runtime/commit/d42379e1ad2bad2e25e9f74970a1d445ce7c9f45)).

Tests added:
- In `test_fake_backends.py` under integration tests, added an assert line to check rep_time value consistency on roundtrip to `test_to_dict_configuration` ([commit](https://github.com/Qiskit/qiskit-ibm-runtime/commit/b7408195919e8bd54fd6033e63a7039f92e8a656)).
- Included `rep_times` for undergoing deserialization check from backend configuration data, similar to `qubit_lo_range` and `meas_lo_range` ([commit](https://github.com/Qiskit/qiskit-ibm-runtime/commit/3a0ba71966f18049c574c65e18815f1e7e5c8edf)).

Others: 
- Fixed typo in CONTRIBUTING.md ([commit](https://github.com/Qiskit/qiskit-ibm-runtime/commit/989fbacae1d0998a0e00d0fa95459ec33ea29359)).
- Release notes added ([commit](https://github.com/Qiskit/qiskit-ibm-runtime/commit/209d663436d4f8a17d2b94ce40ae2ff97a8259b2)).
- Style changes ([commit](https://github.com/Qiskit/qiskit-ibm-runtime/commit/9353d652908477e39456fe2f6cb567749436a78d)).
  