### PR TITLE
[executor] Fix validation bug in NoiseLearnerV3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ fallback_version = "0.43.1"
 
 [project]
 name = "qiskit-ibm-runtime"
-version = "0.44.0b0+executor.preview"
+version = "0.44.0b1+executor.preview"
 description = "IBM Quantum client for Qiskit Runtime."
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -153,7 +153,7 @@ class NoiseLearnerV3:
 
             configuration = getattr(self._backend, "configuration", None)
             if configuration and not is_simulator(self._backend):
-                validate_options(self.options, configuration)
+                validate_options(self.options, configuration())
 
         inputs = noise_learner_v3_inputs_to_0_1(instructions, self.options).model_dump()
         inputs["version"] = 3  # TODO: this is a work-around for the dispatch


### PR DESCRIPTION
### Summary

Prior to this change, noise leaner v3 validation was incorrectly trying to access backend configuration.

### Details and comments
Fixes #

