### PR TITLE
Allow configuring the Cloud Platform Services clients

### DIFF
--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -318,8 +318,13 @@ class CloudAccount(Account):
         authenticator = IAMAuthenticator(self.token, url=iam_url)
         client = GlobalSearchV2(authenticator=authenticator)
         catalog = GlobalCatalogV1(authenticator=authenticator)
+
+        # Prepare the services.
         client.set_service_url(get_global_search_api_url(self.url))
         catalog.set_service_url(get_global_catalog_api_url(self.url))
+        client.configure_service("global_search")
+        catalog.configure_service("global_catalog")
+
         search_cursor = None
         all_crns = []
         while True:
@@ -336,11 +341,11 @@ class CloudAccount(Account):
                     search_cursor=search_cursor,
                     limit=100,
                 ).get_result()
-            except:  # noqa: E722 bare-except
+            except Exception as ex:
                 raise InvalidAccountError(
                     "Unable to retrieve instances. "
                     "Please check that you are using a valid API token."
-                )
+                ) from ex
             crns = []
             items = result.get("items", [])
             for item in items:

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -319,6 +319,7 @@ def resolve_crn(channel: str, url: str, instance: str, token: str) -> list[str]:
             client = ResourceControllerV2(authenticator=authenticator)
             client.set_service_url(get_resource_controller_api_url(url))
             client.set_http_client(session)
+            client.configure_service("resource_controller")
             list_response = client.list_resource_instances(name=instance)
             result = list_response.get_result()
             row_count = result["rows_count"]

--- a/release-notes/unreleased/2712.feat.rst
+++ b/release-notes/unreleased/2712.feat.rst
@@ -1,0 +1,5 @@
+The interactions with the IBM Cloud Platform Services (which happens during
+``QiskitRuntimeService`` instantation) now adhere to the
+`IBM Cloud SDK configuration mechanisms
+<https://github.com/IBM/ibm-cloud-sdk-common/blob/main/README.md#using-external-configuration>`_,
+allowing for custom configuration to be passed via environment variables or credential files.

--- a/release-notes/unreleased/2712.feat.rst
+++ b/release-notes/unreleased/2712.feat.rst
@@ -1,5 +1,6 @@
 The interactions with the IBM Cloud Platform Services (which happens during
-``QiskitRuntimeService`` instantation) now adhere to the
+``QiskitRuntimeService`` instantation, with the service names ``global_search`` and
+``global_catalog``) now adhere to the
 `IBM Cloud SDK configuration mechanisms
 <https://github.com/IBM/ibm-cloud-sdk-common/blob/main/README.md#using-external-configuration>`_,
 allowing for custom configuration to be passed via environment variables or credential files.

--- a/release-notes/unreleased/2712.feat.rst
+++ b/release-notes/unreleased/2712.feat.rst
@@ -1,6 +1,6 @@
 The interactions with the IBM Cloud Platform Services (which happens during
-``QiskitRuntimeService`` instantation, with the service names ``global_search`` and
-``global_catalog``) now adhere to the
+``QiskitRuntimeService`` instantation, with the service names ``global_search``,
+``global_catalog`` and ``resource_controller``) now adhere to the
 `IBM Cloud SDK configuration mechanisms
 <https://github.com/IBM/ibm-cloud-sdk-common/blob/main/README.md#using-external-configuration>`_,
 allowing for custom configuration to be passed via environment variables or credential files.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It was reported that unsuccessful API calls to the Cloud Platform Services can prevent initialization of `QiskitRuntimeService`, which further obscure debugging as the originating exception is not visible to the user. This PR:
* makes the exception visible to end user, by re-raising
* allows users to customize the configuration when interacting with the services, providing control over several features, in particular, re-trying.

### Details and comments
Fixes N/A

This allows for items such as:
```
GLOBAL_SEARCH_ENABLE_RETRIES=true GLOBAL_CATALOG_ENABLE_RETRIES=true RESOURCE_CONTROLLER_ENABLE_RETRIES=true python -m  ...
```

for customizing behavior. 