### PR TITLE
Add `experimental` to `ExecutorOptions`

### DIFF
--- a/qiskit_ibm_runtime/options/executor_options.py
+++ b/qiskit_ibm_runtime/options/executor_options.py
@@ -86,3 +86,6 @@ class ExecutorOptions:
 
     execution: ExecutionOptions = Field(default_factory=ExecutionOptions)
     """Low-level execution options."""
+
+    experimental: dict = Field(default_factory=dict)
+    """Experimental options that are passed to the executor."""

--- a/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
@@ -75,6 +75,13 @@ def quantum_program_to_0_2(program: QuantumProgram, options: ExecutorOptions) ->
             raise ValueError(f"Item {item} is not valid.")
         model_items.append(model_item)
 
+    # Build options dict starting with execution options
+    options_dict = asdict(options.execution)  # type: ignore[call-overload]
+
+    # Add experimental options if provided
+    if options.experimental:
+        options_dict["experimental"] = options.experimental
+
     return ParamsModel(
         quantum_program=QuantumProgramModel(
             shots=program.shots,
@@ -82,7 +89,7 @@ def quantum_program_to_0_2(program: QuantumProgram, options: ExecutorOptions) ->
             meas_level=program.meas_level,
             passthrough_data=program.passthrough_data,
         ),
-        options=asdict(options.execution),  # type: ignore[call-overload]
+        options=options_dict,
     )
 
 

--- a/test/unit/executor/test_executor.py
+++ b/test/unit/executor/test_executor.py
@@ -99,6 +99,29 @@ class TestExecutorOptions(IBMTestCase):
         self.assertEqual(executor.options.environment.log_level, "WARNING")
         self.assertFalse(executor.options.execution.init_qubits)
 
+    def test_experimental_options_default_empty(self):
+        """Test that experimental options default to empty dict."""
+        executor = Executor(mode=get_mocked_backend())
+        self.assertEqual(executor.options.experimental, {})
+
+    def test_experimental_options_from_dict(self):
+        """Test constructing with experimental options in dict."""
+        opts_dict = {"experimental": {"foo": "bar", "baz": 123}}
+        executor = Executor(mode=get_mocked_backend(), options=opts_dict)
+        self.assertEqual(executor.options.experimental, {"foo": "bar", "baz": 123})
+
+    def test_experimental_options_from_instance(self):
+        """Test constructing with an ExecutorOptions instance with experimental options."""
+        opts = ExecutorOptions(experimental={"custom_key": "custom_value"})
+        executor = Executor(mode=get_mocked_backend(), options=opts)
+        self.assertEqual(executor.options.experimental, {"custom_key": "custom_value"})
+
+    def test_experimental_options_setter(self):
+        """Test setting experimental options via the setter."""
+        executor = Executor(mode=get_mocked_backend())
+        executor.options = {"experimental": {"test": "value"}}
+        self.assertEqual(executor.options.experimental, {"test": "value"})
+
 
 class TestExecutor(IBMTestCase):
     """Tests the ``Executor`` class."""

--- a/test/unit/quantum_program/converters/test_converters_0_2.py
+++ b/test/unit/quantum_program/converters/test_converters_0_2.py
@@ -88,13 +88,17 @@ class TestQuantumProgramConverters(IBMTestCase):
             chunk_size=7,
         )
 
-        options = ExecutorOptions(execution=ExecutionOptions(init_qubits=False))
+        experimental_opts = {"custom_option": "test_value", "another_key": 123}
+        options = ExecutorOptions(
+            execution=ExecutionOptions(init_qubits=False), experimental=experimental_opts
+        )
 
         params_model = quantum_program_to_0_2(quantum_program, options)
 
         self.assertEqual(params_model.schema_version, "v0.2")
         self.assertEqual(params_model.options.init_qubits, False)
         self.assertEqual(params_model.options.rep_delay, None)
+        self.assertEqual(params_model.options.experimental, experimental_opts)
 
         quantum_program_model = params_model.quantum_program
         self.assertEqual(quantum_program_model.shots, shots)


### PR DESCRIPTION
### Related Issues
Closes #2618 

### Details and comments
This PR adds an `experimental` field to the `ExecutorOptions` so that it can pass experimental options to the server.

