### PR TITLE
[sampler-preview] Don't pass pub shapes in passthrough data

### DIFF
--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v1/post_processor.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v1/post_processor.py
@@ -116,11 +116,11 @@ def sampler_v2_post_processor_v1(result: QuantumProgramResult) -> PrimitiveResul
         raise ValueError("Missing 'post_processor' in passthrough data.")
     if (options_dict := post_processor_data.get("options", None)) is None:
         raise ValueError("Missing 'options' in passthrough data.")
-    if (pub_shapes := post_processor_data.get("pub_shapes", None)) is None:
-        raise ValueError("Missing 'pub_shapes' in passthrough data.")
-    if len(pub_shapes) != len(result):
-        raise ValueError(f"Expected 'pub_shape' of length {len(result)}, found {len(pub_shapes)}.")
-    pub_shapes = [tuple(pub_shape) for pub_shape in pub_shapes]
+    if (twirling := post_processor_data.get("twirling", None)) is None:
+        raise ValueError("Missing 'twirling' in passthrough data.")
+
+    # TODO: This will fail for PUBs with no measurements, but it will also fail in many other places.
+    pub_shapes = [next(iter(item.values())).shape[1 if twirling else 0 : -2] for item in result]
 
     try:
         options = SamplerOptions(**options_dict)

--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/sampler.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/sampler.py
@@ -163,7 +163,7 @@ def prepare(
             "context": "sampler_v2",
             "version": "v1",
             "options": asdict(options),  # type: ignore[call-overload]
-            "pub_shapes": [tuple(pub.shape) for pub in pubs],
+            "twirling": options.twirling.enable_gates or options.twirling.enable_measure,
         }
     }
 

--- a/test/unit/executor/routines/sampler_v2/test_sampler.py
+++ b/test/unit/executor/routines/sampler_v2/test_sampler.py
@@ -1023,12 +1023,12 @@ class TestPrepareTwirling(unittest.TestCase):
         self.assertIn("post_processor", qp.passthrough_data)
         self.assertEqual(qp.passthrough_data["post_processor"]["context"], "sampler_v2")
         self.assertEqual(qp.passthrough_data["post_processor"]["version"], "v1")
-        # Twirling path: pub_shapes must be present (non-parametric pub → empty shape)
-        self.assertIn("pub_shapes", qp.passthrough_data["post_processor"])
-        self.assertEqual(qp.passthrough_data["post_processor"]["pub_shapes"], [()])
+        # Twirling path: twirling flag must be True
+        self.assertIn("twirling", qp.passthrough_data["post_processor"])
+        self.assertEqual(qp.passthrough_data["post_processor"]["twirling"], True)
 
     def test_prepare_sets_passthrough_data_no_twirling(self):
-        """Test that prepare() does NOT include pub_shapes when twirling is disabled."""
+        """Test that prepare() sets twirling flag to False when twirling is disabled."""
         circuit = QuantumCircuit(1, 1)
         circuit.h(0)
         circuit.measure_all()
@@ -1039,14 +1039,15 @@ class TestPrepareTwirling(unittest.TestCase):
 
         qp, _ = prepare([pub], options, FakeManilaV2(), default_shots=1024)
 
-        # Verify passthrough_data contains post-processor info but no pub_shapes
+        # Verify passthrough_data contains post-processor info with twirling=False
         self.assertIn("post_processor", qp.passthrough_data)
         self.assertEqual(qp.passthrough_data["post_processor"]["context"], "sampler_v2")
         self.assertEqual(qp.passthrough_data["post_processor"]["version"], "v1")
-        self.assertIn("pub_shapes", qp.passthrough_data["post_processor"])
+        self.assertIn("twirling", qp.passthrough_data["post_processor"])
+        self.assertEqual(qp.passthrough_data["post_processor"]["twirling"], False)
 
-    def test_prepare_sets_pub_shapes_parametric_twirling(self):
-        """Test that prepare() stores the parameter sweep shape (not num_rand) in pub_shapes."""
+    def test_prepare_sets_passthrough_data_parametric_twirling(self):
+        """Test that prepare() sets twirling flag for parametric circuits with twirling enabled."""
         theta = Parameter("θ")
         circuit = QuantumCircuit(1, 1)
         circuit.rx(theta, 0)
@@ -1059,32 +1060,9 @@ class TestPrepareTwirling(unittest.TestCase):
 
         qp, _ = prepare([pub], options, FakeManilaV2(), default_shots=1024)
 
