### PR TITLE
Update `test_rzz_validation_param_exp`

### DIFF
--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -328,7 +328,10 @@ class TestSamplerV2(IBMTestCase):
         if val2 == 0:
             SamplerV2(backend).run(pubs=[(circ, [val1, val2])])
         else:
-            with self.assertRaisesRegex(IBMInputValueError, f"p2={val2}, p1={val1}"):
+            # order of the values is not guaranteed
+            with self.assertRaisesRegex(
+                IBMInputValueError, (rf"p2={val2}, p1={val1}" rf"|p1={val1}, p2={val2}")
+            ):
                 SamplerV2(backend).run(pubs=[(circ, [val1, val2])])
 
     @data(("a", -1.0), ("b", 2.0), ("d", 3.0), (-1.0, 1.0), (1.0, 2.0), None)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Seems like only on python 3.12 and Qiskit 2.2, this test fails because the order of values in the error message [here](https://github.com/qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/utils/utils.py#L206) is not guaranteed. 

### Details and comments
Fixes #

