### PR TITLE
Revise slow http-related unit tests

### DIFF
--- a/test/unit/test_client_parameters.py
+++ b/test/unit/test_client_parameters.py
@@ -162,6 +162,9 @@ class TestClientParameters(IBMTestCase):
         handler = params.get_auth_handler()
         self.assertIsInstance(handler, CloudAuth)
         self.assertIn(f"apikey {token}", handler.get_headers().values())
+
+        # Use a new handler, for avoiding delay in second response.
+        handler = params.get_auth_handler()
         self.assertIn(instance, handler.get_headers().values())
         self.assertEqual(handler.tm.disable_ssl_verification, not verify)
         self.assertEqual(handler.tm.proxies, self.mock_proxies_urls)

--- a/test/unit/test_runtime_client.py
+++ b/test/unit/test_runtime_client.py
@@ -61,6 +61,7 @@ class TestAccountClient(IBMTestCase):
 
         for err_resp in sub_tests:
             with self.subTest(response=err_resp):
+                # Use a new client for each request, for avoiding delay in second response.
                 client = self._get_client()
                 self.fake_server.set_error_response(err_resp)
                 with self.assertRaises(RequestsApiError) as err_cm:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Taking a look at the time it took to run unit tests, a couple of them were outstanding:

```
188.85s call     test/unit/test_runtime_client.py::TestAccountClient::test_client_error
59.82s call     test/unit/test_client_parameters.py::TestClientParameters::test_auth_handler_cloud
```

It seems both are hitting a client-side ~60 second delay when making the second request, that is probably related to the retry mechanism as the first requests end in an error (but I have not been able to pinpoint exactly yet). This PR just recreates the item that ends up triggering the request (either a `CloudAuth`, or a `RuntimeClient`) so the requests they make are the first one, so they are not affected by the ~60 seconds hit.

### Details and comments

Fixes N/A

