### PR TITLE
[sampler-preview] Remove `options` from passthrough data

### DIFF
--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v0_1/post_processor.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v0_1/post_processor.py
@@ -19,7 +19,6 @@ from qiskit.primitives import PrimitiveResult
 
 from ......quantum_program.quantum_program_result import QuantumProgramResult
 from ...sampler import SamplerV2
-from ....options.sampler_options import SamplerOptions
 from ..utils import register_post_processor
 from .executor_metadata_to_sampler_metadata import executor_metadata_to_sampler_metadata
 from .flatten_twirling_axes import flatten_twirling_axes
@@ -65,18 +64,11 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     passthrough = cast(dict, result.passthrough_data or {})
     if (post_processor_data := passthrough.get("post_processor", None)) is None:
         raise ValueError("Missing 'post_processor' in passthrough data.")
-    if (options_dict := post_processor_data.get("options", None)) is None:
-        raise ValueError("Missing 'options' in passthrough data.")
     if (twirling := post_processor_data.get("twirling", None)) is None:
         raise ValueError("Missing 'twirling' in passthrough data.")
 
     # TODO: This will fail for PUBs with no measurements, but it will also fail in many other places.
     pub_shapes = [next(iter(item.values())).shape[1 if twirling else 0 : -2] for item in result]
-
-    try:
-        options = SamplerOptions(**options_dict)
-    except (TypeError, ValueError) as ex:
-        raise ValueError("Couldn't initialize SamplerOptions from 'options_dict'.") from ex
 
     # Compute the shots from the second-to-last axis of the result arrays; this corresponds to
     # PUB shots if twirling is OFF, and to ``shots_per_randomization`` if twirling is ON.
@@ -85,14 +77,14 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     shots = next(iter(set_shots))
 
     # Compute the ``num_randomizations`` from the left-most axis of the result arrays
-    if options.twirling.enable_gates or options.twirling.enable_measure:
+    if twirling:
         if len(set_num_randomizations := {array.shape[0] for array in result[0].values()}) != 1:
             raise ValueError("Unable to uniquely identity the number of randomizations.")
         num_randomizations = next(iter(set_num_randomizations))
     else:
         num_randomizations = 0
 
-    if options.twirling.enable_gates or options.twirling.enable_measure:
+    if twirling:
         for item, shape in zip(result, pub_shapes):
             flatten_twirling_axes(item, shape)
 

--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/sampler.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/sampler.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from dataclasses import asdict
 import logging
 from typing import Any
 
@@ -162,7 +161,6 @@ def prepare(
         "post_processor": {
             "context": "sampler_v2",
             "version": "v0.1",
-            "options": asdict(options),  # type: ignore[call-overload]
             "twirling": options.twirling.enable_gates or options.twirling.enable_measure,
         }
     }

--- a/test/unit/executor/routines/sampler_v2/test_sampler.py
+++ b/test/unit/executor/routines/sampler_v2/test_sampler.py
@@ -1082,23 +1082,6 @@ class TestPrepareTwirling(unittest.TestCase):
 
         # Verify options dictionary is present in passthrough_data
         self.assertIn("post_processor", qp.passthrough_data)
-        self.assertIn("options", qp.passthrough_data["post_processor"])
-
-        options_dict = qp.passthrough_data["post_processor"]["options"]
-
-        # Verify it's a dictionary with expected structure
-        self.assertIsInstance(options_dict, dict)
-        self.assertIn("default_shots", options_dict)
-        self.assertIn("twirling", options_dict)
-        self.assertIn("execution", options_dict)
-        self.assertIn("environment", options_dict)
-
-        # Verify custom values are preserved
-        self.assertEqual(options_dict["default_shots"], 2048)
-        self.assertEqual(options_dict["twirling"]["enable_gates"], True)
-        self.assertEqual(options_dict["twirling"]["strategy"], "all")
-        self.assertEqual(options_dict["execution"]["meas_type"], "kerneled")
-        self.assertEqual(options_dict["environment"]["log_level"], "DEBUG")
 
     def test_prepare_includes_options_without_twirling(self):
         """Test that prepare() includes options even when twirling is disabled."""
@@ -1115,12 +1098,6 @@ class TestPrepareTwirling(unittest.TestCase):
 
         # Verify options dictionary is present even without twirling
         self.assertIn("post_processor", qp.passthrough_data)
-        self.assertIn("options", qp.passthrough_data["post_processor"])
-
-        options_dict = qp.passthrough_data["post_processor"]["options"]
-        self.assertIsInstance(options_dict, dict)
-        self.assertEqual(options_dict["default_shots"], 512)
-        self.assertEqual(options_dict["twirling"]["enable_gates"], False)
 
 
 class TestSamplerV2CustomPrepareFn(unittest.TestCase):


### PR DESCRIPTION
This PR removes options as they add redundant info