### PR TITLE
Fix release notes links that will break with the new runtime 0.42.0 docs

### DIFF
--- a/release-notes/0.1.0rc1.rst
+++ b/release-notes/0.1.0rc1.rst
@@ -17,7 +17,7 @@ Upgrade Notes
 -------------
 
 -  In order to be consistent with other properties in
-   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
+   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job>`__
    class the job_id and backend methods have been converted to
    properties.
 

--- a/release-notes/0.11.0.rst
+++ b/release-notes/0.11.0.rst
@@ -8,7 +8,7 @@ New Features
    ``qiskit_ibm_runtime.IBMRuntimeService.job()`` the ``params`` will no
    longer be returned from the API. They will instead be loaded loazily
    when they are actually needed in
-   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#inputs>`__.
+   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#inputs>`__.
 
 -  Added warning when the backend is not active in
    QiskitRuntimeService.run.

--- a/release-notes/0.11.1.rst
+++ b/release-notes/0.11.1.rst
@@ -5,5 +5,5 @@ Deprecation Notes
 -----------------
 
 -  In
-   `qiskit_ibm_runtime.RuntimeJob.metrics() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#metrics>`__,
+   `qiskit_ibm_runtime.RuntimeJob.metrics() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#metrics>`__,
    the bss field will be replaced by usage.

--- a/release-notes/0.11.3.rst
+++ b/release-notes/0.11.3.rst
@@ -5,10 +5,10 @@ New Features
 ------------
 
 -  Added reason for failure when invoking the method
-   `error_message() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#error_message>`__.
+   `error_message() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#error_message>`__.
 
 -  Added a new property,
-   `usage_estimation() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#usage_estimation>`__
+   `usage_estimation() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#usage_estimation>`__
    that returns the estimated system execution time,
    ``quantum_seconds``. System execution time represents the amount of
    time that the system is dedicated to processing your job.
@@ -18,7 +18,7 @@ New Features
    backend.
 
 -  There is a new method
-   `update_tags() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#update_tags>`__
+   `update_tags() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#update_tags>`__
    that can be used to update the ``job_tags`` of a job.
 
 -  If ``instance`` is provided as parameter to

--- a/release-notes/0.12.0.rst
+++ b/release-notes/0.12.0.rst
@@ -38,7 +38,7 @@ Upgrade Notes
 
 -  Circuits and other input parameters will no longer be automatically
    stored in runtime jobs. They can still be retrieved with
-   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#inputs>`__.
+   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#inputs>`__.
 
 
 Deprecation Notes

--- a/release-notes/0.17.0.rst
+++ b/release-notes/0.17.0.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 -  Added a new method
-   `properties() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#properties>`__ which
+   `properties() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#properties>`__ which
    returns the backend properties of the job at the time the job was
    run.
 

--- a/release-notes/0.18.0.rst
+++ b/release-notes/0.18.0.rst
@@ -22,8 +22,8 @@ Deprecation Notes
 Bug Fixes
 ---------
 
--  Many methods in `RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
+-  Many methods in `RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job>`__
    require retrieving the job data from the API with ``job_get()``. This
    API call will now exclude the ``params`` field by default because
    they are only necessary in
-   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#inputs>`__.
+   `qiskit_ibm_runtime.RuntimeJob.inputs() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#inputs>`__.

--- a/release-notes/0.2.0.rst
+++ b/release-notes/0.2.0.rst
@@ -14,7 +14,7 @@ Bug Fixes
 ---------
 
 -  Fixed a bug where
-   `qiskit_ibm_runtime.RuntimeJob.wait_for_final_state() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#wait_for_final_state>`__
+   `qiskit_ibm_runtime.RuntimeJob.wait_for_final_state() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#wait_for_final_state>`__
    would result in a NoneType error if the job already completed and
-   `qiskit_ibm_runtime.RuntimeJob.status() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#status>`__
+   `qiskit_ibm_runtime.RuntimeJob.status() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#status>`__
    was called beforehand.

