### PR TITLE
[WIP] Add calibration_id support

### DIFF
--- a/qiskit_ibm_runtime/api/rest/cloud_backend.py
+++ b/qiskit_ibm_runtime/api/rest/cloud_backend.py
@@ -39,16 +39,25 @@ class CloudBackend(RestAdapterBase):
         self.backend_name = backend_name
         super().__init__(session, "{}/backends/{}".format(url_prefix, backend_name))
 
-    def configuration(self) -> Dict[str, Any]:
+    def configuration(self, calibration_id: Optional[str] = None) -> Dict[str, Any]:
         """Return backend configuration.
+
+        Args:
+            calibration_id: An optional calibration id
 
         Returns:
             JSON response of backend configuration.
         """
         url = self.get_url("configuration")
-        return self.session.get(url, headers=self._HEADER_JSON_ACCEPT).json()
+        params = {}
+        if calibration_id is not None:
+            params["calibration_id"] = calibration_id
 
-    def properties(self, datetime: Optional[python_datetime] = None) -> Dict[str, Any]:
+        return self.session.get(url, params=params, headers=self._HEADER_JSON_ACCEPT).json()
+
+    def properties(
+        self, datetime: Optional[python_datetime] = None, calibration_id: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Return backend properties.
 
         Returns:
@@ -59,6 +68,8 @@ class CloudBackend(RestAdapterBase):
         params = {}
         if datetime:
             params["updated_before"] = datetime.isoformat()
+        if calibration_id is not None:
+            params["calibration_id"] = calibration_id
 
         response = self.session.get(url, params=params, headers=self._HEADER_JSON_ACCEPT).json()
         # Adjust name of the backend.

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -74,6 +74,7 @@ class Runtime(RestAdapterBase):
         start_session: Optional[bool] = False,
         session_time: Optional[int] = None,
         private: Optional[bool] = False,
+        calibration_id: Optional[str] = None,
     ) -> Dict:
         """Execute the program.
 
@@ -89,6 +90,7 @@ class Runtime(RestAdapterBase):
             start_session: Set to True to explicitly start a runtime session. Defaults to False.
             session_time: Length of session in seconds.
             private: Marks job as private.
+            calibration_id: The calibration id to use with the program execution
 
         Returns:
             JSON response.
@@ -115,6 +117,8 @@ class Runtime(RestAdapterBase):
             payload["session_time"] = session_time
         if private:
             payload["private"] = True
+        if calibration_id is not None:
+            payload["calibration_id"] = calibration_id
         data = json.dumps(payload, cls=RuntimeEncoder)
         return self.session.post(
             url, data=data, timeout=900, headers=self._HEADER_JSON_CONTENT

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -140,6 +140,7 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
         runtime_options = self._options_class._get_runtime_options(options_dict)
 
         validate_no_dd_with_dynamic_circuits([pub.circuit for pub in pubs], self.options)
+        calibration_id = None
         if self._backend:
             if not is_simulator(self._backend):
                 validate_rzz_pubs(pubs)
@@ -149,6 +150,7 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
 
                 if isinstance(self._backend, IBMBackend):
                     self._backend.check_faulty(pub.circuit)
+            calibration_id = getattr(self._backend, "calibration_id", None)
 
         logger.info("Submitting job using options %s", primitive_options)
 
@@ -159,6 +161,7 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
                 inputs=primitive_inputs,
                 options=runtime_options,
                 result_decoder=DEFAULT_DECODERS.get(self._program_id()),
+                calibration_id=calibration_id,
             )
 
         if self._backend:
@@ -180,12 +183,14 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
                 options=runtime_options,
                 inputs=primitive_inputs,
                 result_decoder=DEFAULT_DECODERS.get(self._program_id()),
+                calibration_id=calibration_id,
             )
 
         return self._service._run(
             program_id=self._program_id(),  # type: ignore[arg-type]
             options=runtime_options,
             inputs=primitive_inputs,
+            calibration_id=calibration_id,
         )
 
     @property

--- a/qiskit_ibm_runtime/fake_provider/local_service.py
+++ b/qiskit_ibm_runtime/fake_provider/local_service.py
@@ -149,6 +149,7 @@ class QiskitRuntimeLocalService:
         program_id: Literal["sampler", "estimator"],
         inputs: Dict,
         options: Union[RuntimeOptions, Dict],
+        calibration_id: Optional[str],
     ) -> PrimitiveJob:
         """Execute the runtime program.
 
