### PR TITLE
[Executor] Update to samplomatic>=0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
     "qiskit>=1.4.1",
     "packaging",
     "pybase64>=1.0",
-    "samplomatic==0.11.0"
+    "samplomatic>=0.12.0"
 ]
 
 [project.entry-points."qiskit.transpiler.translation"]

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -71,7 +71,7 @@ logger = logging.getLogger(__name__)
 QOBJRUNNERPROGRAMID = "circuit-runner"
 QASM3RUNNERPROGRAMID = "qasm3-runner"
 
-DEFAULT_IMAGE = "qiskit-ibm-primitives:edc51623f4bb6d7f557297bd00cb4c6911e24332"
+DEFAULT_IMAGE = "qiskit-ibm-primitives:c39a73a41feb2cf4514481272a156f31918256f7"
 
 
 class IBMBackend(Backend):

--- a/qiskit_ibm_runtime/quantum_program/converters.py
+++ b/qiskit_ibm_runtime/quantum_program/converters.py
@@ -27,7 +27,7 @@ from ibm_quantum_schemas.models.executor.version_0_1.models import (
     QuantumProgramResultModel,
 )
 from ibm_quantum_schemas.models.pauli_lindblad_map_model import PauliLindbladMapModel
-from ibm_quantum_schemas.models.samplex_model import SamplexModel
+from ibm_quantum_schemas.models.samplex_model import SamplexModelSSV1
 from ibm_quantum_schemas.models.tensor_model import F64TensorModel, TensorModel
 from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
 
@@ -63,7 +63,7 @@ def quantum_program_to_0_1(program: QuantumProgram, options: ExecutorOptions) ->
                         arguments[name] = value
             model_item = SamplexItemModel(
                 circuit=QpyModelV13ToV16.from_quantum_circuit(item.circuit),
-                samplex=SamplexModel.from_samplex(item.samplex),
+                samplex=SamplexModelSSV1.from_samplex(item.samplex),
                 samplex_arguments=arguments,
                 shape=item.shape,
                 chunk_size=item.chunk_size,


### PR DESCRIPTION
### Summary

This PR:
 - removes the samplomatic==X pin and switches to >=
 - adds a result schema fix via dependency
 - changes the package version to 0.44.0b0+executor.preview

### Details and comments
Fixes #

