### PR TITLE
Correct fractional gates configuration check for cached usage of backend object

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -716,11 +716,20 @@ class QiskitRuntimeService:
         try:
             if backend_name in self._backend_configs:
                 config = self._backend_configs[backend_name]
+
+                fractional_gates = {"rzz", "rx"}
+
                 # if cached config does not match use_fractional_gates
                 # or calibration_id is passed in
                 if (
-                    (use_fractional_gates and "rzz" not in config.basis_gates)
-                    or (not use_fractional_gates and "rzz" in config.basis_gates)
+                    (
+                        use_fractional_gates
+                        and not any(fg in config.basis_gates for fg in fractional_gates)
+                    )
+                    or (
+                        not use_fractional_gates
+                        and any(fg in config.basis_gates for fg in fractional_gates)
+                    )
                     or calibration_id
                 ):
                     config = configuration_from_server_data(

--- a/release-notes/unreleased/2524.bug.rst
+++ b/release-notes/unreleased/2524.bug.rst
@@ -1,0 +1,5 @@
+While creating backend objects, `.QiskitRuntimeService` used to check for only ``rzz`` 
+gates in the backend's basis gates to decide whether to use cache or create a new backend 
+object. Now `.QiskitRuntimeService` will check for both ``rzz`` and ``rx`` gates in the 
+backend's basis gates to decide whether to refresh the configuration or fetch 
+from cache.

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -276,6 +276,36 @@ class TestIBMBackend(IBMIntegrationTestCase):
             ):
                 self.service.backend(backend.name, use_fractional_gates=True)
 
+    def test_backend_fractional_gates_cache_behavior(self):
+        """Test backend config cache/refresh logic for use_fractional_gates."""
+        try:
+            real_device_name = "ibm_miami"
+            backend_fg = self.service.backend(real_device_name, use_fractional_gates=True)
+            backend_fg2 = self.service.backend(real_device_name, use_fractional_gates=True)
+            backend_no_fg = self.service.backend(real_device_name, use_fractional_gates=False)
+            backend_no_fg2 = self.service.backend(real_device_name, use_fractional_gates=False)
+            backend_fg3 = self.service.backend(real_device_name, use_fractional_gates=True)
+        except QiskitBackendNotFoundError:
+            self.skipTest("Real backend not available.")
+
+        self.assertIs(
+            backend_fg, backend_fg2, "Cache was not used for repeated use_fractional_gates=True"
+        )
+
+        self.assertIsNot(
+            backend_fg,
+            backend_no_fg,
+            "Configuration was not refreshed when use_fractional_gates changed",
+        )
+
+        self.assertIs(backend_no_fg, backend_no_fg2, "Cache was not used to create backend object")
+
+        self.assertIsNot(
+            backend_no_fg2,
+            backend_fg3,
+            "Configuration was not refreshed when use_fractional_gates changed",
+        )
+
     def test_renew_backend_properties(self):
         """Test renewed backend property"""
         name = self.backend.name


### PR DESCRIPTION
Backport of #2547 to 0.44.