### PR TITLE
[Executor preview] Fix docs workflow

### DIFF
--- a/.github/workflows/docs-executor.yml
+++ b/.github/workflows/docs-executor.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9.12'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This PR bumps Python to 3.10 inside the executor-preview docs workflow file, since 3.9 is no longer supported