-        # pub_shape should be the parameter sweep shape [3], not the full item shape [num_rand, 3]
-        self.assertIn("pub_shapes", qp.passthrough_data["post_processor"])
-        self.assertEqual(qp.passthrough_data["post_processor"]["pub_shapes"], [(3,)])
-
-    def test_prepare_sets_pub_shapes_multiple_pubs_twirling(self):
-        """Test that prepare() stores pub_shapes for each pub when twirling is enabled."""
-        theta = Parameter("θ")
-        circuit1 = QuantumCircuit(1, 1)
-        circuit1.h(0)
-        circuit1.measure_all()
-
-        circuit2 = QuantumCircuit(1, 1)
-        circuit2.rx(theta, 0)
-        circuit2.measure_all()
-
-        param_values = np.array([[0.5], [1.0]])  # shape (2, 1)
-        pub1 = SamplerPub.coerce(circuit1, shots=1024)
-        pub2 = SamplerPub.coerce((circuit2, param_values), shots=1024)
-        options = SamplerOptions()
-        options.twirling.enable_gates = True
-
-        qp, _ = prepare([pub1, pub2], options, FakeManilaV2(), default_shots=1024)
-
-        pub_shapes = qp.passthrough_data["post_processor"]["pub_shapes"]
-        self.assertEqual(pub_shapes[0], ())  # non-parametric pub
-        self.assertEqual(pub_shapes[1], (2,))  # parametric pub with sweep shape (2,)
+        # Verify twirling flag is set (pub_shapes will be computed in post-processor)
+        self.assertIn("twirling", qp.passthrough_data["post_processor"])
+        self.assertEqual(qp.passthrough_data["post_processor"]["twirling"], True)
 
     def test_prepare_includes_options_in_passthrough_data(self):
         """Test that prepare() includes options dictionary in passthrough_data."""

--- a/test/unit/executor/routines/sampler_v2/test_sampler_v2_post_processor.py
+++ b/test/unit/executor/routines/sampler_v2/test_sampler_v2_post_processor.py
@@ -81,7 +81,7 @@ class TestSamplerV2StaticMethod(unittest.TestCase):
                 "context": "sampler_v2",
                 "version": "v1",
                 "options": asdict(options),
-                "pub_shapes": [(), ()],
+                "twirling": True,
             }
         }
 
@@ -289,7 +289,7 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
                 "context": "sampler_v2",
                 "version": "v1",
                 "options": asdict(options),
-                "pub_shapes": [()],
+                "twirling": True,
             }
         }
 
@@ -320,7 +320,7 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
                 "context": "sampler_v2",
                 "version": "v1",
                 "options": asdict(options),
-                "pub_shapes": [(), ()],
+                "twirling": True,
             }
         }
 
@@ -358,7 +358,7 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
                 "context": "sampler_v2",
                 "version": "v1",
                 "options": asdict(options),
-                "pub_shapes": [()],
+                "twirling": True,
             }
         }
 
@@ -393,7 +393,7 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
                 "context": "sampler_v2",
                 "version": "v1",
                 "options": asdict(options),
-                "pub_shapes": [()],
+                "twirling": True,
             }
         }
 
@@ -431,7 +431,7 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
                 "context": "sampler_v2",
                 "version": "v1",
                 "options": asdict(options),
-                "pub_shapes": [()],
+                "twirling": True,
             }
         }
 
@@ -455,14 +455,12 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
     ``pub_shapes`` stored in ``passthrough_data``.
     """
 
-    def _make_result(self, data, pub_shapes=None, twirling_enabled=False):
-        """Helper to build a QuantumProgramResult with optional pub_shapes passthrough.
+    def _make_result(self, data, twirling_enabled=False):
+        """Helper to build a QuantumProgramResult with twirling flag.
 
         Args:
             data: Measurement data for the result
-            pub_shapes: Optional pub shapes (implies twirling if provided)
-            twirling_enabled: Explicitly set twirling state. If None and pub_shapes
-                is provided, defaults to True.
+            twirling_enabled: Whether twirling is enabled
         """
         options = SamplerOptions()
         options.twirling.enable_gates = twirling_enabled
@@ -471,7 +469,7 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
                 "context": "sampler_v2",
                 "version": "v1",
                 "options": asdict(options),
-                "pub_shapes": pub_shapes if pub_shapes else [()],
+                "twirling": twirling_enabled,
             }
         }
 
@@ -488,7 +486,7 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
             0, 2, size=(num_rand, shots_per_rand, num_bits), dtype=np.uint8
         )
         result = sampler_v2_post_processor_v1(
-            self._make_result([{"meas": meas_data}], pub_shapes=[()], twirling_enabled=True)
+            self._make_result([{"meas": meas_data}], twirling_enabled=True)
         )
         bit_array = result[0].data.meas
         self.assertEqual(bit_array.num_shots, num_rand * shots_per_rand)
@@ -502,7 +500,7 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
             0, 2, size=(num_rand, sweep, shots_per_rand, num_bits), dtype=np.uint8
         )
         result = sampler_v2_post_processor_v1(
-            self._make_result([{"meas": meas_data}], pub_shapes=[(sweep,)], twirling_enabled=True)
+            self._make_result([{"meas": meas_data}], twirling_enabled=True)
         )
         bit_array = result[0].data.meas
         self.assertEqual(bit_array.num_shots, num_rand * shots_per_rand)
@@ -518,7 +516,7 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
             0, 2, size=(num_rand, s1, s2, shots_per_rand, num_bits), dtype=np.uint8
         )
         result = sampler_v2_post_processor_v1(
-            self._make_result([{"meas": meas_data}], pub_shapes=[(s1, s2)], twirling_enabled=True)
+            self._make_result([{"meas": meas_data}], twirling_enabled=True)
         )
         bit_array = result[0].data.meas
         self.assertEqual(bit_array.num_shots, num_rand * shots_per_rand)
