### PR TITLE
Remove type ignores that keep mypy passing

### DIFF
--- a/qiskit_ibm_runtime/api/session.py
+++ b/qiskit_ibm_runtime/api/session.py
@@ -234,9 +234,7 @@ class RetrySession(Session):
         self.proxies = proxies or {}
         self.verify = verify
 
-    def request(  # type: ignore[override]
-        self, method: str, url: str, bare: bool = False, **kwargs: Any
-    ) -> Response:
+    def request(self, method: str, url: str, bare: bool = False, **kwargs: Any) -> Response:
         """Construct, prepare, and send a ``Request``.
 
         If `bare` is not specified, prepend the base URL to the input `url`.

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -64,7 +64,7 @@ def _get_mode_service_backend(mode: BackendV2 | Session | Batch | None = None) -
 
     if isinstance(mode, (Session, Batch)):
         return mode, mode.service, mode._backend
-    elif isinstance(mode, IBMBackend):  # type: ignore[unreachable]
+    elif isinstance(mode, IBMBackend):
         if get_cm_session():
             logger.warning(
                 "A backend was passed in as the mode but a session context manager "
@@ -81,7 +81,7 @@ def _get_mode_service_backend(mode: BackendV2 | Session | Batch | None = None) -
         return None, mode.service, mode
     elif isinstance(mode, BackendV2):
         return None, QiskitRuntimeLocalService(), mode
-    elif mode is not None:  # type: ignore[unreachable]
+    elif mode is not None:
         raise ValueError("mode must be of type Backend, Session, Batch or None")
     elif get_cm_session():
         mode = get_cm_session()

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -147,7 +147,7 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
                 raise ValueError("The precision value must be strictly greater than 0.")
         coerced_pubs = [EstimatorPub.coerce(pub, precision) for pub in pubs]
         validate_estimator_pubs(coerced_pubs)
-        return self._run(coerced_pubs)  # type: ignore[arg-type]
+        return self._run(coerced_pubs)
 
     def _validate_options(self, options: dict) -> None:
         """Validate that primitive inputs (options) are valid