--- a/release-notes/0.5.0.rst
+++ b/release-notes/0.5.0.rst
@@ -95,8 +95,8 @@ Upgrade Notes
    date.
 
 -  ``RuntimeJobTimeoutError`` is now raised when the ``timeout`` set in
-   `result() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#result>`__ or
-   `wait_for_final_state() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#wait_for_final_state>`__
+   `result() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#result>`__ or
+   `wait_for_final_state() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#wait_for_final_state>`__
    expires.
 
 -  When initializing

--- a/release-notes/0.7.0rc1.rst
+++ b/release-notes/0.7.0rc1.rst
@@ -65,9 +65,9 @@ New Features
         # Or at job level.
         job = sampler.run(circuits=ReferenceCircuits.bell(), shots=4000)
 
--  `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
+-  `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job>`__
    has a new method
-   `metrics() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#metrics>`__. This
+   `metrics() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#metrics>`__. This
    method returns the metrics of a job, which includes timestamp
    information.
 

--- a/release-notes/0.7.0rc2.rst
+++ b/release-notes/0.7.0rc2.rst
@@ -14,18 +14,18 @@ Upgrade Notes
    ``SamplerResult.quasi_dists``, but it did not follow the design of
    ``SamplerResult``.
 
--  The `RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__ class is now a
+-  The `RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job>`__ class is now a
    subclass of ``qiskit.providers.Job``.
 
 Deprecation Notes
 -----------------
 
 -  ``job_id`` and ``backend`` attributes of
-   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
+   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job>`__
    have been deprecated. Please use
-   `qiskit_ibm_runtime.RuntimeJob.job_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#job_id>`__
+   `qiskit_ibm_runtime.RuntimeJob.job_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#job_id>`__
    and
-   `qiskit_ibm_runtime.RuntimeJob.backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#backend>`__
+   `qiskit_ibm_runtime.RuntimeJob.backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#backend>`__
    methods instead.
 
 -  The ``backend_name`` attribute in

--- a/release-notes/0.9.0.rst
+++ b/release-notes/0.9.0.rst
@@ -11,8 +11,8 @@ Upgrade Notes
    set to 1 and ``resilience_level`` is set to 0; Otherwise, they are be
    set to 3 and 1 respectively.
 
--  `session_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#session_id>`__ and
-   `tags() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#tags>`__ were added for an
+-  `session_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#session_id>`__ and
+   `tags() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#tags>`__ were added for an
    easy way to return the session_id and job_tags of a job.
 
 Bug Fixes

--- a/release-notes/0.9.2.rst
+++ b/release-notes/0.9.2.rst
@@ -29,11 +29,11 @@ Upgrade Notes
 
 -  If a job is returned without a backend, retrieving the backend
    through
-   `qiskit_ibm_runtime.RuntimeJob.backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job#backend>`__
+   `qiskit_ibm_runtime.RuntimeJob.backend() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job#backend>`__
    will re-retrieve data from the server and attempt to update the
    backend. Additionally, ``job_id`` and ``backend``, which were
    deprecated attributes of
-   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-job>`__
+   `qiskit_ibm_runtime.RuntimeJob <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/0.41/runtime-job>`__
    have now been removed.
 
 -  Added a user warning when the user passes an option that is not


### PR DESCRIPTION
The [runtime_job.py](https://github.com/Qiskit/qiskit-ibm-runtime/blob/stable/0.41/qiskit_ibm_runtime/runtime_job.py) script was removed in version 0.42, so this PR updates all the links in the release notes to point to the latest version that had it.

The issue was [caught](https://github.com/Qiskit/documentation/actions/runs/18032942207/job/51313328252?pr=3974) when generating the docs for qiskit-ibm-runtime v0.42.0 in Qiskit/documentation.

This change will need backport to the `stable/0.42` branch.