@@ -532,36 +530,26 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
             0, 2, size=(num_rand, shots_per_rand, num_bits), dtype=np.uint8
         )
         result = sampler_v2_post_processor_v1(
-            self._make_result([{"meas": meas_data}], pub_shapes=[()], twirling_enabled=True)
+            self._make_result([{"meas": meas_data}], twirling_enabled=True)
         )
         expected_flat = meas_data.reshape(num_rand * shots_per_rand, num_bits)
         reconstructed = result[0].data.meas.to_bool_array()
         np.testing.assert_array_equal(reconstructed, expected_flat.astype(bool))
 
     def test_non_twirled_no_reshape_when_pub_shapes_absent(self):
-        """Without pub_shapes in passthrough_data, no flattening is performed."""
+        """Without twirling enabled, no flattening is performed."""
         num_shots, num_bits = 100, 3
         meas_data = np.random.randint(0, 2, size=(num_shots, num_bits), dtype=np.uint8)
-        # No pub_shapes → passthrough_data is None
+        # twirling_enabled=False (default)
         result = sampler_v2_post_processor_v1(
-            self._make_result([{"meas": meas_data}], pub_shapes=None)
+            self._make_result([{"meas": meas_data}], twirling_enabled=False)
         )
         bit_array = result[0].data.meas
         self.assertEqual(bit_array.num_shots, num_shots)
         self.assertEqual(bit_array.num_bits, num_bits)
 
-    def test_wrong_pub_shape_raises_error(self):
-        """If pub_shape dimensions don't match data, a ValueError is raised."""
-        with self.assertRaises(ValueError):
-            sampler_v2_post_processor_v1(
-                self._make_result(
-                    [{"meas": np.random.randint(0, 2, size=(4, 7, 64, 3), dtype=np.uint8)}],
-                    pub_shapes=[(5), (5,)],
-                )
-            )
-
-    def test_error_when_twirling_enabled_but_pub_shapes_missing(self):
-        """Verify error is raised when twirling is enabled but pub_shapes is missing."""
+    def test_error_when_twirling_missing_from_passthrough(self):
+        """Verify error is raised when twirling flag is missing from passthrough data."""
         num_rand, shots_per_rand, num_bits = 4, 64, 2
         meas_data = np.random.randint(
             0, 2, size=(num_rand, shots_per_rand, num_bits), dtype=np.uint8
@@ -572,12 +560,12 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
         options.twirling.enable_gates = True
         options_dict = asdict(options)
 
-        # Build result with options but WITHOUT pub_shapes
+        # Build result with options but WITHOUT twirling flag
         post_processor_data = {
             "context": "sampler_v2",
             "version": "v1",
             "options": options_dict,
-            # Intentionally omit pub_shapes
+            # Intentionally omit twirling flag
         }
         qp_result = QuantumProgramResult(
             data=[{"meas": meas_data}],
@@ -589,10 +577,10 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             sampler_v2_post_processor_v1(qp_result)
 
-        self.assertIn("pub_shapes", str(context.exception))
+        self.assertIn("twirling", str(context.exception))
 
     def test_multiple_pubs_mixed_twirled(self):
-        """Multiple pubs: each pub is flattened according to its own pub_shape."""
+        """Multiple pubs: each pub is flattened according to its computed pub_shape."""
         num_rand, shots_per_rand, num_bits = 4, 64, 2
         # Pub 0: non-parametric twirled → (num_rand, shots_per_rand, bits)
         meas0 = np.random.randint(0, 2, size=(num_rand, shots_per_rand, num_bits), dtype=np.uint8)
@@ -601,9 +589,7 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
             0, 2, size=(num_rand, 3, shots_per_rand, num_bits), dtype=np.uint8
         )
         result = sampler_v2_post_processor_v1(
-            self._make_result(
-                [{"meas": meas0}, {"meas": meas1}], pub_shapes=[(), (3,)], twirling_enabled=True
-            )
+            self._make_result([{"meas": meas0}, {"meas": meas1}], twirling_enabled=True)
         )
         self.assertEqual(result[0].data.meas.num_shots, num_rand * shots_per_rand)
         self.assertEqual(result[0].data.shape, ())
@@ -631,7 +617,7 @@ class TestSamplerV2PostProcessorFlattening(unittest.TestCase):
                 meas_data[r, p, :, :] = (r + p) % 2
 
         result = sampler_v2_post_processor_v1(
-            self._make_result([{"meas": meas_data}], pub_shapes=[(sweep,)], twirling_enabled=True)
+            self._make_result([{"meas": meas_data}], twirling_enabled=True)
         )
 
         bit_array = result[0].data.meas


### PR DESCRIPTION
### Summary
This PR removes the pub shapes from the passthrough data, in favor of a single twirling bit. Follow up PRs will remove the options from the passthrough data.

### Details and comments
Integration tests pass.

