### PR TITLE
Setup minimal benchmarking facilities

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,39 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[dev]'
-      - name: Run benchmarks
-        run: make benchmark
       - name: Run integration tests
         run: make integration-test
+  benchmarks:
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'Qiskit'
+    name: Run benchmarks - ${{ matrix.environment }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # avoid cancellation of in-progress jobs if any matrix job fails
+      fail-fast: false
+      matrix:
+        python-version: [ '3.10' ]
+        os: [ "ubuntu-latest" ]
+        environment: ["ibm-cloud-production", "ibm-cloud-staging" ]
+    environment: ${{ matrix.environment }}
+    env:
+      QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}
+      QISKIT_IBM_URL: ${{ secrets.QISKIT_IBM_URL }}
+      QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
+      QISKIT_IBM_QPU: ${{ secrets.QISKIT_IBM_QPU }}
+      LOG_LEVEL: DEBUG
+      STREAM_LOG: True
+      QISKIT_IN_PARALLEL: True
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+      - name: Run benchmarks
+        run: make benchmark

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,5 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[dev]'
+      - name: Run benchmarks
+        run: make benchmark
       - name: Run integration tests
         run: make integration-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,12 +229,12 @@ To execute the smoke tests, run
 make smoke-test
 ```
 
-###### Configuration
+#### Configuration
 
-Integration tests require an environment configuration and can be run against the IBM Quantum Platform API
-(`ibm_quantum_platform` channel).
+Integration and smoke tests require an environment configuration and can be run against the IBM
+Quantum Platform API (`ibm_quantum_platform` channel).
 
-Sample configuration for IBM Cloud (ibm_quantum_platform)
+Sample configuration for IBM Cloud (ibm_quantum_platform):
 
 ```bash
 QISKIT_IBM_TOKEN=...                                            # IBM Cloud API key
@@ -250,6 +250,14 @@ To enable test cases against external system in your private fork, make sure to 
 For example, in your github fork settings, add the environment you want to run tests on
 (`ibm-cloud-production`, `ibm-cloud-staging`). Then add the appropriate environment secrets
 (`QISKIT_IBM_INSTANCE`, `QISKIT_IBM_TOKEN`, `QISKIT_IBM_URL`, `QISKIT_IBM_DEVICE`).
+
+#### Benchmarking
+
+Experimental support for benchmarking is available via:
+
+```sh
+make benchmark
+```
 
 ### Style guide
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ integration-test:
 smoke-test:
 	pytest test/smoke
 
+benchmark:
+	pytest test/benchmark
+
 docs-test:
 	./test/docs/vale.sh
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 
-.PHONY: unit-test integration-test smoke-test docs-test unit-test-coverage
+.PHONY: unit-test integration-test smoke-test benchmark docs-test unit-test-coverage
 
 unit-test:
 	pytest test/unit

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ smoke-test:
 	pytest test/smoke
 
 benchmark:
-	pytest test/benchmark
+	pytest test/benchmarks
 
 docs-test:
 	./test/docs/vale.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,8 @@ documentation = [
 visualization = ["plotly>=5.23.0"]
 test = [
     "ddt>=1.2.0,!=1.4.0,!=1.4.3",
-    "pytest",
+    "pytest>=8.1",
+    "pytest-benchmark==5.2.3",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,13 +193,7 @@ documentation = [
     "packaging",
 ]
 
-visualization = ["plotly>=5.23.0"]
-test = [
-    "ddt>=1.2.0,!=1.4.0,!=1.4.3",
-    "pytest",
-]
-
-dev = [
+dev_legacy = [
     "qiskit-ibm-runtime[test]",
     "qiskit-ibm-runtime[common]",
     "qiskit-ibm-runtime[style]",
@@ -233,7 +227,7 @@ style_local = [
 
 test = [
     "ddt>=1.2.0,!=1.4.0,!=1.4.3",
-    "pytest>=8.1"
+    "pytest>=8.1",
     "pproxy==2.7.8",
     "coverage>=6.3",
     "pytest-benchmark==5.2.3",

--- a/test/benchmarks/__init__.py
+++ b/test/benchmarks/__init__.py
@@ -1,0 +1,13 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Benchmarks for `qiskit-ibm-runtime`."""

--- a/test/benchmarks/test_benchmarks.py
+++ b/test/benchmarks/test_benchmarks.py
@@ -1,0 +1,47 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Benchmarks for `qiskit-ibm-runtime`."""
+
+from functools import partial
+import subprocess
+import sys
+from unittest import SkipTest
+
+from qiskit_ibm_runtime import QiskitRuntimeService
+from qiskit_ibm_runtime.accounts import AccountManager
+
+
+def run_in_subprocess(cmd: str) -> None:
+    """Run a Python `cmd` in a separate Python subprocess.
+
+    This allows for benchmarking cases where the import time is meaningful.
+
+    Args:
+        cmd: a valid Python program as a string.
+    """
+    command = [sys.executable, "-c", cmd]
+    subprocess.run(command, check=True)
+
+
+def test_import_qiskit_ibm_runtime(benchmark):
+    """Benchmark the importing of the package."""
+    benchmark(partial(run_in_subprocess, "import qiskit_ibm_runtime"))
+
+
+def test_instantiate_qiskit_runtime_service(benchmark):
+    """Benchmark the instantating of `QiskitRuntimeService`."""
+    account_manager = AccountManager()
+    if len(account_manager.list()) == 0:
+        raise SkipTest("No accounts available")
+
+    benchmark(QiskitRuntimeService)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Introduce two `pytest-benchmark` benchmarks, for `import` time and for instantiating the arguably main class of the package (`QiskitRuntimeService`). 

This is intended just for developers' needs at this stage, providing a convenient way for comparing the amount of time to run use cases that are significant. In order to provide some baseline, the benchmarks are run in the daily workflow that runs the integration tests, so we can start gathering some data and better tackle some performance-related issues - and at the same time, explore if this relatively simple approach can be expanded later.

### Details and comments

Related to #1286 and related discussions (such as #2213).

No attempt at storing benchmark results or providing a consistent environment is part of this PR (some alternatives such as [this action](https://github.com/benchmark-action/github-action-benchmark) if the GitHub runners provide a consistent environment, which is to be explored). The benchmarks included are specifically for #2423, #1286, and evaluating the impact of #2563 (which might uncover additional work for reducing import time).