### PR TITLE
Fix integration test

### DIFF
--- a/test/integration/test_fake_backends.py
+++ b/test/integration/test_fake_backends.py
@@ -77,8 +77,8 @@ class TestFakeBackends(IBMTestCase):
             "fake_singapore",
         }:
             self.skipTest(
-                f"Unable to run fake_backend {backend.backend_name} as it does not contain "
-                "'measure' in the target."
+                f"Unable to run fake_backend {backend.backend_name} since its configuration does "
+                "not have a 'supported_instructions' attribute."
             )
         backend.set_options(seed_simulator=42)
         pm = generate_preset_pass_manager(backend=backend, optimization_level=optimization_level)


### PR DESCRIPTION
Integration tests started failing after #2535 due to the fact that some of the configuration object of some of the backends does not contain the 'supported_instructions' attribute

This PR temporarily skips the tests for those backends, until we fix them