### PR TITLE
host verification disable now works

### DIFF
--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -314,9 +314,10 @@ class CloudAccount(Account):
     def list_instances(self) -> list[dict[str, Any]]:
         """Retrieve all crns with the IBM Cloud Global Search API."""
         iam_url = get_iam_api_url(self.url)
-        authenticator = IAMAuthenticator(self.token, url=iam_url)
+        authenticator = IAMAuthenticator(self.token, url=iam_url, disable_ssl_verification=(not self.verify))
         client = GlobalSearchV2(authenticator=authenticator)
-        catalog = GlobalCatalogV1(authenticator=authenticator)
+        catalog = GlobalCatalogV1(authenticator=authenticator,
+                                  disable_ssl_verification=(not self.verify))
         client.set_service_url(get_global_search_api_url(self.url))
         catalog.set_service_url(get_global_catalog_api_url(self.url))
         search_cursor = None

--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -314,10 +314,10 @@ class CloudAccount(Account):
     def list_instances(self) -> list[dict[str, Any]]:
         """Retrieve all crns with the IBM Cloud Global Search API."""
         iam_url = get_iam_api_url(self.url)
-        authenticator = IAMAuthenticator(self.token, url=iam_url, disable_ssl_verification=(not self.verify))
+        authenticator = IAMAuthenticator(self.token, url=iam_url)
         client = GlobalSearchV2(authenticator=authenticator)
-        catalog = GlobalCatalogV1(authenticator=authenticator,
-                                  disable_ssl_verification=(not self.verify))
+        catalog = GlobalCatalogV1(authenticator=authenticator)
+        catalog.set_disable_ssl_verification(not self.verify)
         client.set_service_url(get_global_search_api_url(self.url))
         catalog.set_service_url(get_global_catalog_api_url(self.url))
         search_cursor = None

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -378,7 +378,7 @@ class QiskitRuntimeService:
     ) -> Account:
         """Discover account for ibm_cloud and ibm_quantum_platform channels."""
         account = None
-        verify_ = verify or True
+        verify_ = verify
         if name:
             if filename:
                 if any([channel, token, url]):


### PR DESCRIPTION
## PR summary
fixes  https://github.com/Qiskit/qiskit-ibm-runtime/issues/2592
This is a 3 lines change:
* GlobalCatalogV1 object now carries a disable_ssl_verification flag
* GlobalSearchV2 now initializes the BaseService parent with the proper value of disable_ssl_verification


## Current vs new behavior  
disabling host verification now works

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

