### PR TITLE
Fix branch ruff warnings (UP007, C401, E741)

### DIFF
--- a/qiskit_ibm_runtime/noise_learner_v3/learning_protocol.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/learning_protocol.py
@@ -13,7 +13,7 @@
 """Learning protocols."""
 
 from enum import Enum
-from typing import Literal, Union
+from typing import Literal
 
 
 class LearningProtocol(str, Enum):
@@ -26,7 +26,7 @@ class LearningProtocol(str, Enum):
     """Readout learning protocol."""
 
 
-LearningProtocolLiteral = Union[LearningProtocol, Literal["pauli_lindblad", "trex"]]
+LearningProtocolLiteral = LearningProtocol | Literal["pauli_lindblad", "trex"]
 """The supported learning protocols.
  * ``pauli_lindblad``: Pauli Lindblad learning from arXiv:2201.09866..
  * ``trex``: Readout learning protocol.

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3_result.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3_result.py
@@ -24,7 +24,7 @@ from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauliList
 from samplomatic import InjectNoise
 from samplomatic.utils import get_annotation
 
-MetadataLeafTypes = Union[int, str, float]
+MetadataLeafTypes = int | str | float
 MetadataValue = Union[MetadataLeafTypes, "Metadata", list["MetadataValue"]]
 Metadata = dict[str, MetadataValue]
 
@@ -94,7 +94,7 @@ class NoiseLearnerV3Result:
         if len({len(obj._generators), len(obj._rates), len(obj._rates_std)}) != 1:
             raise ValueError("'generators', 'rates', and 'rates_std' must be of the same length.")
 
-        if len(set(generator.num_qubits for generator in obj._generators)) != 1:
+        if len({generator.num_qubits for generator in obj._generators}) != 1:
             raise ValueError("All the generators must have the same number of qubits.")
 
         return obj

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -75,8 +75,8 @@ class TestNoiseLearnerV3Result(IBMTestCase):
     def test_to_pauli_lindblad_map(self):
         """Test ``NoiseLearnerV3Result.to_pauli_lindblad_map``."""
         generators = [
-            QubitSparsePauliList.from_list(l)
-            for l in [
+            QubitSparsePauliList.from_list(list_)
+            for list_ in [
                 ["IX", "ZX"],
                 ["IY", "ZY"],
                 ["IZ"],


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`0.45.0` includes `ruff` as part of the tooling, and enforces it to pass as part of the `make lint` stage - this PR takes care of the warnings that will be emitted when syncing the branch to `0.45.0`, for having an easier time later on.


### Details and comments
Fixes #N/A

