### PR TITLE
Fix integration tests and benchmarks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,6 +72,7 @@ jobs:
       LOG_LEVEL: DEBUG
       STREAM_LOG: True
       QISKIT_IN_PARALLEL: True
+      PYTEST_ADDOPTS: "--benchmark-time-unit s"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,6 +84,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[dev]'
+          pip install -e '.[test,performance]'
       - name: Run benchmarks
         run: make benchmark

--- a/test/benchmarks/test_benchmarks.py
+++ b/test/benchmarks/test_benchmarks.py
@@ -18,7 +18,8 @@ import sys
 from unittest import SkipTest
 
 from qiskit_ibm_runtime import QiskitRuntimeService
-from qiskit_ibm_runtime.accounts import AccountManager
+
+from ..decorators import _get_integration_test_config
 
 
 def run_in_subprocess(cmd: str) -> None:
@@ -40,8 +41,17 @@ def test_import_qiskit_ibm_runtime(benchmark):
 
 def test_instantiate_qiskit_runtime_service(benchmark):
     """Benchmark the instantating of `QiskitRuntimeService`."""
-    account_manager = AccountManager()
-    if len(account_manager.list()) == 0:
+
+    channel, token, url, instance, _ = _get_integration_test_config()
+    if not all([channel, token, url]):
         raise SkipTest("No accounts available")
 
-    benchmark(QiskitRuntimeService)
+    benchmark(
+        partial(
+            QiskitRuntimeService,
+            instance=instance,
+            channel=channel,
+            token=token,
+            url=url,
+        )
+    )

--- a/test/benchmarks/test_benchmarks.py
+++ b/test/benchmarks/test_benchmarks.py
@@ -19,7 +19,7 @@ from unittest import SkipTest
 
 from qiskit_ibm_runtime import QiskitRuntimeService
 
-from ..decorators import _get_integration_test_config
+from ..decorators import get_integration_test_config
 
 
 def run_in_subprocess(cmd: str) -> None:
@@ -42,7 +42,7 @@ def test_import_qiskit_ibm_runtime(benchmark):
 def test_instantiate_qiskit_runtime_service(benchmark):
     """Benchmark the instantating of `QiskitRuntimeService`."""
 
-    channel, token, url, instance, _ = _get_integration_test_config()
+    channel, token, url, instance, _ = get_integration_test_config()
     if not all([channel, token, url]):
         raise SkipTest("No accounts available")
 

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -53,7 +53,7 @@ def run_cloud_fake(func):
     return _wrapper
 
 
-def _get_integration_test_config():
+def get_integration_test_config():
     token, url, instance, qpu = (
         os.getenv("QISKIT_IBM_TOKEN"),
         os.getenv("QISKIT_IBM_URL"),
@@ -103,7 +103,7 @@ def integration_test_setup(
                 else supported_channel
             )
 
-            channel, token, url, instance, qpu = _get_integration_test_config()
+            channel, token, url, instance, qpu = get_integration_test_config()
             if not all([channel, token, url]):
                 raise Exception("Configuration Issue")
 

--- a/test/integration/test_proxies.py
+++ b/test/integration/test_proxies.py
@@ -97,6 +97,7 @@ class TestProxies(IBMTestCase):
             channel=dependencies.channel,
             verify=False,
             proxies={"urls": VALID_PROXIES},
+            url=dependencies.url,
         )
         service.jobs(limit=1)
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes for a couple of oversights from #2607 and #2708:
* pass the `url` to one of the proxy tests, as otherwise the staging run would fail due to using production's IAM
* revise the skipping of the benchmarks (reusing some decorator pieces), to ensure they are not always skipped in CI, as well as using seconds always in the output and take a bit of time off conforming to #2707


### Details and comments
Fixes N/A
