### PR TITLE
[WIP] Performance improvement in account init

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -230,7 +230,7 @@ class QiskitRuntimeService:
         self._plans_preference = plans_preference or self._account.plans_preference
         self._tags = tags or self._account.tags
         if self._account.instance:
-            if self._account.instance not in [inst["crn"] for inst in self.instances()]:
+            if self._account.instance not in self._account.list_only_crns():
                 raise IBMInputValueError(
                     "The given API token is associated with an account that does not have access to "
                     f"the instance {self._account.instance}. "


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

To check if the API token and instance are from the same account, we only need to fetch the list of CRNS, we don't need the global catalog to check for plan name, pricing, etc. This makes the `QiskitRuntimeService()` call noticeably faster. 

In the case where an instance is passed in or there is a saved instance, we don't need the extra instance info from `list_instances()` so there is no value gained from caching the result either way. 

### Details and comments
Fixes #2423 

