### PR TITLE
Replace `"python"` with `sys.executable` in unit test

### DIFF
--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -15,6 +15,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import warnings
 from datetime import datetime
@@ -238,7 +239,7 @@ if __name__ == '__main__':
             with self.subTest(operator=operator):
                 encoded = json.dumps(operator, cls=RuntimeEncoder)
                 self.assertIsInstance(encoded, str)
-                cmd = ["python", temp_fp.name, encoded]
+                cmd = [sys.executable, temp_fp.name, encoded]
                 proc = subprocess.run(
                     cmd,
                     capture_output=True,


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes #2694 by not making the assumption that "python" is the correct interpreter that should be used to spawn the subprocesses executing the test scripts. Instead, use the current interpreter running the test module available in `sys.executable`.

