### PR TITLE
Avoid ThreadPoolExecutor in BaseFakeRuntimeJob

### DIFF
--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -121,7 +121,7 @@ class BaseFakeRuntimeJob:
     def _auto_progress(self):
         """Automatically update job status."""
         for status in self._job_progress:
-            time.sleep(0.5)
+            time.sleep(0.1)
             self._status = status
 
         if self._status == "COMPLETED":

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -14,7 +14,6 @@
 
 import base64
 import json
-import time
 import uuid
 from datetime import timezone, datetime as python_datetime
 from typing import Any
@@ -121,12 +120,6 @@ class BaseFakeRuntimeJob:
 
             if self._status == "COMPLETED":
                 self._result = json.dumps({"quasi_dists": [{0: 0.5, 3: 0.5}], "metadata": []})
-
-    def _auto_progress(self):
-        """Automatically update job status."""
-        for status in self._job_progress:
-            time.sleep(0.1)
-            self._status = status
 
     def to_dict(self):
         """Convert to dictionary format."""

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -17,7 +17,6 @@ import json
 import time
 import uuid
 from datetime import timezone, datetime as python_datetime
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -82,8 +81,6 @@ class BaseFakeRuntimeJob:
 
     _job_progress = ["QUEUED", "RUNNING", "COMPLETED"]
 
