### PR TITLE
Unpin setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 65.0.2", "setuptools_scm[toml]~=8.0"]
+requires = ["setuptools >= 65.0.2", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
Addresses #2691 

In the last release, the version of setuptools_scm was incorrectly pinned to ~=8.0. This PR reverts it, restroring the original `>=6.2`