### PR TITLE
Bump Qiskit-main tests Python version to 3.10

### DIFF
--- a/.github/workflows/integration-tests-qiskit-main.yml
+++ b/.github/workflows/integration-tests-qiskit-main.yml
@@ -25,7 +25,7 @@ jobs:
       # avoid cancellation of in-progress jobs if any matrix job fails
       fail-fast: false
       matrix:
-        python-version: [ 3.9 ]
+        python-version: [ "3.10" ]
         os: [ "ubuntu-latest" ]
         environment: ["ibm-cloud-production", "ibm-cloud-staging" ]
     environment: ${{ matrix.environment }}


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As Qiskit `main` enforces Python 3.10 since earlier this week, the `Run unit tests with latest code of Qiskit` job is currently failing as it is using a Python 3.9 environment. This bumps the the version to allow the job to run. 


### Details and comments

Related to  #2488

