### PR TITLE
[sampler preview] Simplify flattening function

### DIFF
--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v0_1/flatten_twirling_axes.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v0_1/flatten_twirling_axes.py
@@ -25,9 +25,7 @@ def flatten_twirling_axes(item: dict[str, np.ndarray], pub_shape: tuple[int, ...
     each array to ``(*pub_shape, total_shots, num_bits)`` where
     ``total_shots = num_rand * shots_per_rand``.
 
-    If the data does not have the expected twirled shape (i.e. its ndim equals
-    ``len(pub_shape) + 2`` rather than ``len(pub_shape) + 3``), it is left
-    unchanged.
+    The function should only be called when twirling was on.
 
     Args:
         item: Dictionary mapping classical register names to measurement arrays.
@@ -35,32 +33,14 @@ def flatten_twirling_axes(item: dict[str, np.ndarray], pub_shape: tuple[int, ...
         pub_shape: The parameter-sweep shape of the pub (without the leading
             ``num_rand`` axis), e.g. ``()`` for a non-parametric pub or
             ``(3,)`` for a 1-D parameter sweep.
-
-    Raises:
-        ValueError: If the data has the expected twirled ndim but the middle
-            dimensions do not match ``pub_shape``.
     """
-    # NOTE: This assumes a single num_randomization axis, which is the existing practice.
-    # In theory, one could set more than one such axes.
-    expected_non_twirled_ndim = len(pub_shape) + 2  # (*pub_shape, shots, bits)
     for creg_name, data in list(item.items()):
-        if data.ndim == expected_non_twirled_ndim + 1:
-            # Twirled shape: (num_rand, *pub_shape, shots_per_rand, num_bits)
-            # Validate that the middle dimensions match pub_shape
-            actual_pub_shape = data.shape[1 : 1 + len(pub_shape)]
-            if actual_pub_shape != pub_shape:
-                raise ValueError(
-                    f"Classical register '{creg_name}': expected pub shape {pub_shape} "
-                    f"in dimensions [1:{1 + len(pub_shape)}] of data with shape {data.shape}, "
-                    f"but found {actual_pub_shape}."
-                )
-            num_rand = data.shape[0]
-            shots_per_rand = data.shape[len(pub_shape) + 1]
-            total_shots = num_rand * shots_per_rand
-            num_bits = data.shape[-1]
-            # Move num_rand axis to be adjacent to shots_per_rand before reshaping
-            # to avoid mixing randomization indices with parameter sweep indices
-            data_reordered = np.moveaxis(data, 0, len(pub_shape))
-            # Now shape is (*pub_shape, num_rand, shots_per_rand, num_bits)
-            item[creg_name] = data_reordered.reshape(*pub_shape, total_shots, num_bits)
-        # else: already the correct non-twirled shape — no reshape needed
+        num_rand = data.shape[0]
+        shots_per_rand = data.shape[len(pub_shape) + 1]
+        total_shots = num_rand * shots_per_rand
+        num_bits = data.shape[-1]
+        # Move num_rand axis to be adjacent to shots_per_rand before reshaping
+        # to avoid mixing randomization indices with parameter sweep indices
+        data_reordered = np.moveaxis(data, 0, len(pub_shape))
+        # Now shape is (*pub_shape, num_rand, shots_per_rand, num_bits) and is safe for reshaping
+        item[creg_name] = data_reordered.reshape(*pub_shape, total_shots, num_bits)

--- a/test/unit/executor/routines/sampler_v2/post_processors/v0_1/test_flatten_twirling_axes.py
+++ b/test/unit/executor/routines/sampler_v2/post_processors/v0_1/test_flatten_twirling_axes.py
@@ -101,21 +101,6 @@ class TestFlattenTwirlingAxes(unittest.TestCase):
                 reshaped = flattened_param_data.reshape(num_rand, shots_per_rand, num_bits)
                 np.testing.assert_array_equal(reshaped, original_param_data)
 
-    def test_non_twirled_data_unchanged(self):
-        """Test that non-twirled data (already correct shape) is left unchanged."""
-        pub_shape = (3,)
-        total_shots = 100
-        num_bits = 2
-
-        # Create non-twirled data: (param_size, total_shots, num_bits)
-        data = np.random.randint(0, 2, size=(*pub_shape, total_shots, num_bits), dtype=np.uint8)
-        item = {"meas": data.copy()}
-
-        flatten_twirling_axes(item, pub_shape=pub_shape)
-
-        # Data should remain unchanged
-        np.testing.assert_array_equal(item["meas"], data)
-
     def test_multiple_classical_registers(self):
         """Test flattening with multiple classical registers."""
         num_rand = 4
@@ -140,27 +125,6 @@ class TestFlattenTwirlingAxes(unittest.TestCase):
 
         self.assertEqual(item["creg1"].shape, expected_shape1)
         self.assertEqual(item["creg2"].shape, expected_shape2)
-
-    def test_pub_shape_mismatch_raises_error(self):
-        """Test that ValueError is raised when pub_shape doesn't match data dimensions."""
-        num_rand = 3
-        actual_pub_shape = (2, 3)
-        wrong_pub_shape = (2, 4)  # Incorrect shape
-        shots_per_rand = 5
-        num_bits = 2
-
-        # Create data with actual_pub_shape
-        data = np.random.randint(
-            0, 2, size=(num_rand, *actual_pub_shape, shots_per_rand, num_bits), dtype=np.uint8
-        )
-        item = {"meas": data}
-
-        # Should raise ValueError because pub_shape doesn't match
-        with self.assertRaisesRegex(
-            ValueError,
-            r"Classical register 'meas': expected pub shape \(2, 4\).*but found \(2, 3\)",
-        ):
-            flatten_twirling_axes(item, pub_shape=wrong_pub_shape)
 
     def test_data_ordering_preserved(self):
         """Test that the order of shots is preserved correctly after flattening."""

--- a/test/unit/executor/routines/sampler_v2/test_sampler_v2_post_processor.py
+++ b/test/unit/executor/routines/sampler_v2/test_sampler_v2_post_processor.py
@@ -70,9 +70,14 @@ class TestSamplerV2StaticMethod(unittest.TestCase):
 
     def test_single_pub_multiple_registers(self):
         """Test conversion with single pub and multiple classical registers."""
-        num_shots = 50
-        meas_data_c1 = np.random.randint(0, 2, size=(num_shots, 2), dtype=np.uint8)
-        meas_data_c2 = np.random.randint(0, 2, size=(num_shots, 3), dtype=np.uint8)
+        num_rands = 10
+        num_shots_per_rand = 10
+        meas_data_c1 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 2), dtype=np.uint8
+        )
+        meas_data_c2 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 3), dtype=np.uint8
+        )
 
         options = SamplerOptions()
         options.twirling.enable_gates = True
