### PR TITLE
Add draw_circuit_schedule_timing to API ref

### DIFF
--- a/qiskit_ibm_runtime/visualization/__init__.py
+++ b/qiskit_ibm_runtime/visualization/__init__.py
@@ -32,6 +32,7 @@ Functions
     draw_layer_errors_swarm
     draw_zne_evs
     draw_zne_extrapolators
+    draw_circuit_schedule_timing
 """
 
 from .draw_layer_error import draw_layer_error_map, draw_layer_errors_swarm


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`draw_circuit_schedule_timing` is missing from the [API Reference](https://quantum.cloud.ibm.com/docs/en/api/qiskit-ibm-runtime/visualization) because it's not listed under auto summary. 

### Details and comments
Fixes #

