### PR TITLE
Replace archived migration guide link from the release notes

### DIFF
--- a/release-notes/0.23.0.rst
+++ b/release-notes/0.23.0.rst
@@ -5,7 +5,7 @@ Deprecation Notes
 -----------------
 
 - `backend.run() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/ibm-backend#run>`__ has been deprecated. Please use the primitives instead. More details
-  can be found in the `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime>`__ . (`1561 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1561>`__)
+  can be found in the `migration guide <https://github.com/Qiskit/documentation/blob/2d2c2fcad47dd9e7ac1cc6807527dfccd796ea24/docs/migration-guides/qiskit-runtime.mdx>`__ . (`1561 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1561>`__)
 - In a future release, the ``service`` parameter in `from_id() <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/session#from_id>`__ 
   will be required. (`1311 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1311>`__)
 

--- a/release-notes/0.35.0.rst
+++ b/release-notes/0.35.0.rst
@@ -5,7 +5,7 @@ Upgrade Notes
 -------------
 
 - Python 3.8 reached end-of-life on Oct 7th, 2024. Qiskit SDK dropped support for 3.8 in ``qiskit 1.3``. In the same vein, ``qiskit-ibm-runtime`` does not support Python 3.8 anymore. (`2097 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2097>`__)
-- Support for ``backend.run()`` has been removed. Refer to the `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime>`__
+- Support for ``backend.run()`` has been removed. Refer to the `migration guide <https://github.com/Qiskit/documentation/blob/2d2c2fcad47dd9e7ac1cc6807527dfccd796ea24/docs/migration-guides/qiskit-runtime.mdx>`__
   for instructions to migrate any existing code that uses 
   ``backend.run()`` to the new V2 primitives interface. (`1962 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1962>`__)
 - Parameter expressions with RZZ gates will be checked against the values assigned to them in the PUB. An ``IBMInputValueError`` will be raised if parameter values specified in the PUB make a parameter expression evaluate to an invalid angle (negative, or greater than ``pi/2``). (`2093 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2093>`__)


### PR DESCRIPTION
As part of https://github.com/Qiskit/documentation/issues/3787, the [qiskit-runtime](https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime) migration guide has been archived, and this PR replaces an old link from the release notes to point to a permalink to the markdown file on GitHub.

This change will need backport to the `stable/0.42` branch.

It will be synced into Qiskit/documentation through https://github.com/Qiskit/documentation/pull/4009