@@ -283,13 +288,13 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
         meas_data = np.random.randint(0, 2, size=(num_shots, num_bits), dtype=np.uint8)
 
         options = SamplerOptions()
-        options.twirling.enable_gates = True
+        options.twirling.enable_gates = False
         passthrough_data = {
             "post_processor": {
                 "context": "sampler_v2",
                 "version": "v0.1",
                 "options": asdict(options),
-                "twirling": True,
+                "twirling": False,
             }
         }
 
@@ -309,9 +314,14 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
 
     def test_post_processor_with_multiple_pubs(self):
         """Test that post-processor handles multiple pubs correctly."""
-        num_shots = 50
-        meas_data_1 = np.random.randint(0, 2, size=(num_shots, 2), dtype=np.uint8)
-        meas_data_2 = np.random.randint(0, 2, size=(num_shots, 3), dtype=np.uint8)
+        num_rands = 10
+        num_shots_per_rand = 5
+        meas_data_1 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 2), dtype=np.uint8
+        )
+        meas_data_2 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 3), dtype=np.uint8
+        )
 
         options = SamplerOptions()
         options.twirling.enable_gates = True
@@ -342,11 +352,16 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
 
     def test_post_processor_applies_bit_flips(self):
         """Test that post-processor applies measurement twirling bit flips via XOR."""
-        num_shots = 10
+        num_rands = 10
+        num_shots_per_rand = 10
         num_bits = 3
 
-        meas_data = np.random.randint(0, 2, size=(num_shots, num_bits), dtype=np.uint8)
-        bit_flips = np.random.randint(0, 2, size=(num_shots, num_bits), dtype=np.uint8)
+        meas_data = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, num_bits), dtype=np.uint8
+        )
+        bit_flips = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, num_bits), dtype=np.uint8
+        )
 
         # Store original data to verify XOR
         original_meas = meas_data.copy()
@@ -374,17 +389,28 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
         self.assertNotIn("measurement_flips.meas", result[0].data)
         self.assertIn("meas", result[0].data)
 
-        # Verify the data in qp_result was XORed
+        # Verify the data in qp_result was XORed (and flattened)
         expected_data = original_meas ^ bit_flips
-        np.testing.assert_array_equal(qp_result[0]["meas"], expected_data)
+        np.testing.assert_array_equal(
+            qp_result[0]["meas"], expected_data.reshape(num_shots_per_rand * num_rands, num_bits)
+        )
 
     def test_post_processor_bit_flips_multiple_registers(self):
         """Test bit flips with multiple classical registers."""
-        num_shots = 5
-        meas_data_c1 = np.random.randint(0, 2, size=(num_shots, 2), dtype=np.uint8)
-        meas_data_c2 = np.random.randint(0, 2, size=(num_shots, 3), dtype=np.uint8)
-        bit_flips_c1 = np.random.randint(0, 2, size=(num_shots, 2), dtype=np.uint8)
-        bit_flips_c2 = np.random.randint(0, 2, size=(num_shots, 3), dtype=np.uint8)
+        num_rands = 5
+        num_shots_per_rand = 5
+        meas_data_c1 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 2), dtype=np.uint8
+        )
+        meas_data_c2 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 3), dtype=np.uint8
+        )
+        bit_flips_c1 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 2), dtype=np.uint8
+        )
+        bit_flips_c2 = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, 3), dtype=np.uint8
+        )
 
         options = SamplerOptions()
         options.twirling.enable_gates = True
@@ -420,9 +446,12 @@ class TestSamplerV2PostProcessor(unittest.TestCase):
 
     def test_post_processor_no_bit_flips(self):
         """Test that post-processor works when no bit flips are present."""
-        num_shots = 10
+        num_rands = 5
+        num_shots_per_rand = 10
         num_bits = 3
-        meas_data = np.random.randint(0, 2, size=(num_shots, num_bits), dtype=np.uint8)
+        meas_data = np.random.randint(
+            0, 2, size=(num_rands, num_shots_per_rand, num_bits), dtype=np.uint8
+        )
 
         options = SamplerOptions()
         options.twirling.enable_gates = True


### PR DESCRIPTION
### Summary
This PR follows up #2662 and simplifies the logic of the flattening function. Now that the PUBs are inferred instead of passed, there is no sense in testing things against the pub shapes. Also, the function is only called when twirling is on, so that too can be simplified.
