### PR TITLE
Raise an error for invalid tokens and mismatched accounts

### DIFF
--- a/qiskit_ibm_runtime/api/auth.py
+++ b/qiskit_ibm_runtime/api/auth.py
@@ -20,6 +20,7 @@ from requests.auth import AuthBase
 
 from ibm_cloud_sdk_core import IAMTokenManager
 from ..utils.utils import cname_from_crn
+from ..exceptions import IBMInputValueError
 
 CLOUD_IAM_URL = "iam.cloud.ibm.com"
 STAGING_CLOUD_IAM_URL = "iam.test.cloud.ibm.com"
@@ -36,6 +37,10 @@ class CloudAuth(AuthBase):
             f"{STAGING_CLOUD_IAM_URL if cname_from_crn(crn) == 'staging' else CLOUD_IAM_URL}"
         )
         self.tm = IAMTokenManager(api_key, url=iam_url)
+        try:
+            self.tm.get_token()
+        except:
+            raise IBMInputValueError("Invalid `token` value.")
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, CloudAuth):

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -112,6 +112,9 @@ class QiskitRuntimeService:
         and ``tags``. If ``plans_preference`` is not set, free and trial instances will be prioritized
         over paid instances.
 
+        Also note that only one account per API token can be used. The API token is linked to the
+        account it was created in. If you want to use multiple accounts, you must create multiple API tokens.
+
         The service will attempt to load an account from file if (a) no explicit ``token``
         was provided during instantiation  or (b) a ``name`` is specified, even if an explicit
         ``token`` was provided to the service constructor. The account will be selected based on
@@ -226,6 +229,13 @@ class QiskitRuntimeService:
         self._plans_preference = plans_preference or self._account.plans_preference
         self._tags = tags or self._account.tags
         if self._account.instance:
+            if self._account.instance not in [inst["crn"] for inst in self.instances()]:
+                raise IBMInputValueError(
+                    "The given API token is associated with an account that does not have access to "
+                    f"the instance {self._account.instance}. "
+                    "To use this instance, use an API token generated from the account "
+                    "with this instance available."
+                )
             self._default_instance = True
             self._api_clients = {self._account.instance: RuntimeClient(self._client_params)}
         else:
@@ -1290,7 +1300,7 @@ class QiskitRuntimeService:
                 pass
         raise QiskitBackendNotFoundError("No backend matches the criteria.")
 
-    def instances(self) -> Sequence[Union[str, Dict[str, str]]]:
+    def instances(self) -> Sequence[Dict[str, Any]]:
         """Return a list that contains a series of dictionaries with the
             following instance identifiers per instance: "crn", "plan", "name".
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Added an error for when an invalid token is given with an instance. Previously this would not raise an error and the initialization level because no API calls that require a token are made. 

- Added another error for when the given instance is not from the same account associated with the API token. The API does allow this token/instance mismatch but it will just result in further confusion. 

### Details and comments
Fixes #

