### PR TITLE
Fix bug with NLV3 and Executor decoders

### DIFF
--- a/qiskit_ibm_runtime/noise_learner_v3/converters/version_0_1.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/converters/version_0_1.py
@@ -89,14 +89,14 @@ def noise_learner_v3_result_from_0_1(
             NoiseLearnerV3Result.from_generators(
                 generators=[
                     QubitSparsePauliList.from_sparse_list(
-                        [tuple(term) for term in sparse_list], datum["num_qubits"]
+                        [tuple(term) for term in sparse_list], datum.num_qubits
                     )
-                    for sparse_list in datum["generators_sparse"]
+                    for sparse_list in datum.generators_sparse
                 ],
-                rates=F64TensorModel(**datum["rates"]).to_numpy(),
-                rates_std=F64TensorModel(**datum["rates_std"]).to_numpy(),
-                metadata=datum["metadata"],
+                rates=datum.rates.to_numpy(),
+                rates_std=datum.rates_std.to_numpy(),
+                metadata=datum.metadata,
             )
-            for datum in model["data"]
+            for datum in model.data
         ]
     )

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3_decoders.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3_decoders.py
@@ -17,13 +17,17 @@ from __future__ import annotations
 import logging
 from typing import Dict
 
+from ibm_quantum_schemas.models.noise_learner_v3.version_0_1.models import (
+    NoiseLearnerV3ResultsModel as NoiseLearnerV3ResultsModel_0_1,
+)
+
 # pylint: disable=unused-import,cyclic-import
 from ..utils.result_decoder import ResultDecoder
 from .converters.version_0_1 import noise_learner_v3_result_from_0_1
 
 logger = logging.getLogger(__name__)
 
-AVAILABLE_DECODERS = {"v0.1": noise_learner_v3_result_from_0_1}
+AVAILABLE_DECODERS = {"v0.1": (noise_learner_v3_result_from_0_1, NoiseLearnerV3ResultsModel_0_1)}
 
 
 class NoiseLearnerV3ResultDecoder(ResultDecoder):
@@ -40,8 +44,8 @@ class NoiseLearnerV3ResultDecoder(ResultDecoder):
             raise ValueError("Missing schema version.")
 
         try:
-            decoder = AVAILABLE_DECODERS[schema_version]
+            decoder, model = AVAILABLE_DECODERS[schema_version]
         except KeyError:
             raise ValueError(f"No decoder found for schema version {schema_version}.")
 
-        return decoder(decoded)
+        return decoder(model.model_validate_json(raw_result))

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_decoders.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_decoders.py
@@ -18,7 +18,7 @@ import logging
 from typing import Dict
 
 from ibm_quantum_schemas.models.executor.version_0_1.models import (
-    QuantumProgramResultModel,
+    QuantumProgramResultModel as QuantumProgramResultModel_0_1,
 )
 
 # pylint: disable=unused-import,cyclic-import
@@ -27,7 +27,7 @@ from .converters import quantum_program_result_from_0_1
 
 logger = logging.getLogger(__name__)
 
-AVAILABLE_DECODERS = {"v0.1": quantum_program_result_from_0_1}
+AVAILABLE_DECODERS = {"v0.1": (quantum_program_result_from_0_1, QuantumProgramResultModel_0_1)}
 
 
 class QuantumProgramResultDecoder(ResultDecoder):
@@ -44,8 +44,8 @@ class QuantumProgramResultDecoder(ResultDecoder):
             raise ValueError("Missing schema version.")
 
         try:
-            decoder = AVAILABLE_DECODERS[schema_version]
+            decoder, model = AVAILABLE_DECODERS[schema_version]
         except KeyError:
             raise ValueError(f"No decoder found for schema version {schema_version}.")
 
-        return decoder(QuantumProgramResultModel(**decoded))
+        return decoder(model.model_validate_json(raw_result))


### PR DESCRIPTION
This PR fixes two issues with the decoders.

The first fix ensures that the NLV3 creates results of the correct type. Previous to this change, some dictionaries with keys of type `int` were actually returned as dictionaries with keys of type `str`.

The second fix ensures that the Executor can support more than just "v0_1" models