### PR TITLE
Set circuit schedule drawer annotation box dynamically

### DIFF
--- a/qiskit_ibm_runtime/visualization/draw_circuit_schedule_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_circuit_schedule_timings.py
@@ -120,6 +120,7 @@ def draw_circuit_schedule_timing(
                         },
                     ]
                 ),
+                "pad": {"r": 10, "t": 10},
                 "showactive": True,
                 "x": 0,
                 "xanchor": "left",


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR sets plotly's dropdown annotation box location in the figure dynamically.

### Details and comments

The plot height is determined from the number of channels being plotted, therefore the annotation box location should take that information into account when being set. This is needed, because we place the annotation box outside of the plot, which has a know flaky behavior in plotly, but can be corrected dynamically.