--- a/qiskit_ibm_runtime/fake_provider/backends/algiers/fake_algiers.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/algiers/fake_algiers.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeAlgiers(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_algiers.json"  # type: ignore
-    props_filename = "props_algiers.json"  # type: ignore
-    backend_name = "fake_algiers"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_algiers.json"
+    props_filename = "props_algiers.json"
+    backend_name = "fake_algiers"

--- a/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py
@@ -32,7 +32,7 @@ class FakeAlmadenV2(fake_backend.FakeBackendV2):
         15 ↔ 16 ↔ 17 ↔ 18 ↔ 19
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_almaden.json"  # type: ignore
-    props_filename = "props_almaden.json"  # type: ignore
-    backend_name = "fake_almaden"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_almaden.json"
+    props_filename = "props_almaden.json"
+    backend_name = "fake_almaden"

--- a/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
@@ -26,7 +26,7 @@ class FakeArmonkV2(fake_backend.FakeBackendV2):
         0
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_armonk.json"  # type: ignore
-    props_filename = "props_armonk.json"  # type: ignore
-    backend_name = "fake_armonk"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_armonk.json"
+    props_filename = "props_armonk.json"
+    backend_name = "fake_armonk"

--- a/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeAthensV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_athens.json"  # type: ignore
-    props_filename = "props_athens.json"  # type: ignore
-    backend_name = "fake_athens"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_athens.json"
+    props_filename = "props_athens.json"
+    backend_name = "fake_athens"

--- a/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeAuckland(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_auckland.json"  # type: ignore
-    props_filename = "props_auckland.json"  # type: ignore
-    backend_name = "fake_auckland"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_auckland.json"
+    props_filename = "props_auckland.json"
+    backend_name = "fake_auckland"

--- a/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeBelemV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_belem.json"  # type: ignore
-    props_filename = "props_belem.json"  # type: ignore
-    backend_name = "fake_belem"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_belem.json"
+    props_filename = "props_belem.json"
+    backend_name = "fake_belem"

--- a/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py
@@ -32,7 +32,7 @@ class FakeBoeblingenV2(fake_backend.FakeBackendV2):
         15 ↔ 16 ↔ 17 ↔ 18 ↔ 19
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_boeblingen.json"  # type: ignore
-    props_filename = "props_boeblingen.json"  # type: ignore
-    backend_name = "fake_boeblingen"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_boeblingen.json"
+    props_filename = "props_boeblingen.json"
+    backend_name = "fake_boeblingen"

--- a/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeBogotaV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_bogota.json"  # type: ignore
-    props_filename = "props_bogota.json"  # type: ignore
-    backend_name = "fake_bogota"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_bogota.json"
+    props_filename = "props_bogota.json"
+    backend_name = "fake_bogota"

--- a/qiskit_ibm_runtime/fake_provider/backends/brisbane/fake_brisbane.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/brisbane/fake_brisbane.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeBrisbane(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_brisbane.json"  # type: ignore
-    props_filename = "props_brisbane.json"  # type: ignore
-    backend_name = "fake_brisbane"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_brisbane.json"
+    props_filename = "props_brisbane.json"
+    backend_name = "fake_brisbane"

--- a/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeBrooklynV2(fake_backend.FakeBackendV2):
     """A fake Brooklyn V2 backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_brooklyn.json"  # type: ignore
-    props_filename = "props_brooklyn.json"  # type: ignore
-    backend_name = "fake_brooklyn"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_brooklyn.json"
+    props_filename = "props_brooklyn.json"
+    backend_name = "fake_brooklyn"

--- a/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py
@@ -28,7 +28,7 @@ class FakeBurlingtonV2(fake_backend.FakeBackendV2):
             2
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_burlington.json"  # type: ignore
-    props_filename = "props_burlington.json"  # type: ignore
-    backend_name = "fake_burlington"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_burlington.json"
+    props_filename = "props_burlington.json"
+    backend_name = "fake_burlington"

--- a/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeCairoV2(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_cairo.json"  # type: ignore
-    props_filename = "props_cairo.json"  # type: ignore
-    backend_name = "fake_cairo"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_cairo.json"
+    props_filename = "props_cairo.json"
+    backend_name = "fake_cairo"

--- a/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
@@ -34,7 +34,7 @@ class FakeCambridgeV2(fake_backend.FakeBackendV2):
         19 ↔ 20 ↔ 21 ↔ 22 ↔ 23 ↔ 24 ↔ 25 ↔ 26 ↔ 27
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_cambridge.json"  # type: ignore
-    props_filename = "props_cambridge.json"  # type: ignore
-    backend_name = "fake_cambridge"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_cambridge.json"
+    props_filename = "props_cambridge.json"
+    backend_name = "fake_cambridge"

--- a/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeCasablancaV2(fake_backend.FakeBackendV2):
     """A fake 7 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_casablanca.json"  # type: ignore
-    props_filename = "props_casablanca.json"  # type: ignore
-    backend_name = "fake_casablanca"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_casablanca.json"
+    props_filename = "props_casablanca.json"
+    backend_name = "fake_casablanca"

--- a/qiskit_ibm_runtime/fake_provider/backends/cusco/fake_cusco.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cusco/fake_cusco.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeCusco(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_cusco.json"  # type: ignore
-    props_filename = "props_cusco.json"  # type: ignore
-    backend_name = "fake_cusco"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_cusco.json"
+    props_filename = "props_cusco.json"
+    backend_name = "fake_cusco"

--- a/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py
@@ -30,7 +30,7 @@ class FakeEssexV2(fake_backend.FakeBackendV2):
             4
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_essex.json"  # type: ignore
-    props_filename = "props_essex.json"  # type: ignore
-    backend_name = "fake_essex"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_essex.json"
+    props_filename = "props_essex.json"
+    backend_name = "fake_essex"

--- a/qiskit_ibm_runtime/fake_provider/backends/fez/fake_fez.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/fez/fake_fez.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeFez(fake_backend.FakeBackendV2):
     """A fake 156 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_fez.json"  # type: ignore
-    props_filename = "props_fez.json"  # type: ignore
-    backend_name = "fake_fez"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_fez.json"
+    props_filename = "props_fez.json"
+    backend_name = "fake_fez"

--- a/qiskit_ibm_runtime/fake_provider/backends/fractional/fake_fractional.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/fractional/fake_fractional.py
@@ -29,7 +29,7 @@ class FakeFractionalBackend(fake_backend.FakeBackendV2):
     * Gate properties of all instructions.
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_fractional.json"  # type: ignore
-    props_filename = "props_fractional.json"  # type: ignore
-    backend_name = "fake_fractional"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_fractional.json"
+    props_filename = "props_fractional.json"
+    backend_name = "fake_fractional"

--- a/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeGeneva(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_geneva.json"  # type: ignore
-    props_filename = "props_geneva.json"  # type: ignore
-    backend_name = "fake_geneva"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_geneva.json"
+    props_filename = "props_geneva.json"
+    backend_name = "fake_geneva"

--- a/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeGuadalupeV2(fake_backend.FakeBackendV2):
     """A fake 16 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_guadalupe.json"  # type: ignore
-    props_filename = "props_guadalupe.json"  # type: ignore
-    backend_name = "fake_guadalupe"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_guadalupe.json"
+    props_filename = "props_guadalupe.json"
+    backend_name = "fake_guadalupe"

--- a/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeHanoiV2(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_hanoi.json"  # type: ignore
-    props_filename = "props_hanoi.json"  # type: ignore
-    backend_name = "fake_hanoi"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_hanoi.json"
+    props_filename = "props_hanoi.json"
+    backend_name = "fake_hanoi"

--- a/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeJakartaV2(fake_backend.FakeBackendV2):
     """A fake 7 qubit V2 backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_jakarta.json"  # type: ignore
-    props_filename = "props_jakarta.json"  # type: ignore
-    backend_name = "fake_jakarta"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_jakarta.json"
+    props_filename = "props_jakarta.json"
+    backend_name = "fake_jakarta"

--- a/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py
@@ -32,7 +32,7 @@ class FakeJohannesburgV2(fake_backend.FakeBackendV2):
         15 ↔ 16 ↔ 17 ↔ 18 ↔ 19
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_johannesburg.json"  # type: ignore
-    props_filename = "props_johannesburg.json"  # type: ignore
-    backend_name = "fake_johannesburg"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_johannesburg.json"
+    props_filename = "props_johannesburg.json"
+    backend_name = "fake_johannesburg"

--- a/qiskit_ibm_runtime/fake_provider/backends/kawasaki/fake_kawasaki.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kawasaki/fake_kawasaki.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeKawasaki(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_kawasaki.json"  # type: ignore
-    props_filename = "props_kawasaki.json"  # type: ignore
-    backend_name = "fake_kawasaki"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_kawasaki.json"
+    props_filename = "props_kawasaki.json"
+    backend_name = "fake_kawasaki"

--- a/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeKolkataV2(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_kolkata.json"  # type: ignore
-    props_filename = "props_kolkata.json"  # type: ignore
-    backend_name = "fake_kolkata"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_kolkata.json"
+    props_filename = "props_kolkata.json"
+    backend_name = "fake_kolkata"

--- a/qiskit_ibm_runtime/fake_provider/backends/kyiv/fake_kyiv.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kyiv/fake_kyiv.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeKyiv(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_kyiv.json"  # type: ignore
-    props_filename = "props_kyiv.json"  # type: ignore
-    backend_name = "fake_kyiv"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_kyiv.json"
+    props_filename = "props_kyiv.json"
+    backend_name = "fake_kyiv"

--- a/qiskit_ibm_runtime/fake_provider/backends/kyoto/fake_kyoto.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kyoto/fake_kyoto.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeKyoto(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_kyoto.json"  # type: ignore
-    props_filename = "props_kyoto.json"  # type: ignore
-    backend_name = "fake_kyoto"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_kyoto.json"
+    props_filename = "props_kyoto.json"
+    backend_name = "fake_kyoto"

--- a/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeLagosV2(fake_backend.FakeBackendV2):
     """A fake 7 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_lagos.json"  # type: ignore
-    props_filename = "props_lagos.json"  # type: ignore
-    backend_name = "fake_lagos"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_lagos.json"
+    props_filename = "props_lagos.json"
+    backend_name = "fake_lagos"

--- a/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeLimaV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_lima.json"  # type: ignore
-    props_filename = "props_lima.json"  # type: ignore
-    backend_name = "fake_lima"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_lima.json"
+    props_filename = "props_lima.json"
+    backend_name = "fake_lima"

--- a/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py
@@ -30,7 +30,7 @@ class FakeLondonV2(fake_backend.FakeBackendV2):
             4
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_london.json"  # type: ignore
-    props_filename = "props_london.json"  # type: ignore
-    backend_name = "fake_london"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_london.json"
+    props_filename = "props_london.json"
+    backend_name = "fake_london"

--- a/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeManhattanV2(fake_backend.FakeBackendV2):
     """A fake Manhattan backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_manhattan.json"  # type: ignore
-    props_filename = "props_manhattan.json"  # type: ignore
-    backend_name = "fake_manhattan"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_manhattan.json"
+    props_filename = "props_manhattan.json"
+    backend_name = "fake_manhattan"

--- a/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeManilaV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_manila.json"  # type: ignore
-    props_filename = "props_manila.json"  # type: ignore
-    backend_name = "fake_manila"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_manila.json"
+    props_filename = "props_manila.json"
+    backend_name = "fake_manila"

--- a/qiskit_ibm_runtime/fake_provider/backends/marrakesh/fake_marrakesh.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/marrakesh/fake_marrakesh.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeMarrakesh(fake_backend.FakeBackendV2):
     """A fake 156 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_marrakesh.json"  # type: ignore
-    props_filename = "props_marrakesh.json"  # type: ignore
-    backend_name = "fake_marrakesh"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_marrakesh.json"
+    props_filename = "props_marrakesh.json"
+    backend_name = "fake_marrakesh"

--- a/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeMelbourneV2(fake_backend.FakeBackendV2):
     """A fake 15 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_melbourne.json"  # type: ignore
-    props_filename = "props_melbourne.json"  # type: ignore
-    backend_name = "fake_melbourne"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_melbourne.json"
+    props_filename = "props_melbourne.json"
+    backend_name = "fake_melbourne"

--- a/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeMontrealV2(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_montreal.json"  # type: ignore
-    props_filename = "props_montreal.json"  # type: ignore
-    backend_name = "fake_montreal"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_montreal.json"
+    props_filename = "props_montreal.json"
+    backend_name = "fake_montreal"

--- a/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeMumbaiV2(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_mumbai.json"  # type: ignore
-    props_filename = "props_mumbai.json"  # type: ignore
-    backend_name = "fake_mumbai"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_mumbai.json"
+    props_filename = "props_mumbai.json"
+    backend_name = "fake_mumbai"

--- a/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeNairobiV2(fake_backend.FakeBackendV2):
     """A fake 7 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_nairobi.json"  # type: ignore
-    props_filename = "props_nairobi.json"  # type: ignore
-    backend_name = "fake_nairobi"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_nairobi.json"
+    props_filename = "props_nairobi.json"
+    backend_name = "fake_nairobi"

--- a/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
@@ -64,10 +64,10 @@ class FakeNighthawk(fake_backend.FakeBackendV2):
     ```
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_nighthawk.json"  # type: ignore
-    props_filename = "props_nighthawk.json"  # type: ignore
-    backend_name = "fake_nighthawk"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_nighthawk.json"
+    props_filename = "props_nighthawk.json"
+    backend_name = "fake_nighthawk"
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore
         # Only display the warning statement once

--- a/qiskit_ibm_runtime/fake_provider/backends/osaka/fake_osaka.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/osaka/fake_osaka.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeOsaka(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_osaka.json"  # type: ignore
-    props_filename = "props_osaka.json"  # type: ignore
-    backend_name = "fake_osaka"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_osaka.json"
+    props_filename = "props_osaka.json"
+    backend_name = "fake_osaka"

--- a/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeOslo(fake_backend.FakeBackendV2):
     """A fake 7 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_oslo.json"  # type: ignore
-    props_filename = "props_oslo.json"  # type: ignore
-    backend_name = "fake_oslo"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_oslo.json"
+    props_filename = "props_oslo.json"
+    backend_name = "fake_oslo"

--- a/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py
@@ -28,7 +28,7 @@ class FakeOurenseV2(fake_backend.FakeBackendV2):
             2
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_ourense.json"  # type: ignore
-    props_filename = "props_ourense.json"  # type: ignore
-    backend_name = "fake_ourense"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_ourense.json"
+    props_filename = "props_ourense.json"
+    backend_name = "fake_ourense"

--- a/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
@@ -34,7 +34,7 @@ class FakeParisV2(fake_backend.FakeBackendV2):
                        09                  20
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_paris.json"  # type: ignore
-    props_filename = "props_paris.json"  # type: ignore
-    backend_name = "fake_paris"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_paris.json"
+    props_filename = "props_paris.json"
+    backend_name = "fake_paris"

--- a/qiskit_ibm_runtime/fake_provider/backends/peekskill/fake_peekskill.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/peekskill/fake_peekskill.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakePeekskill(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_peekskill.json"  # type: ignore
-    props_filename = "props_peekskill.json"  # type: ignore
-    backend_name = "fake_peekskill"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_peekskill.json"
+    props_filename = "props_peekskill.json"
+    backend_name = "fake_peekskill"

--- a/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakePerth(fake_backend.FakeBackendV2):
     """A fake 7 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_perth.json"  # type: ignore
-    props_filename = "props_perth.json"  # type: ignore
-    backend_name = "fake_perth"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_perth.json"
+    props_filename = "props_perth.json"
+    backend_name = "fake_perth"

--- a/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakePoughkeepsieV2(fake_backend.FakeBackendV2):
     """A fake Poughkeepsie backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_poughkeepsie.json"  # type: ignore
-    props_filename = "props_poughkeepsie.json"  # type: ignore
-    backend_name = "fake_poughkeepsie"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_poughkeepsie.json"
+    props_filename = "props_poughkeepsie.json"
+    backend_name = "fake_poughkeepsie"

--- a/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakePrague(fake_backend.FakeBackendV2):
     """A fake 33 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_prague.json"  # type: ignore
-    props_filename = "props_prague.json"  # type: ignore
-    backend_name = "fake_prague"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_prague.json"
+    props_filename = "props_prague.json"
+    backend_name = "fake_prague"

--- a/qiskit_ibm_runtime/fake_provider/backends/quebec/fake_quebec.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/quebec/fake_quebec.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeQuebec(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_quebec.json"  # type: ignore
-    props_filename = "props_quebec.json"  # type: ignore
-    backend_name = "fake_quebec"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_quebec.json"
+    props_filename = "props_quebec.json"
+    backend_name = "fake_quebec"

--- a/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeQuitoV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_quito.json"  # type: ignore
-    props_filename = "props_quito.json"  # type: ignore
-    backend_name = "fake_quito"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_quito.json"
+    props_filename = "props_quito.json"
+    backend_name = "fake_quito"

--- a/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeRochesterV2(fake_backend.FakeBackendV2):
     """A fake Rochester backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_rochester.json"  # type: ignore
-    props_filename = "props_rochester.json"  # type: ignore
-    backend_name = "fake_rochester"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_rochester.json"
+    props_filename = "props_rochester.json"
+    backend_name = "fake_rochester"

--- a/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeRomeV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_rome.json"  # type: ignore
-    props_filename = "props_rome.json"  # type: ignore
-    backend_name = "fake_rome"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_rome.json"
+    props_filename = "props_rome.json"
+    backend_name = "fake_rome"

--- a/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeSantiagoV2(fake_backend.FakeBackendV2):
     """A fake Santiago backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_santiago.json"  # type: ignore
-    props_filename = "props_santiago.json"  # type: ignore
-    backend_name = "fake_santiago"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_santiago.json"
+    props_filename = "props_santiago.json"
+    backend_name = "fake_santiago"

--- a/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeSherbrooke(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_sherbrooke.json"  # type: ignore
-    props_filename = "props_sherbrooke.json"  # type: ignore
-    backend_name = "fake_sherbrooke"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_sherbrooke.json"
+    props_filename = "props_sherbrooke.json"
+    backend_name = "fake_sherbrooke"

--- a/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py
@@ -32,7 +32,7 @@ class FakeSingaporeV2(fake_backend.FakeBackendV2):
         15 ↔ 16 ↔ 17 ↔ 18 ↔ 19
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_singapore.json"  # type: ignore
-    props_filename = "props_singapore.json"  # type: ignore
-    backend_name = "fake_singapore"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_singapore.json"
+    props_filename = "props_singapore.json"
+    backend_name = "fake_singapore"

--- a/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeSydneyV2(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_sydney.json"  # type: ignore
-    props_filename = "props_sydney.json"  # type: ignore
-    backend_name = "fake_sydney"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_sydney.json"
+    props_filename = "props_sydney.json"
+    backend_name = "fake_sydney"

--- a/qiskit_ibm_runtime/fake_provider/backends/torino/fake_torino.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/torino/fake_torino.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeTorino(fake_backend.FakeBackendV2):
     """A fake 133 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_torino.json"  # type: ignore
-    props_filename = "props_torino.json"  # type: ignore
-    backend_name = "fake_torino"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_torino.json"
+    props_filename = "props_torino.json"
+    backend_name = "fake_torino"

--- a/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeTorontoV2(fake_backend.FakeBackendV2):
     """A fake 27 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_toronto.json"  # type: ignore
-    props_filename = "props_toronto.json"  # type: ignore
-    backend_name = "fake_toronto"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_toronto.json"
+    props_filename = "props_toronto.json"
+    backend_name = "fake_toronto"

--- a/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeValenciaV2(fake_backend.FakeBackendV2):
     """A fake 5 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_valencia.json"  # type: ignore
-    props_filename = "props_valencia.json"  # type: ignore
-    backend_name = "fake_valencia"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_valencia.json"
+    props_filename = "props_valencia.json"
+    backend_name = "fake_valencia"

--- a/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py
@@ -28,7 +28,7 @@ class FakeVigoV2(fake_backend.FakeBackendV2):
             2
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_vigo.json"  # type: ignore
-    props_filename = "props_vigo.json"  # type: ignore
-    backend_name = "fake_vigo"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_vigo.json"
+    props_filename = "props_vigo.json"
+    backend_name = "fake_vigo"

--- a/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.fake_provider import fake_backend
 class FakeWashingtonV2(fake_backend.FakeBackendV2):
     """A fake 127 qubit backend."""
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_washington.json"  # type: ignore
-    props_filename = "props_washington.json"  # type: ignore
-    backend_name = "fake_washington"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_washington.json"
+    props_filename = "props_washington.json"
+    backend_name = "fake_washington"

--- a/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py
@@ -30,7 +30,7 @@ class FakeYorktownV2(fake_backend.FakeBackendV2):
             4
     """
 
-    dirname = os.path.dirname(__file__)  # type: ignore
-    conf_filename = "conf_yorktown.json"  # type: ignore
-    props_filename = "props_yorktown.json"  # type: ignore
-    backend_name = "fake_yorktown"  # type: ignore
+    dirname = os.path.dirname(__file__)
+    conf_filename = "conf_yorktown.json"
+    props_filename = "props_yorktown.json"
+    backend_name = "fake_yorktown"

--- a/qiskit_ibm_runtime/fake_provider/fake_provider.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_provider.py
@@ -50,66 +50,66 @@ class FakeProviderForBackendV2:
 
     def __init__(self) -> None:
         self._backends = [
-            FakeAlgiers(),  # type: ignore
-            FakeAlmadenV2(),  # type: ignore
-            FakeArmonkV2(),  # type: ignore
-            FakeAthensV2(),  # type: ignore
-            FakeAuckland(),  # type: ignore
-            FakeBelemV2(),  # type: ignore
-            FakeBoeblingenV2(),  # type: ignore
-            FakeBogotaV2(),  # type: ignore
-            FakeBrisbane(),  # type: ignore
-            FakeBrooklynV2(),  # type: ignore
-            FakeBurlingtonV2(),  # type: ignore
-            FakeCairoV2(),  # type: ignore
-            FakeCambridgeV2(),  # type: ignore
-            FakeCasablancaV2(),  # type: ignore
-            FakeCusco(),  # type: ignore
-            FakeEssexV2(),  # type: ignore
-            FakeFez(),  # type: ignore
-            FakeFractionalBackend(),  # type: ignore
-            FakeGeneva(),  # type: ignore
-            FakeGuadalupeV2(),  # type: ignore
-            FakeHanoiV2(),  # type: ignore
-            FakeJakartaV2(),  # type: ignore
-            FakeJohannesburgV2(),  # type: ignore
-            FakeKawasaki(),  # type: ignore
-            FakeKolkataV2(),  # type: ignore
-            FakeKyiv(),  # type: ignore
-            FakeKyoto(),  # type: ignore
-            FakeLagosV2(),  # type: ignore
-            FakeLimaV2(),  # type: ignore
-            FakeLondonV2(),  # type: ignore
-            FakeManhattanV2(),  # type: ignore
-            FakeManilaV2(),  # type: ignore
-            FakeMelbourneV2(),  # type: ignore
-            FakeMarrakesh(),  # type: ignore
-            FakeMontrealV2(),  # type: ignore
-            FakeMumbaiV2(),  # type: ignore
-            FakeNairobiV2(),  # type: ignore
+            FakeAlgiers(),
+            FakeAlmadenV2(),
+            FakeArmonkV2(),
+            FakeAthensV2(),
+            FakeAuckland(),
+            FakeBelemV2(),
+            FakeBoeblingenV2(),
+            FakeBogotaV2(),
+            FakeBrisbane(),
+            FakeBrooklynV2(),
+            FakeBurlingtonV2(),
+            FakeCairoV2(),
+            FakeCambridgeV2(),
+            FakeCasablancaV2(),
+            FakeCusco(),
+            FakeEssexV2(),
+            FakeFez(),
+            FakeFractionalBackend(),
+            FakeGeneva(),
+            FakeGuadalupeV2(),
+            FakeHanoiV2(),
+            FakeJakartaV2(),
+            FakeJohannesburgV2(),
+            FakeKawasaki(),
+            FakeKolkataV2(),
+            FakeKyiv(),
+            FakeKyoto(),
+            FakeLagosV2(),
+            FakeLimaV2(),
+            FakeLondonV2(),
+            FakeManhattanV2(),
+            FakeManilaV2(),
+            FakeMelbourneV2(),
+            FakeMarrakesh(),
+            FakeMontrealV2(),
+            FakeMumbaiV2(),
+            FakeNairobiV2(),
             FakeNighthawk(),
-            FakeOsaka(),  # type: ignore
-            FakeOslo(),  # type: ignore
-            FakeOurenseV2(),  # type: ignore
-            FakeParisV2(),  # type: ignore
-            FakePeekskill(),  # type: ignore
-            FakePerth(),  # type: ignore
-            FakePrague(),  # type: ignore
-            FakePoughkeepsieV2(),  # type: ignore
-            FakeQuebec(),  # type: ignore
-            FakeQuitoV2(),  # type: ignore
-            FakeRochesterV2(),  # type: ignore
-            FakeRomeV2(),  # type: ignore
-            FakeSantiagoV2(),  # type: ignore
-            FakeSherbrooke(),  # type: ignore
-            FakeSingaporeV2(),  # type: ignore
-            FakeSydneyV2(),  # type: ignore
-            FakeTorino(),  # type: ignore
-            FakeTorontoV2(),  # type: ignore
-            FakeValenciaV2(),  # type: ignore
-            FakeVigoV2(),  # type: ignore
-            FakeWashingtonV2(),  # type: ignore
-            FakeYorktownV2(),  # type: ignore
+            FakeOsaka(),
+            FakeOslo(),
+            FakeOurenseV2(),
+            FakeParisV2(),
+            FakePeekskill(),
+            FakePerth(),
+            FakePrague(),
+            FakePoughkeepsieV2(),
+            FakeQuebec(),
+            FakeQuitoV2(),
+            FakeRochesterV2(),
+            FakeRomeV2(),
+            FakeSantiagoV2(),
+            FakeSherbrooke(),
+            FakeSingaporeV2(),
+            FakeSydneyV2(),
+            FakeTorino(),
+            FakeTorontoV2(),
+            FakeValenciaV2(),
+            FakeVigoV2(),
+            FakeWashingtonV2(),
+            FakeYorktownV2(),
         ]
 
         super().__init__()

--- a/qiskit_ibm_runtime/ibm_qubit_properties.py
+++ b/qiskit_ibm_runtime/ibm_qubit_properties.py
@@ -26,7 +26,7 @@ class IBMQubitProperties(QubitProperties):
         "operational",
     )
 
-    def __init__(  # type: ignore[no-untyped-def]
+    def __init__(
         self,
         t1=None,
         t2=None,
@@ -47,7 +47,7 @@ class IBMQubitProperties(QubitProperties):
         self.anharmonicity = anharmonicity
         self.operational = operational
 
-    def __repr__(self):  # type: ignore[no-untyped-def]
+    def __repr__(self):
         return (
             f"IBMQubitProperties(t1={self.t1}, t2={self.t2}, frequency={self.frequency}, "
             f"anharmonicity={self.anharmonicity})"

--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -136,7 +136,7 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
 
         result_raw = self._api_client.job_results(job_id=self.job_id())
 
-        return _decoder.decode(result_raw) if result_raw else None  # type: ignore
+        return _decoder.decode(result_raw) if result_raw else None
 
     def cancel(self) -> None:
         """Cancel the job.
@@ -254,7 +254,7 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
         Raises:
             IBMRuntimeError: If a network error occurred.
         """
-        if not self._backend:  # type: ignore
+        if not self._backend:
             self.wait_for_final_state(timeout=timeout)
             try:
                 raw_data = self._api_client.job_get(self.job_id())

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -108,7 +108,7 @@ class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
 
         validate_classical_registers(coerced_pubs)
 
-        return self._run(coerced_pubs)  # type: ignore[arg-type]
+        return self._run(coerced_pubs)
 
     def _validate_options(self, options: dict) -> None:
         """Validate that primitive inputs (options) are valid

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -169,7 +169,7 @@ class Session:
 
         if isinstance(self._service, QiskitRuntimeService):
             job = self._service._run(
-                program_id=program_id,  # type: ignore[arg-type]
+                program_id=program_id,
                 options=options,
                 inputs=inputs,
                 session_id=self._session_id,

--- a/qiskit_ibm_runtime/utils/converters.py
+++ b/qiskit_ibm_runtime/utils/converters.py
@@ -37,8 +37,8 @@ def utc_to_local(utc_dt: datetime | str) -> datetime:
         utc_dt = parser.parse(utc_dt)
     if not isinstance(utc_dt, datetime):
         raise TypeError("Input `utc_dt` is not string or datetime.")
-    utc_dt = utc_dt.replace(tzinfo=timezone.utc)  # type: ignore[arg-type]
-    local_dt = utc_dt.astimezone(tz.tzlocal())  # type: ignore[attr-defined]
+    utc_dt = utc_dt.replace(tzinfo=timezone.utc)
+    local_dt = utc_dt.astimezone(tz.tzlocal())
     return local_dt
 
 

--- a/qiskit_ibm_runtime/utils/estimator_result_decoder.py
+++ b/qiskit_ibm_runtime/utils/estimator_result_decoder.py
@@ -22,9 +22,7 @@ class EstimatorResultDecoder(ResultDecoder):
     """Class used to decode estimator results"""
 
     @classmethod
-    def decode(  # type: ignore # pylint: disable=arguments-differ
-        cls, raw_result: str
-    ) -> PrimitiveResult:
+    def decode(cls, raw_result: str) -> PrimitiveResult:
         """Convert the result to EstimatorResult."""
         decoded: dict = super().decode(raw_result)
 

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -267,9 +267,7 @@ class RuntimeEncoder(json.JSONEncoder):
             }
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(
-                    data, buff, RuntimeEncoder, **kwargs
-                ),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff, RuntimeEncoder, **kwargs),
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):
@@ -289,9 +287,7 @@ class RuntimeEncoder(json.JSONEncoder):
             quantum_circuit.append(obj, quantum_register)
             value = _serialize_and_encode(
                 data=quantum_circuit,
-                serializer=lambda buff, data: dump(
-                    data, buff, **kwargs
-                ),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff, **kwargs),
             )
             return {"__type__": "Instruction", "__value__": value}
         if isinstance(obj, ObservablesArray):

--- a/qiskit_ibm_runtime/utils/noise_learner_result_decoder.py
+++ b/qiskit_ibm_runtime/utils/noise_learner_result_decoder.py
@@ -21,9 +21,7 @@ class NoiseLearnerResultDecoder(ResultDecoder):
     """Class used to decode noise learner results"""
 
     @classmethod
-    def decode(  # type: ignore # pylint: disable=arguments-differ
-        cls, raw_result: str
-    ) -> NoiseLearnerResult:
+    def decode(cls, raw_result: str) -> NoiseLearnerResult:
         """Convert the result to NoiseLearnerResult."""
         decoded: dict = super().decode(raw_result)
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Remove some `# type: ignore` comments that do not cause `mypy` warnings since the update of `mypy` version in #2491.


### Details and comments
Related to #2514 

