### PR TITLE
[sampler preview] Remove unnecessary check for experimental options

### DIFF
--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/sampler.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/sampler.py
@@ -75,13 +75,6 @@ def prepare(
     if options.twirling.enable_gates or options.twirling.enable_measure:
         raise NotImplementedError("Twirling is not yet supported in the executor-based SamplerV2.")
 
-    if options.experimental is not None:
-        if any(k != "image" for k in options.experimental.keys()):
-            raise NotImplementedError(
-                "Experimental options (except image) are not supported in the "
-                "executor-based SamplerV2."
-            )
-
     # Create QuantumProgram with CircuitItem for each pub
     items = []
     for pub in pubs:

--- a/test/unit/executor/routines/sampler_v2/test_sampler.py
+++ b/test/unit/executor/routines/sampler_v2/test_sampler.py
@@ -788,21 +788,6 @@ class TestPrepareOptionsHandling(unittest.TestCase):
 
         self.assertIn("Twirling", str(context.exception))
 
-    def test_prepare_validates_experimental_options(self):
-        """Test that prepare raises error for unsupported experimental options."""
-        circuit = QuantumCircuit(1, 1)
-        circuit.h(0)
-        circuit.measure_all()
-
-        pub = SamplerPub.coerce(circuit, shots=1024)
-        options = SamplerOptions()
-        options.experimental = {"unsupported_key": "value"}
-
-        with self.assertRaises(NotImplementedError) as context:
-            prepare([pub], options)
-
-        self.assertIn("Experimental options", str(context.exception))
-
     def test_prepare_allows_experimental_image(self):
         """Test that prepare allows experimental.image."""
         circuit = QuantumCircuit(1, 1)


### PR DESCRIPTION
### Summary
#2629 added support for experimental options but left in a check that doesn't allow experimental options. This PR fixes the issue by removing the check and associated test.