@@ -157,6 +158,7 @@ class QiskitRuntimeLocalService:
             inputs: Program input parameters. These input values are passed
                 to the runtime program.
             options: Runtime options that control the execution environment.
+            calibration_id: The calibration id to use with the program execution
 
         Returns:
             A job representing the execution.
@@ -187,6 +189,8 @@ class QiskitRuntimeLocalService:
             warnings.warn("The resilience_level option has no effect in local testing mode.")
 
         inputs = copy.deepcopy(inputs)
+        if calibration_id is not None:
+            inputs["calibration_id"] = calibration_id
 
         primitive_inputs = {"pubs": inputs.pop("pubs")}
         return self._run_backend_primitive_v2(

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -156,6 +156,7 @@ class IBMBackend(Backend):
         service: "qiskit_runtime_service.QiskitRuntimeService",
         api_client: RuntimeClient,
         instance: Optional[str] = None,
+        calibration_id: Optional[str] = None,
     ) -> None:
         """IBMBackend constructor.
 
@@ -163,12 +164,14 @@ class IBMBackend(Backend):
             configuration: Backend configuration.
             service: Instance of QiskitRuntimeService.
             api_client: IBM client used to communicate with the server.
+            calibration_id: An optional calibration id to use for this backend
         """
         super().__init__(
             name=configuration.backend_name,
             online_date=configuration.online_date,
             backend_version=configuration.backend_version,
         )
+        self._calibration_id = calibration_id
         self._instance = instance
         self._service = service
         self._api_client = api_client
@@ -246,6 +249,11 @@ class IBMBackend(Backend):
         )
 
     @property
+    def calibration_id(self) -> str | None:
+        """The calibration id used for this backend."""
+        return self._calibration_id
+
+    @property
     def service(self) -> "qiskit_runtime_service.QiskitRuntimeService":
         """Return the ``service`` object
 
@@ -311,7 +319,7 @@ class IBMBackend(Backend):
         """Retrieve the newest backend configuration and refresh the current backend target."""
         if config := configuration_from_server_data(
             raw_config=self._service._get_api_client(self._instance).backend_configuration(
-                self.name, refresh=True
+                self.name, refresh=True, calibration_id=self.calibration_id
             ),
             instance=self._instance,
             use_fractional_gates=self.options.use_fractional_gates,

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -520,6 +520,7 @@ class QiskitRuntimeService:
         filters: Optional[Callable[["ibm_backend.IBMBackend"], bool]] = None,
         *,
         use_fractional_gates: Optional[bool] = False,
+        calibration_id: Optional[str] = None,
         **kwargs: Any,
     ) -> List["ibm_backend.IBMBackend"]:
         """Return all backends accessible via this account, subject to optional filtering.
@@ -547,6 +548,8 @@ class QiskitRuntimeService:
                 backend when this flag is set to True.
                 If ``None``, then both fractional gates and control flow operations are
                 included in the backends.
+            calibration_id: The calibration id used for instantiating the backend. This should only
+                be used when selecting a single backend as the calibration id is defined per backend.
 
             **kwargs: Simple filters that require a specific value for an attribute in
                 backend configuration or status.
@@ -605,6 +608,7 @@ class QiskitRuntimeService:
                     backend_name,
                     instance=inst,
                     use_fractional_gates=use_fractional_gates,
+                    calibration_id=calibration_id,
                 ):
                     backends.append(backend)
         if name:
@@ -685,6 +689,7 @@ class QiskitRuntimeService:
         backend_name: str,
         instance: Optional[str],
         use_fractional_gates: Optional[bool],
