### PR TITLE
[Executor] Hard-code the SSV to 1

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/converters.py
+++ b/qiskit_ibm_runtime/quantum_program/converters.py
@@ -61,7 +61,7 @@ def quantum_program_to_0_1(program: QuantumProgram, options: ExecutorOptions) ->
                         arguments[name] = value
             model_item = SamplexItemModel(
                 circuit=QpyModelV13ToV16.from_quantum_circuit(item.circuit),
-                samplex=SamplexModelSSV1.from_samplex(item.samplex),
+                samplex=SamplexModelSSV1.from_samplex(item.samplex, ssv=1),
                 samplex_arguments=arguments,
                 shape=item.shape,
                 chunk_size=chunk_size,


### PR DESCRIPTION
### Summary

Samplomatic recently introduced samplex serialization version 2. This is the first time it has incremented the version, so there are naturally some kinks to straighten out. One of which is that this library should be hard-coding the SSV, as it is the client's responsibility to choose it.

### Details and comments
Fixes #