-    _executor = ThreadPoolExecutor()
-
     def __init__(
         self,
         job_id,
@@ -112,20 +109,24 @@ class BaseFakeRuntimeJob:
         self._start_session = start_session
         self._creation_date = python_datetime.now(timezone.utc)
         if final_status is None:
-            self._future = self._executor.submit(self._auto_progress)
             self._result = None
         elif final_status == "COMPLETED":
             self._result = json.dumps({"quasi_dists": [{0: 0.5, 3: 0.5}], "metadata": []})
         self._final_status = final_status
+
+    def advance_progress(self):
+        """Progress to the next job status."""
+        if self._status != self._final_status:
+            self._status = self._job_progress[self._job_progress.index(self._status) + 1]
+
+            if self._status == "COMPLETED":
+                self._result = json.dumps({"quasi_dists": [{0: 0.5, 3: 0.5}], "metadata": []})
 
     def _auto_progress(self):
         """Automatically update job status."""
         for status in self._job_progress:
             time.sleep(0.1)
             self._status = status
-
-        if self._status == "COMPLETED":
-            self._result = json.dumps({"quasi_dists": [{0: 0.5, 3: 0.5}], "metadata": []})
 
     def to_dict(self):
         """Convert to dictionary format."""
@@ -158,9 +159,9 @@ class FailedRuntimeJob(BaseFakeRuntimeJob):
 
     _job_progress = ["QUEUED", "RUNNING", "FAILED"]
 
-    def _auto_progress(self):
-        """Automatically update job status."""
-        super()._auto_progress()
+    def advance_progress(self):
+        """Progress to the next job status."""
+        super().advance_progress()
 
         if self._status == "FAILED":
             self._result = "Kaboom!"
@@ -171,9 +172,9 @@ class FailedRanTooLongRuntimeJob(BaseFakeRuntimeJob):
 
     _job_progress = ["QUEUED", "RUNNING", "CANCELLED"]
 
-    def _auto_progress(self):
-        """Automatically update job status."""
-        super()._auto_progress()
+    def advance_progress(self):
+        """Progress to the next job status."""
+        super().advance_progress()
 
         if self._status == "CANCELLED":
             self._reason = "RAN TOO LONG"
@@ -193,7 +194,6 @@ class CancelableRuntimeJob(BaseFakeRuntimeJob):
 
     def cancel(self):
         """Cancel the job."""
-        self._future.cancel()
         self._cancelled = True
 
     def to_dict(self):
@@ -209,28 +209,12 @@ class CustomResultRuntimeJob(BaseFakeRuntimeJob):
 
     custom_result = "bar"
 
-    def _auto_progress(self):
-        """Automatically update job status."""
-        super()._auto_progress()
+    def advance_progress(self):
+        """Progress to the next job status."""
+        super().advance_progress()
 
         if self._status == "COMPLETED":
             self._result = json.dumps(self.custom_result, cls=RuntimeEncoder)
-
-
-class TimedRuntimeJob(BaseFakeRuntimeJob):
-    """Class for a job that runs for the input seconds."""
-
-    def __init__(self, **kwargs):
-        self._runtime = kwargs.pop("run_time")
-        super().__init__(**kwargs)
-
-    def _auto_progress(self):
-        self._status = "RUNNING"
-        time.sleep(self._runtime)
-        self._status = "COMPLETED"
-
-        if self._status == "COMPLETED":
-            self._result = json.dumps({"quasi_dists": [{0: 0.5, 3: 0.5}], "metadata": []})
 
 
 class BaseFakeRuntimeClient:
@@ -387,6 +371,7 @@ class BaseFakeRuntimeClient:
         final_states = ["COMPLETED", "FAILED", "CANCELLED", "CANCELLED - RAN TOO LONG"]
         status = self._get_job(job_id).status()
         while status not in final_states:
+            self._get_job(job_id).advance_progress()
             status = self._get_job(job_id).status()
 
     def _get_job(self, job_id: str, exclude_params: bool | None = None) -> Any:

--- a/test/unit/test_job_retrieval.py
+++ b/test/unit/test_job_retrieval.py
@@ -47,7 +47,7 @@ class TestRetrieveJobs(IBMTestCase):
 
         jobs = []
         for _ in range(25):
-            jobs.append(run_program(service, program_id))
+            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
         rjobs = service.jobs(limit=None)
         self.assertEqual(25, len(rjobs))
 
@@ -59,7 +59,7 @@ class TestRetrieveJobs(IBMTestCase):
         jobs = []
         job_count = 25
         for _ in range(job_count):
-            jobs.append(run_program(service, program_id))
+            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
 
         limits = [21, 30]
         for limit in limits:
@@ -74,7 +74,7 @@ class TestRetrieveJobs(IBMTestCase):
 
         jobs = []
         for _ in range(5):
-            jobs.append(run_program(service, program_id))
+            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
         rjobs = service.jobs(skip=4)
         self.assertEqual(1, len(rjobs))
 
@@ -97,7 +97,7 @@ class TestRetrieveJobs(IBMTestCase):
 
         jobs = []
         for _ in range(10):
-            jobs.append(run_program(service, program_id))
+            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
         rjobs = service.jobs(skip=4, limit=2)
         self.assertEqual(2, len(rjobs))
 

--- a/test/unit/test_job_retrieval.py
+++ b/test/unit/test_job_retrieval.py
@@ -47,7 +47,7 @@ class TestRetrieveJobs(IBMTestCase):
 
         jobs = []
         for _ in range(25):
-            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
+            jobs.append(run_program(service, program_id))
         rjobs = service.jobs(limit=None)
         self.assertEqual(25, len(rjobs))
 
@@ -59,7 +59,7 @@ class TestRetrieveJobs(IBMTestCase):
         jobs = []
         job_count = 25
         for _ in range(job_count):
-            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
+            jobs.append(run_program(service, program_id))
 
         limits = [21, 30]
         for limit in limits:
@@ -74,7 +74,7 @@ class TestRetrieveJobs(IBMTestCase):
 
         jobs = []
         for _ in range(5):
-            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
+            jobs.append(run_program(service, program_id))
         rjobs = service.jobs(skip=4)
         self.assertEqual(1, len(rjobs))
 
@@ -97,7 +97,7 @@ class TestRetrieveJobs(IBMTestCase):
 
         jobs = []
         for _ in range(10):
-            jobs.append(run_program(service, program_id, final_status="COMPLETED"))
+            jobs.append(run_program(service, program_id))
         rjobs = service.jobs(skip=4, limit=2)
         self.assertEqual(2, len(rjobs))
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`BaseFakeRuntimeJob` uses a `ThreadPoolExecutor` for auto-progress to the next status of a job, which can cause those `future`s to be running even after the test that spawned them is completed. Combined with the large number of them being created during the tests (most notably by `test_job_retrieval.py`), this causes an overhead in total test time.

This PR replaces that mechanism with a simple method, taking advantage of `BaseFakeRuntimeClient.wait_for_final_state()`, for trimming down on test time and for simplicity.


### Details and comments

Noticed during #2700, while peeking at the [test durations](https://github.com/Qiskit/qiskit-ibm-runtime/actions/runs/23590033422/job/68693076132#step:5:262).