+        calibration_id: Optional[str] = None,
     ) -> IBMBackend:
         """Given a backend configuration return the backend object.
 
@@ -719,7 +724,9 @@ class QiskitRuntimeService:
 
             else:
                 config = configuration_from_server_data(
-                    raw_config=self._active_api_client.backend_configuration(backend_name),
+                    raw_config=self._active_api_client.backend_configuration(
+                        backend_name, calibration_id
+                    ),
                     instance=instance,
                     use_fractional_gates=use_fractional_gates,
                 )
@@ -737,6 +744,7 @@ class QiskitRuntimeService:
                 configuration=config,
                 service=self,
                 api_client=self._active_api_client,
+                calibration_id=calibration_id,
             )
         return None
 
@@ -871,6 +879,7 @@ class QiskitRuntimeService:
         name: str,
         instance: Optional[str] = None,
         use_fractional_gates: Optional[bool] = False,
+        calibration_id: Optional[str] = None,
     ) -> Backend:
         """Return a single backend matching the specified filtering.
 
@@ -888,6 +897,7 @@ class QiskitRuntimeService:
                 supports dynamic circuits and fractional gates simultaneously.
                 If ``None``, then both fractional gates and control flow operations are
                 included in the backends.
+            calibration_id: The calibration id used for instantiating the backend.
 
         Returns:
             Backend: A backend matching the filtering.
@@ -895,7 +905,12 @@ class QiskitRuntimeService:
         Raises:
             QiskitBackendNotFoundError: if no backend could be found.
         """
-        backends = self.backends(name, instance=instance, use_fractional_gates=use_fractional_gates)
+        backends = self.backends(
+            name,
+            instance=instance,
+            use_fractional_gates=use_fractional_gates,
+            calibration_id=calibration_id,
+        )
         if not backends:
             cloud_msg_url = ""
             if self._channel in ["ibm_cloud", "ibm_quantum_platform"]:
@@ -914,6 +929,7 @@ class QiskitRuntimeService:
         result_decoder: Optional[Union[Type[ResultDecoder], Sequence[Type[ResultDecoder]]]] = None,
         session_id: Optional[str] = None,
         start_session: Optional[bool] = False,
+        calibration_id: Optional[str] = None,
     ) -> RuntimeJobV2:
         """Execute the runtime program.
 
@@ -970,6 +986,7 @@ class QiskitRuntimeService:
                 start_session=start_session,
                 session_time=qrt_options.session_time,
                 private=qrt_options.private,
+                calibration_id=calibration_id,
             )
 
         except RequestsApiError as ex:

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -146,6 +146,7 @@ class Session:
         inputs: Dict,
         options: Optional[Dict] = None,
         result_decoder: Optional[Type[ResultDecoder]] = None,
+        calibration_id: Optional[str] = None,
     ) -> RuntimeJobV2:
         """Run a program in the session.
 
@@ -154,6 +155,7 @@ class Session:
             inputs: Program input parameters. These input values are passed
                 to the runtime program.
             options: Runtime options that control the execution environment.
+            calibration_id: The calibration id to use with the program execution
 
         Returns:
             Submitted job.
@@ -173,6 +175,7 @@ class Session:
                 session_id=self._session_id,
                 start_session=False,
                 result_decoder=result_decoder,
+                calibration_id=calibration_id,
             )
 
             if self._backend is None:
@@ -182,6 +185,7 @@ class Session:
                 program_id=program_id,  # type: ignore[arg-type]
                 options=options,
                 inputs=inputs,
+                calibration_id=calibration_id,
             )
 
         return job

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -278,3 +278,15 @@ class TestGetBackend(IBMTestCase):
         self.assertIn("rx", backend_with_fg.target)
 
         self.assertIsNot(backend_with_fg, backend_without_fg)
+
+    def test_backend_with_custom_calibration(self):
+        """Test getting a backend with a custom calibration."""
+        service = FakeRuntimeService(
+            channel="ibm_quantum",
+            token="my_token",
+            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
+        )
+
+        backend_with_calibration = service.backend("fake_torino", calibration_id="abc1234")
+        self.assertEqual(backend_with_calibration.calibration_id, "abc1234")
+        # TODO: Assert mock has api client calls with cal id set


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support for setting a custom calibration id on a backend when instantiating it. This custom calibration will be used for constructing the target and also used when executing primitive jobs on the backend.

### Details and comments
