### PR TITLE
[sampler preview] fix results flattening axes ordering

### DIFF
--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v1/post_processor.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v1/post_processor.py
@@ -66,7 +66,11 @@ def _flatten_twirling_axes(item: dict[str, np.ndarray], pub_shape: tuple[int, ..
             shots_per_rand = data.shape[len(pub_shape) + 1]
             total_shots = num_rand * shots_per_rand
             num_bits = data.shape[-1]
-            item[creg_name] = data.reshape(*pub_shape, total_shots, num_bits)
+            # Move num_rand axis to be adjacent to shots_per_rand before reshaping
+            # to avoid mixing randomization indices with parameter sweep indices
+            data_reordered = np.moveaxis(data, 0, len(pub_shape))
+            # Now shape is (*pub_shape, num_rand, shots_per_rand, num_bits)
+            item[creg_name] = data_reordered.reshape(*pub_shape, total_shots, num_bits)
         # else: already the correct non-twirled shape — no reshape needed
 
 

--- a/test/unit/executor/routines/sampler_v2/test_sampler_v2_post_processor.py
+++ b/test/unit/executor/routines/sampler_v2/test_sampler_v2_post_processor.py
@@ -608,3 +608,61 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
         self.assertEqual(result[0].data.shape, ())
         self.assertEqual(result[1].data.meas.num_shots, num_rand * shots_per_rand)
         self.assertEqual(result[1].data.shape, (3,))
+
+    def test_twirled_axis_ordering_preserved(self):
+        """Test that parameter sweep axes are not mixed with randomization axes during flattening."""
+        num_rand, sweep, shots_per_rand, num_bits = 2, 3, 2, 1
+
+        # Create data where each (rand, param) combination has a unique pattern
+        # This allows us to verify that parameter indices are preserved
+        meas_data = np.zeros((num_rand, sweep, shots_per_rand, num_bits), dtype=np.uint8)
+
+        # Fill with identifiable patterns:
+        # rand0, param0: all 0s
+        # rand0, param1: all 1s
+        # rand0, param2: all 0s
+        # rand1, param0: all 1s
+        # rand1, param1: all 0s
+        # rand1, param2: all 1s
+        for r in range(num_rand):
+            for p in range(sweep):
+                # Alternate pattern based on (r + p) % 2
+                meas_data[r, p, :, :] = (r + p) % 2
+
+        result = sampler_v2_post_processor_v1(
+            self._make_result([{"meas": meas_data}], pub_shapes=[(sweep,)], twirling_enabled=True)
+        )
+
+        bit_array = result[0].data.meas
+        reconstructed = bit_array.to_bool_array()
+
+        # Verify shape is correct
+        self.assertEqual(reconstructed.shape, (sweep, num_rand * shots_per_rand, num_bits))
+
+        # Verify that each parameter index contains the correct merged randomizations
+        # For param0: should have rand0 shots (all 0s) followed by rand1 shots (all 1s)
+        param0_shots = reconstructed[0, :, 0]
+        np.testing.assert_array_equal(
+            param0_shots[:shots_per_rand], np.zeros(shots_per_rand, dtype=bool)
+        )
+        np.testing.assert_array_equal(
+            param0_shots[shots_per_rand:], np.ones(shots_per_rand, dtype=bool)
+        )
+
+        # For param1: should have rand0 shots (all 1s) followed by rand1 shots (all 0s)
+        param1_shots = reconstructed[1, :, 0]
+        np.testing.assert_array_equal(
+            param1_shots[:shots_per_rand], np.ones(shots_per_rand, dtype=bool)
+        )
+        np.testing.assert_array_equal(
+            param1_shots[shots_per_rand:], np.zeros(shots_per_rand, dtype=bool)
+        )
+
+        # For param2: should have rand0 shots (all 0s) followed by rand1 shots (all 1s)
+        param2_shots = reconstructed[2, :, 0]
+        np.testing.assert_array_equal(
+            param2_shots[:shots_per_rand], np.zeros(shots_per_rand, dtype=bool)
+        )
+        np.testing.assert_array_equal(
+            param2_shots[shots_per_rand:], np.ones(shots_per_rand, dtype=bool)
+        )


### PR DESCRIPTION
### Summary
There was a bug in the way we flattened the results, which caused randomizations and parameter sweep axes to mix. This PR fixes it.

### Details and comments
This was tested with a job combining parameter sweep and twirling, and now works well:
<img width="790" height="789" alt="image" src="https://github.com/user-attachments/assets/85ceca75-0d3c-4f3b-aa34-45714a85618b" />

