### PR TITLE
Add UTC timezone info to executor result timing

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/converters/converters_0_1.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_0_1.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from datetime import timezone
 
 import numpy as np
 from samplomatic.tensor_interface import TensorSpecification, PauliLindbladMapSpecification
@@ -141,7 +142,9 @@ def quantum_program_result_from_0_1(model: QuantumProgramResultModel) -> Quantum
     metadata = Metadata(
         chunk_timing=[
             ChunkSpan(
-                span.start, span.stop, [ChunkPart(part.idx_item, part.size) for part in span.parts]
+                span.start.replace(tzinfo=timezone.utc),
+                span.stop.replace(tzinfo=timezone.utc),
+                [ChunkPart(part.idx_item, part.size) for part in span.parts],
             )
             for span in model.metadata.chunk_timing
         ]

--- a/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from datetime import timezone
 
 import numpy as np
 from samplomatic.tensor_interface import TensorSpecification, PauliLindbladMapSpecification
@@ -154,7 +155,9 @@ def quantum_program_result_from_0_2(model: QuantumProgramResultModel) -> Quantum
     metadata = Metadata(
         chunk_timing=[
             ChunkSpan(
-                span.start, span.stop, [ChunkPart(part.idx_item, part.size) for part in span.parts]
+                span.start.replace(tzinfo=timezone.utc),
+                span.stop.replace(tzinfo=timezone.utc),
+                [ChunkPart(part.idx_item, part.size) for part in span.parts],
             )
             for span in model.metadata.chunk_timing
         ]

--- a/test/unit/quantum_program/converters/test_converters_0_1.py
+++ b/test/unit/quantum_program/converters/test_converters_0_1.py
@@ -12,7 +12,7 @@
 
 """Tests the quantum program converters."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 import numpy as np
 
 from samplomatic import Twirl, InjectNoise, build
@@ -161,8 +161,8 @@ class TestQuantumProgramConverters(IBMTestCase):
         meas1 = np.array([[False], [True], [True]])
         meas2 = np.array([[True, True], [True, False], [False, False]])
         meas_flips = np.array([[False, False]])
-        chunk_start = datetime(2025, 12, 30, 14, 10)
-        chunk_stop = datetime(2025, 12, 30, 14, 15)
+        chunk_start = datetime(2025, 12, 30, 14, 10, tzinfo=timezone.utc)
+        chunk_stop = datetime(2025, 12, 30, 14, 15, tzinfo=timezone.utc)
 
         chunk_model = ChunkSpan(
             start=chunk_start,

--- a/test/unit/quantum_program/converters/test_converters_0_2.py
+++ b/test/unit/quantum_program/converters/test_converters_0_2.py
@@ -12,7 +12,7 @@
 
 """Tests the quantum program converters."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 import numpy as np
 
 from samplomatic import Twirl, InjectNoise, build
@@ -172,8 +172,8 @@ class TestQuantumProgramConverters(IBMTestCase):
         meas1 = np.array([[False], [True], [True]])
         meas2 = np.array([[True, True], [True, False], [False, False]])
         meas_flips = np.array([[False, False]])
-        chunk_start = datetime(2025, 12, 30, 14, 10)
-        chunk_stop = datetime(2025, 12, 30, 14, 15)
+        chunk_start = datetime(2025, 12, 30, 14, 10, tzinfo=timezone.utc)
+        chunk_stop = datetime(2025, 12, 30, 14, 15, tzinfo=timezone.utc)
 
         chunk_model = ChunkSpan(
             start=chunk_start,

--- a/test/unit/quantum_program/test_decoder.py
+++ b/test/unit/quantum_program/test_decoder.py
@@ -71,8 +71,12 @@ class TestDecoder(IBMTestCase):
         self.assertTrue(np.array_equal(decoded[0]["meas"], self.meas1))
         self.assertTrue(np.array_equal(decoded[1]["meas"], self.meas2))
         self.assertTrue(np.array_equal(decoded[1]["measurement_flips.meas"], self.meas_flips))
-        self.assertEqual(decoded.metadata.chunk_timing[0].start, self.chunk_start)
-        self.assertEqual(decoded.metadata.chunk_timing[0].stop, self.chunk_stop)
+        self.assertEqual(
+            decoded.metadata.chunk_timing[0].start.replace(tzinfo=None), self.chunk_start
+        )
+        self.assertEqual(
+            decoded.metadata.chunk_timing[0].stop.replace(tzinfo=None), self.chunk_stop
+        )
         self.assertEqual(decoded.metadata.chunk_timing[0].parts[0].idx_item, 0)
         self.assertEqual(decoded.metadata.chunk_timing[0].parts[0].size, 1)
         self.assertEqual(decoded.metadata.chunk_timing[0].parts[1].idx_item, 1)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes a shortcoming of the 0.1, 0.2 schemas by adding timezone information to the converted models to mark them as being UTC (which is what we promise). Without this information, most tooling will assume they're in the local timezone which is incorrect.

### Details and comments

<img width="865" height="578" alt="image" src="https://github.com/user-attachments/assets/7b3f1652-7623-4912-b054-b401761a7ef7" />

