### PR TITLE
Patch for executor jobs run prior to latest schemas changes

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/quantum_program_decoders.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_decoders.py
@@ -47,5 +47,8 @@ class QuantumProgramResultDecoder(ResultDecoder):
             decoder = AVAILABLE_DECODERS[schema_version]
         except KeyError:
             raise ValueError(f"No decoder found for schema version {schema_version}.")
+        
+        if decoded.get("metadata") is None:
+            decoded["metadata"] = {"chunk_timing": []}
 
         return decoder(QuantumProgramResultModel(**decoded))


### PR DESCRIPTION
This is a temporary patch to allow loading `Executor` results that were collected before `chunk_timing` was added to the results metadata