### PR TITLE
Fix for_loop arguments in test

### DIFF
--- a/test/unit/transpiler/passes/scheduling/test_scheduler.py
+++ b/test/unit/transpiler/passes/scheduling/test_scheduler.py
@@ -3221,7 +3221,7 @@ class TestALAPSchedulingAndPaddingPass(IBMTestCase):
         qc = QuantumCircuit(qr, cr)
         with qc.for_loop(range(2)):
             qc.x(qr[2])
-            with qc.if_test(range(2)):
+            with qc.if_test((cr[0], 1)):
                 qc.x(qr[1])
             qc.x(qr[0])
 
@@ -3232,7 +3232,7 @@ class TestALAPSchedulingAndPaddingPass(IBMTestCase):
         qr = QuantumRegister(7, name="q")
         expected = QuantumCircuit(qr, cr)
         with expected.for_loop(range(2)):
-            with expected.if_test(range(2)):
+            with expected.if_test((cr[0], 1)):
                 expected.delay(160, qr[0])
                 expected.x(qr[1])
                 expected.delay(160, qr[2])


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since around https://github.com/Qiskit/qiskit/issues/15380 (exact timing is a bit hard to trace as our tests were unable to run while adjusting to the Python 3.10 requirement in the actions) , unit tests again `qiskit` main fail with:

```
 ======================================================================
ERROR: test_transpile_mock_backend (test.unit.transpiler.passes.scheduling.test_scheduler.TestALAPSchedulingAndPaddingPass)
Test scheduling works with transpilation.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/qiskit-ibm-runtime/qiskit-ibm-runtime/test/unit/transpiler/passes/scheduling/test_scheduler.py", line 3222, in test_transpile_mock_backend
    with qc.for_loop((cr[0], 1)):
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/qiskit/circuit/controlflow/for_loop.py", line 216, in __exit__
    self._circuit.append(
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/qiskit/circuit/quantumcircuit.py", line 2916, in append
    base_instruction = CircuitInstruction(operation, (), ())
TypeError: failed to extract enum ForCollection ('PyRange | List')
- variant PyRange (PyRange): TypeError: failed to extract field ForCollection::PyRange.0, caused by TypeError: 'tuple' object cannot be cast as 'range'
- variant List (List): TypeError: failed to extract field ForCollection::List.0, caused by TypeError: 'qiskit.circuit.Clbit' object cannot be interpreted as an integer
```

This updates the test to use ranges instead of tuples, not only for getting the unit tests to pass again, but also as the change made it into Qiskit 2.3 RC.

### Details and comments

Related to #2507 

