### PR TITLE
[sampler preview] Remove custom post processor

### DIFF
--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -110,21 +110,15 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
         self,
         timeout: float | None = None,
         decoder: type[ResultDecoder] | None = None,
-        post_processor: Callable[[QuantumProgramResult], Any] | None = None,
     ) -> Any:
         """Return the results of the job.
 
         If the decoded job results are of type QuantumProgramResult, and if a post processor is specified
-        (explicitly by the users, or via the results' passthrough data), the results are post-processed
-        before being returned. If provided, the user-specified `post_processor` takes precedence over the
-        post processor specified in the passthrough data.
+        via the results' passthrough data, the results are post-processed before being returned.
 
         Args:
             timeout: Number of seconds to wait for job.
             decoder: A :class:`ResultDecoder` subclass used to decode job results.
-            post_processor: Post-processor callable to apply to results.
-                Only applies to QuantumProgramResult. If provided, takes precedence
-                over ``post_processor`` specified in ``passthrough_data``.
 
         Returns:
             Runtime job result (post-processed if applicable).
@@ -151,28 +145,23 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
 
         # Apply post-processing only if result is QuantumProgramResult
         if result is not None:
-            result = self._apply_post_processing(result, post_processor)
+            result = self._apply_post_processing(result)
 
         return result
 
     def _apply_post_processing(
         self,
         result: Any,
-        post_processor_override: Callable[[QuantumProgramResult], Any] | None = None,
     ) -> Any:
         """Apply post-processing to the decoded result.
 
         Post-processing is only applied if the result is a QuantumProgramResult
         (from Executor jobs). Other result types are returned unchanged.
 
-        Post-processing precedence:
-        1. ``post_processor_override`` parameter (if provided)
-        2. Post-processor from result's ``passthrough_data`` (if available)
-        3. No post-processing (return result as-is)
+        Post-processing is applied from the result's ``passthrough_data`` (if available).
 
         Args:
             result: The decoded result
-            post_processor_override: Optional post-processor to use, overriding defaults
 
         Returns:
             Post-processed result or original result if no post-processing applies
@@ -182,15 +171,9 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
         if not isinstance(result, QuantumProgramResult):
             return result
 
-        # Determine which post-processor to use
+        # Check post-processor in passthrough data
         post_processor_fn = None
-
-        # Priority 1: Override parameter
-        if post_processor_override:
-            post_processor_fn = post_processor_override
-
-        # Priority 2: Post-processor from passthrough_data
-        if not post_processor_fn and isinstance(result.passthrough_data, dict):
+        if isinstance(result.passthrough_data, dict):
             if isinstance(
                 post_processor_info := result.passthrough_data.get("post_processor"), dict
             ):

