### PR TITLE
Remove deprecated `QuantumProgram.append`

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/quantum_program.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program.py
@@ -18,7 +18,6 @@ import abc
 import math
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterable
-import warnings
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit


### PR DESCRIPTION
Continuing #2573.

Includes update to docstrings: docstrings of `QuantumProgram.append` were modified in #2566, but the corresponding docstrings in the new methods were remained unchanged.