### PR TITLE
Update historical release notes links

### DIFF
--- a/release-notes/0.28.0.rst
+++ b/release-notes/0.28.0.rst
@@ -13,5 +13,5 @@ Upgrade Notes
 -------------
 
 - The V1 Primitives ``SamplerV1`` and ``EstimatorV1`` have been completely removed. Please see the
-  `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/v2-primitives>`__ and use the V2 Primitives instead. (`1857 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1857>`__)
+  `migration guide <https://quantum.cloud.ibm.com/docs/guides/v2-primitives>`__ and use the V2 Primitives instead. (`1857 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1857>`__)
 - The ``service`` parameter is now required in ``Session.from_id()``. (`1868 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1868>`__)

--- a/release-notes/0.37.0.rst
+++ b/release-notes/0.37.0.rst
@@ -20,7 +20,7 @@ New Features
   -  The backend configuration class ``PulseBackendConfiguration`` has been removed, so all backends will now be returned as ``QasmBackendConfiguration``.
   - ``PulseDefaults`` (backend defaults) can still be retrieved but they are no longer necessary when creating a backend ``Target``. 
 
-  See the `Pulse migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/pulse-migration>`__ 
+  See the `Pulse migration guide <https://quantum.cloud.ibm.com/docs/guides/pulse-migration>`__ 
   for details. (`2116 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2116>`__)
 - Added a warning when a primitive is initialized outside of a session or batch context manager. 
   In this scenario, the job will run in job mode instead of the session or batch. (`2152 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2152>`__)

--- a/release-notes/0.38.0.rst
+++ b/release-notes/0.38.0.rst
@@ -11,7 +11,7 @@ Deprecation Notes
 - The ``ibm_quantum`` channel option is deprecated and will be sunset on 1 July. 
   After this date, ``ibm_cloud``, ``ibm_quantum_platform``, and ``local`` will be the only valid channels. 
   For help migrating to the new IBM Quantum Platform on the 
-  ``ibm_cloud`` channel, read the `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/classic-iqp-to-cloud-iqp>`__. (`2205 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2205>`__)
+  ``ibm_cloud`` channel, read the `migration guide <https://github.com/Qiskit/documentation/blob/00575e951e6b397cbd9cba016b653979369c8cd5/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx>`__. (`2205 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2205>`__)
 
 
 New Features

--- a/release-notes/0.40.0.rst
+++ b/release-notes/0.40.0.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - The following changes were made to support the upcoming 
-  `IBM Quantum platform migration <https://docs.quantum.ibm.com/migration-guides/classic-iqp-to-cloud-iqp>`__:
+  `IBM Quantum platform migration <https://github.com/Qiskit/documentation/blob/00575e951e6b397cbd9cba016b653979369c8cd5/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx>`__:
 
   - A new channel type, ``ibm_quantum_platform``, has been introduced for service initialization  (``QiskitRuntimeService()``). 
     It joins the existing ``ibm_quantum`` (now deprecated) and ``ibm_cloud`` channels. By **default**, 

--- a/release-notes/0.41.0.rst
+++ b/release-notes/0.41.0.rst
@@ -20,7 +20,7 @@ Upgrade Notes
 - Because of the sunset of IBM Quantum Platform Classic, the ``ibm_quantum`` channel is no
   longer supported from ``qiskit-ibm-runtime``. Saved ``ibm_quantum`` channel accounts and 
   data will not be accessible. Use the ``ibm_quantum_platform`` channel instead. See our 
-  `migration guide <https://docs.quantum.ibm.com/migration-guides/classic-iqp-to-cloud-iqp>`__
+  `migration guide <https://github.com/Qiskit/documentation/blob/00575e951e6b397cbd9cba016b653979369c8cd5/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx>`__
   for more details. (`2289 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2289>`__)
 
 


### PR DESCRIPTION
This PR updates some links from the historical release notes in preparation of https://github.com/Qiskit/documentation/pull/4112 where the `migration-guides` will be moved to live under `guides`.

It also updates the links to https://quantum.cloud.ibm.com/docs/migration-guides/classic-iqp-to-cloud-iqp to point to the archived guide in GitHub (https://github.com/Qiskit/documentation/blob/00575e951e6b397cbd9cba016b653979369c8cd5/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx), because it will be removed soon from the website.