--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -112,9 +112,6 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
     ) -> Any:
         """Return the results of the job.
 
-        If the decoded job results are of type QuantumProgramResult, and if a post processor is specified
-        via the results' passthrough data, the results are post-processed before being returned.
-
         Args:
             timeout: Number of seconds to wait for job.
             decoder: A :class:`ResultDecoder` subclass used to decode job results.
@@ -156,8 +153,6 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
 
         Post-processing is only applied if the result is a QuantumProgramResult
         (from Executor jobs). Other result types are returned unchanged.
-
-        Post-processing is applied from the result's ``passthrough_data`` (if available).
 
         Args:
             result: The decoded result

--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from typing import Any, Literal
-from collections.abc import Callable
 from collections.abc import Sequence
 from concurrent import futures
 import logging

--- a/test/unit/test_runtime_job_post_processing.py
+++ b/test/unit/test_runtime_job_post_processing.py
@@ -83,7 +83,7 @@ class TestRuntimeJobPostProcessing(unittest.TestCase):
 
         # Test with various non-QuantumProgramResult types
         for result in ["string_result", 123, {"dict": "result"}, None]:
-            processed = job._apply_post_processing(result, None)
+            processed = job._apply_post_processing(result)
             self.assertEqual(processed, result)
 
     def test_apply_post_processing_no_processor(self):
@@ -91,20 +91,8 @@ class TestRuntimeJobPostProcessing(unittest.TestCase):
         job = self._create_job()
         qp_result = QuantumProgramResult(data=[{"c": np.array([[0, 1]])}], metadata=Metadata())
 
-        processed = job._apply_post_processing(qp_result, None)
+        processed = job._apply_post_processing(qp_result)
         self.assertEqual(processed, qp_result)
-
-    def test_apply_post_processing_with_override(self):
-        """Test post-processing with override parameter."""
-        job = self._create_job()
-        qp_result = QuantumProgramResult(data=[{"c": np.array([[0, 1]])}], metadata=Metadata())
-
-        # Define override processor inline for this specific test
-        def override_proc(qp_result):  # pylint: disable=unused-argument
-            return "override_result"
-
-        processed = job._apply_post_processing(qp_result, override_proc)
-        self.assertEqual(processed, "override_result")
 
     def test_apply_post_processing_with_passthrough_data(self):
         """Test post-processing with passthrough_data."""
@@ -121,34 +109,7 @@ class TestRuntimeJobPostProcessing(unittest.TestCase):
         )
 
         # Apply with passthrough_data (uses pre-registered "v0.1" processor)
-        processed = job._apply_post_processing(qp_result, None)
-        self.assertEqual(processed, "processed_result")
-
-    def test_post_processing_precedence(self):
-        """Test that override > passthrough_data."""
-        job = self._create_job()
-
-        # Create result with passthrough_data
-        qp_result_with_passthrough = QuantumProgramResult(
-            data=[{"c": np.array([[0, 1]])}],
-            metadata=Metadata(),
-            passthrough_data={
-                "post_processor": {
-                    "context": "sampler_v2",
-                    "version": "v0.1",
-                }
-            },
-        )
-
-        # Test 1: Override takes precedence over passthrough_data
-        def override_proc(qp_result):  # pylint: disable=unused-argument
-            return "override"
-
-        processed = job._apply_post_processing(qp_result_with_passthrough, override_proc)
-        self.assertEqual(processed, "override")
-
-        # Test 2: Passthrough_data used when no override
-        processed = job._apply_post_processing(qp_result_with_passthrough, None)
+        processed = job._apply_post_processing(qp_result)
         self.assertEqual(processed, "processed_result")
 
     def test_passthrough_data_wrong_context(self):
@@ -166,7 +127,7 @@ class TestRuntimeJobPostProcessing(unittest.TestCase):
         )
 
         # Should return unchanged since context is not registered
-        processed = job._apply_post_processing(qp_result, None)
+        processed = job._apply_post_processing(qp_result)
         self.assertEqual(processed, qp_result)
 
     def test_passthrough_data_missing_version(self):
@@ -185,38 +146,6 @@ class TestRuntimeJobPostProcessing(unittest.TestCase):
 
         # Should raise ValueError since version is required for sampler_v2 context
         with self.assertRaises(ValueError) as context:
-            job._apply_post_processing(qp_result, None)
+            job._apply_post_processing(qp_result)
 
         self.assertIn("Could not determine a post-processor version", str(context.exception))
-
-    def test_post_processing_error_propagation(self):
-        """Test that post-processing errors are propagated."""
-        job = self._create_job()
-        qp_result = QuantumProgramResult(data=[{"c": np.array([[0, 1]])}], metadata=Metadata())
-
-        # Use pre-registered failing processor as override
-        with self.assertRaises(RuntimeError) as context:
-            job._apply_post_processing(qp_result, SAMPLER_POST_PROCESSORS["failing_version"])
-
-        self.assertIn("Test error", str(context.exception))
-
-    def test_result_with_post_processor_parameter(self):
-        """Test result() with post_processor parameter."""
-        job = self._create_job()
-        job._status = "DONE"
-
-        # Mock the API response
-        self.mock_api_client.job_results.return_value = '{"test": "data"}'
-
-        # Mock decoder to return QuantumProgramResult
-        mock_decoder = Mock()
-        mock_decoder.decode.return_value = self.qp_result
-        job._final_result_decoder = mock_decoder  # type: ignore[assignment]
-
-        # Define test processor inline for this specific test
-        def test_proc(qp_result):  # pylint: disable=unused-argument
-            return "param_result"
-
-        result = job.result(post_processor=test_proc)
-
-        self.assertEqual(result, "param_result")


### PR DESCRIPTION
### Summary
This PR removes the custom post-processor argument in the `job.result()` method.