### PR TITLE
Add draw_chunk_timings() and a draw() method for QuantumProgramResult.timings

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -69,7 +69,7 @@ class Metadata:
     """Timing information about all executed chunks of a quantum program."""
 
 
-class ChunkTimings:
+class ChunkTiming:
     """A collection of chunk timing information for a :class:`QuantumProgramResult`.
 
     This class is a readonly list-like containing :class:`~.ChunkSpan` objects, where each span
@@ -114,21 +114,21 @@ class ChunkTimings:
     def __getitem__(self, idxs: int) -> ChunkSpan: ...
 
     @overload
-    def __getitem__(self, idxs: slice) -> ChunkTimings: ...
+    def __getitem__(self, idxs: slice) -> ChunkTiming: ...
 
     def __getitem__(self, idxs):  # type: ignore[no-untyped-def]
         if isinstance(idxs, int):
             return self._spans[idxs]
-        return ChunkTimings(self._spans[idxs])
+        return ChunkTiming(self._spans[idxs])
 
     def __iter__(self) -> Iterator[ChunkSpan]:
         return iter(self._spans)
 
     def __repr__(self) -> str:
-        return f"ChunkTimings({repr(self._spans)})"
+        return f"ChunkTiming({repr(self._spans)})"
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, ChunkTimings) and self._spans == other._spans
+        return isinstance(other, ChunkTiming) and self._spans == other._spans
 
     @property
     def start(self) -> datetime.datetime:
@@ -152,7 +152,7 @@ class ChunkTimings:
         line_width: int = 4,
         tz: timezone | None = None,
     ) -> PlotlyFigure:
-        """Draw these chunk timings.
+        """Draw timing information on a bar plot.
 
         To draw chunk timings with additional options like ``common_start``, or to draw
         timings of several jobs on the same axis, consider calling
@@ -208,19 +208,19 @@ class QuantumProgramResult:
         return f"{type(self).__name__}(<{len(self)} results>)"
 
     @property
-    def chunk_timings(self) -> ChunkTimings:
+    def timing(self) -> ChunkTiming:
         """Execution timing information of these results.
 
         A single executor job may be broken up into chunks of work that are executed serially.
-        This object stores information about their timing. Most notably, for each chunk of execution
-        a start and stop timestamp are provided that bound the window in which the data was
-        collected.
+        This property stores information about their timing. Most notably, for each chunk of
+        execution, a start and stop timestamp are provided that bound the window in which the data
+        was collected.
 
         To draw the timings for a single result:
 
         .. code-block:: python
 
-            result.chunk_timings.draw()
+            job.result().timing.draw()
 
         To draw the timings for several results on one plot:
 
@@ -229,13 +229,13 @@ class QuantumProgramResult:
             from qiskit_ibm_runtime.visualization import draw_chunk_timings
 
             draw_chunk_timings(
-                result1.chunk_timings,
-                result2.chunk_timings,
+                job1.result().timing,
+                job2.result().timing,
                 names=["job 1", "job 2"],
                 common_start=True,
             )
 
         Returns:
-            A :class:`ChunkTimings` collection.
+            A :class:`~.ChunkTiming` collection.
         """
-        return ChunkTimings(self.metadata.chunk_timing)
+        return ChunkTiming(self.metadata.chunk_timing)

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -72,7 +72,7 @@ class Metadata:
 class ChunkTimings:
     """A collection of chunk timing information for a :class:`QuantumProgramResult`.
 
-    This class is a readonly list-like containing :class:`ChunkSpan` objects, where each span
+    This class is a readonly list-like containing :class:`~.ChunkSpan` objects, where each span
     represents a single execution chunk on the backend and contains timing information and a
     description of which parts of the :class:`~.QuantumProgram` were executed in that chunk.
 
@@ -154,10 +154,9 @@ class ChunkTimings:
     ) -> PlotlyFigure:
         """Draw these chunk timings.
 
-        .. note::
-            To draw chunk timings with additional options like ``common_start``, or to draw
-            timings of several jobs on the same axis, consider calling
-            :meth:`~qiskit_ibm_runtime.visualization.draw_chunk_timings` directly.
+        To draw chunk timings with additional options like ``common_start``, or to draw
+        timings of several jobs on the same axis, consider calling
+        :meth:`~qiskit_ibm_runtime.visualization.draw_chunk_timings` directly.
 
         Args:
             name: A label for this set of chunks.

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -116,7 +116,7 @@ class ChunkTimings:
     @overload
     def __getitem__(self, idxs: slice) -> ChunkTimings: ...
 
-    def __getitem__(self, idxs):
+    def __getitem__(self, idxs):  # type: ignore[no-untyped-def]
         if isinstance(idxs, int):
             return self._spans[idxs]
         return ChunkTimings(self._spans[idxs])

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -14,12 +14,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 import datetime
+from datetime import timezone
+from typing import overload, TYPE_CHECKING
 import numpy as np
 
 from ..utils.datatree import DataTree
+
+if TYPE_CHECKING:
+    from plotly.graph_objects import Figure as PlotlyFigure
 
 
 @dataclass
@@ -64,6 +69,92 @@ class Metadata:
     """Timing information about all executed chunks of a quantum program."""
 
 
+class ChunkTimings:
+    """A collection of chunk timing information for a :class:`QuantumProgramResult`.
+
+    This class is a readonly list-like containing :class:`ChunkSpan` objects, where each span
+    represents a single execution chunk on the backend and contains timing information and a
+    description of which parts of the :class:`~.QuantumProgram` were executed in that chunk.
+
+    .. code:: python
+
+        result = job.result()
+        for chunk in result.chunk_timings:
+            print(chunk)
+    """
+
+    def __init__(self, spans: Iterable[ChunkSpan]):
+        self._spans = list(spans)
+
+    def __len__(self) -> int:
+        return len(self._spans)
+
+    @overload
+    def __getitem__(self, idxs: int) -> ChunkSpan: ...
+
+    @overload
+    def __getitem__(self, idxs: slice) -> ChunkTimings: ...
+
+    def __getitem__(self, idxs):
+        if isinstance(idxs, int):
+            return self._spans[idxs]
+        return ChunkTimings(self._spans[idxs])
+
+    def __iter__(self) -> Iterator[ChunkSpan]:
+        return iter(self._spans)
+
+    def __repr__(self) -> str:
+        return f"ChunkTimings({repr(self._spans)})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ChunkTimings) and self._spans == other._spans
+
+    @property
+    def start(self) -> datetime.datetime:
+        """The start time of the earliest chunk, in UTC."""
+        return min(span.start for span in self)
+
+    @property
+    def stop(self) -> datetime.datetime:
+        """The stop time of the latest chunk, in UTC."""
+        return max(span.stop for span in self)
+
+    @property
+    def duration(self) -> float:
+        """The total duration from first start to last stop, in seconds."""
+        return (self.stop - self.start).total_seconds()
+
+    def draw(
+        self,
+        name: str | None = None,
+        normalize_y: bool = False,
+        line_width: int = 4,
+        tz: timezone | None = None,
+    ) -> PlotlyFigure:
+        """Draw these chunk timings.
+
+        .. note::
+            To draw chunk timings with additional options like ``common_start``, consider calling
+            :meth:`~qiskit_ibm_runtime.visualization.draw_chunk_timings` directly.
+
+        Args:
+            name: A label for this set of chunks.
+            normalize_y: Whether to display the y-axis units as a percentage of work complete,
+                rather than cumulative elements completed.
+            line_width: The thickness of line segments.
+            tz: The timezone to use for displaying times. ``None`` (default) uses the local system
+                timezone. Pass ``datetime.timezone.utc`` to display times in UTC.
+
+        Returns:
+            A plotly figure.
+        """
+        from ..visualization import draw_chunk_timings
+
+        return draw_chunk_timings(
+            self, names=name, normalize_y=normalize_y, line_width=line_width, tz=tz
+        )
+
+
 class QuantumProgramResult:
     """A container to store results from executing a :class:`QuantumProgram`.
 
@@ -94,3 +185,36 @@ class QuantumProgramResult:
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(<{len(self)} results>)"
+
+    @property
+    def chunk_timings(self) -> ChunkTimings:
+        """Execution timing information of these results.
+
+        A single executor job may be broken up into chunks of work that are executed serially.
+        This object stores information about their timing. Most notably, for each chunk of execution
+        a start and stop timestamp are provided that bound the window in which the data was
+        collected.
+
+        To draw the timings for a single result:
+
+        .. code-block:: python
+
+            result.chunk_timings.draw()
+
+        To draw the timings for several results on one plot:
+
+        .. code-block:: python
+
+            from qiskit_ibm_runtime.visualization import draw_chunk_timings
+
+            draw_chunk_timings(
+                result1.chunk_timings,
+                result2.chunk_timings,
+                names=["job 1", "job 2"],
+                common_start=True,
+            )
+
+        Returns:
+            A :class:`ChunkTimings` collection.
+        """
+        return ChunkTimings(self.metadata.chunk_timing)

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -76,11 +76,32 @@ class ChunkTimings:
     represents a single execution chunk on the backend and contains timing information and a
     description of which parts of the :class:`~.QuantumProgram` were executed in that chunk.
 
-    .. code:: python
+    To iterate over chunks:
+
+    .. code-block:: python
 
         result = job.result()
-        for chunk in result.chunk_timings:
+        for chunk in chunk_timings:
             print(chunk)
+
+    To draw the timings for a single result:
+
+    .. code-block:: python
+
+        chunk_timings.draw()
+
+    To draw the timings for several results on one plot:
+
+    .. code-block:: python
+
+        from qiskit_ibm_runtime.visualization import draw_chunk_timings
+
+        draw_chunk_timings(
+            chunk_timings1,
+            chunk_timings2,
+            names=["job 1", "job 2"],
+            common_start=True,
+        )
     """
 
     def __init__(self, spans: Iterable[ChunkSpan]):
@@ -134,7 +155,8 @@ class ChunkTimings:
         """Draw these chunk timings.
 
         .. note::
-            To draw chunk timings with additional options like ``common_start``, consider calling
+            To draw chunk timings with additional options like ``common_start``, or to draw
+            timings of several jobs on the same axis, consider calling
             :meth:`~qiskit_ibm_runtime.visualization.draw_chunk_timings` directly.
 
         Args:

--- a/qiskit_ibm_runtime/visualization/__init__.py
+++ b/qiskit_ibm_runtime/visualization/__init__.py
@@ -26,6 +26,7 @@ Functions
     :toctree: ../stubs/
     :nosignatures:
 
+    draw_chunk_timings
     draw_execution_spans
     draw_layer_error_map
     draw_layer_errors_swarm
@@ -35,6 +36,7 @@ Functions
 """
 
 from .draw_layer_error import draw_layer_error_map, draw_layer_errors_swarm
+from .draw_chunk_timings import draw_chunk_timings
 from .draw_execution_spans import draw_execution_spans
 from .draw_zne import draw_zne_evs, draw_zne_extrapolators
 from .draw_circuit_schedule_timings import draw_circuit_schedule_timing

--- a/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
@@ -1,0 +1,199 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Function to visualize chunk timings from a :class:`~.QuantumProgramResult`."""
+
+from __future__ import annotations
+
+from itertools import cycle
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+from collections.abc import Iterable
+
+from ..quantum_program.quantum_program_result import ChunkTimings
+from .utils import plotly_module
+
+if TYPE_CHECKING:
+    from plotly.graph_objects import Figure as PlotlyFigure
+
+
+_HOVER_HEADER = "<br>".join(
+    [
+        "<b>{name}[{idx}]</b>",
+        "<b>&nbsp;&nbsp;&nbsp;Start:</b> {start:%Y-%m-%d %H:%M:%S.%f}",
+        "<b>&nbsp;&nbsp;&nbsp;Stop:</b> {stop:%Y-%m-%d %H:%M:%S.%f}",
+        "<b>&nbsp;&nbsp;&nbsp;Duration:</b> {duration:.4g}s",
+        "<b>&nbsp;&nbsp;&nbsp;Size:</b> {size}",
+        "<b>&nbsp;&nbsp;&nbsp;Parts ({n_parts}):</b>",
+    ]
+)
+_HOVER_PART = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;item[{idx_item}]: {size}"
+_HOVER_ELLIPSIS = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;..."
+_PARTS_LIMIT = 10
+
+
+def _apply_tz(dt: datetime, tz: timezone | None) -> datetime:
+    """Convert a datetime (assumed UTC if naive) to the given timezone, stripped of tzinfo.
+
+    Args:
+        dt: The datetime to convert. Treated as UTC if timezone-naive.
+        tz: Target timezone. ``None`` means the local system timezone.
+
+    Returns:
+        A timezone-naive datetime in the target timezone.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(tz=tz).replace(tzinfo=None)
+
+
+def _format_hover(name: str, idx: int, chunk, tz: timezone | None) -> str:
+    chunk_size = sum(p.size for p in chunk.parts)
+    duration = (chunk.stop - chunk.start).total_seconds()
+    lines = [
+        _HOVER_HEADER.format(
+            name=name,
+            idx=idx,
+            start=_apply_tz(chunk.start, tz),
+            stop=_apply_tz(chunk.stop, tz),
+            duration=duration,
+            size=chunk_size,
+            n_parts=len(chunk.parts),
+        )
+    ]
+    for part in chunk.parts[:_PARTS_LIMIT]:
+        lines.append(_HOVER_PART.format(idx_item=part.idx_item, size=part.size))
+    if len(chunk.parts) > _PARTS_LIMIT:
+        lines.append(_HOVER_ELLIPSIS)
+    return "<br>".join(lines)
+
+
+def _get_id(ct: ChunkTimings, multiple: bool) -> str:
+    return f"<{hex(id(ct))}>" if multiple else ""
+
+
+def draw_chunk_timings(
+    *chunk_timings: ChunkTimings,
+    names: str | Iterable[str] | None = None,
+    common_start: bool = False,
+    normalize_y: bool = False,
+    line_width: int = 4,
+    show_legend: bool | None = None,
+    tz: timezone | None = None,
+) -> PlotlyFigure:
+    """Draw one or more :class:`~.ChunkTimings` on a bar plot.
+
+    Each chunk corresponds to a single execution window on the backend. The y-axis represents
+    cumulative work completed across chunks — in units of elements executed, or as a percentage
+    if ``normalize_y=True``.
+
+    When comparing multiple :class:`~.ChunkTimings` (e.g. from different jobs), use
+    ``common_start=True`` to align traces at :math:`t=0` for direct comparison.
+
+    .. note::
+        For a simpler single-trace interface, call :meth:`~.ChunkTimings.draw` directly on the
+        ``result.chunk_timings`` attribute.
+
+    Args:
+        chunk_timings: One or more :class:`~.ChunkTimings` collections,
+            e.g. ``result.chunk_timings``.
+        names: Name or names to assign to the respective ``chunk_timings``. When provided, a
+            legend is shown by default.
+        common_start: Whether to shift each collection's chunks so that its first chunk starts
+            at :math:`t=0`. Useful for comparing timings from different jobs side by side.
+        normalize_y: Whether to display the y-axis units as a percentage of work complete,
+            rather than cumulative elements completed.
+        line_width: The thickness of line segments.
+        show_legend: Whether to show a legend. By default, shown only when ``names`` is provided.
+        tz: The timezone to use for displaying times. ``None`` (default) uses the local system
+            timezone. Pass ``datetime.timezone.utc`` to display times in UTC.
+
+    Returns:
+        A plotly figure.
+    """
+    go = plotly_module(".graph_objects")
+    colors = plotly_module(".colors").qualitative.Plotly
+
+    fig = go.Figure()
+
+    # resolve names and legend visibility
+    all_names: list[str] = []
+    if names is None:
+        show_legend = False if show_legend is None else show_legend
+    else:
+        show_legend = True if show_legend is None else show_legend
+        if isinstance(names, str):
+            all_names = [names]
+        else:
+            all_names.extend(names)
+
+    # fill in default names for any without an explicit one
+    multiple = len(chunk_timings) > 1
+    all_names.extend(
+        f"ChunkTimings{_get_id(ct, multiple)}" for ct in chunk_timings[len(all_names) :]
+    )
+
+    for ct, color, name in zip(chunk_timings, cycle(colors), all_names):
+        if not ct:
+            continue
+
+        sorted_chunks = sorted(enumerate(ct), key=lambda x: x[1].start)
+
+        offset = timedelta()
+        if common_start:
+            first_start = _apply_tz(sorted_chunks[0][1].start, tz)
+            offset = first_start - datetime(year=1970, month=1, day=1)
+
+        total_size = sum(sum(p.size for p in c.parts) for c in ct) if normalize_y else 1
+        y_value = 0.0
+        x_data = []
+        y_data = []
+        text_data = []
+
+        for idx, chunk in sorted_chunks:
+            chunk_size = sum(p.size for p in chunk.parts)
+            y_value += chunk_size / total_size
+            text = _format_hover(name, idx, chunk, tz)
+            x_data.extend(
+                [_apply_tz(chunk.start, tz) - offset, _apply_tz(chunk.stop, tz) - offset, None]
+            )
+            y_data.extend([y_value, y_value, None])
+            text_data.extend([text] * 3)
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_data,
+                y=y_data,
+                mode="lines",
+                line={"width": line_width, "color": color},
+                text=text_data,
+                hoverinfo="text",
+                name=name,
+            )
+        )
+
+    fig.update_layout(
+        xaxis={"title": "Time", "type": "date"},
+        showlegend=show_legend,
+        legend={"yanchor": "bottom", "y": 0.01, "xanchor": "right", "x": 0.99},
+        margin={"l": 70, "r": 20, "t": 20, "b": 70},
+    )
+
+    if normalize_y:
+        fig.update_yaxes(title="Completed Workload", tickformat=".0%")
+    else:
+        fig.update_yaxes(title="Elements Completed")
+
+    if common_start:
+        fig.update_xaxes(tickformat="%H:%M:%S.%f")
+
+    return fig

--- a/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 from collections.abc import Iterable
 
-from ..quantum_program.quantum_program_result import ChunkTimings, ChunkSpan
+from ..quantum_program.quantum_program_result import ChunkTiming, ChunkSpan
 from .utils import plotly_module
 
 if TYPE_CHECKING:
@@ -77,12 +77,12 @@ def _format_hover(name: str, idx: int, chunk: ChunkSpan, tz: timezone | None) ->
     return "<br>".join(lines)
 
 
-def _get_id(ct: ChunkTimings, multiple: bool) -> str:
+def _get_id(ct: ChunkTiming, multiple: bool) -> str:
     return f"<{hex(id(ct))}>" if multiple else ""
 
 
 def draw_chunk_timings(
-    *timings: ChunkTimings,
+    *timings: ChunkTiming,
     names: str | Iterable[str] | None = None,
     common_start: bool = False,
     normalize_y: bool = False,
@@ -90,21 +90,22 @@ def draw_chunk_timings(
     show_legend: bool | None = None,
     tz: timezone | None = None,
 ) -> PlotlyFigure:
-    """Draw one or more :class:`~.ChunkTimings` on a bar plot.
+    """Draw one or more :class:`~.ChunkTiming` on a bar plot.
 
     Each chunk corresponds to a single execution window on the backend. The y-axis represents
     cumulative work completed across chunks — in units of elements executed, or as a percentage
     if ``normalize_y=True``.
 
-    When comparing multiple :class:`~.ChunkTimings` (e.g. from different jobs), use
+    When comparing multiple :class:`~.ChunkTiming` (e.g. from different jobs), use
     ``common_start=True`` to align traces at :math:`t=0` for direct comparison.
 
     .. note::
-        For a simpler single-trace interface, call :meth:`~.ChunkTimings.draw` directly on the
-        ``result.chunk_timings`` attribute.
+
+        For a simpler single-trace interface for data from an executor job, call
+        :meth:`~.ChunkTiming.draw` directly on ``job.result().timings``.
 
     Args:
-        timings: One or more :class:`~.ChunkTimings` collections.
+        timings: One or more :class:`~.ChunkTiming` collections.
         names: Name or names to assign to the respective ``timings``. When provided, a
             legend is shown by default.
         common_start: Whether to shift each collection's chunks so that its first chunk starts

--- a/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
@@ -77,10 +77,6 @@ def _format_hover(name: str, idx: int, chunk: ChunkSpan, tz: timezone | None) ->
     return "<br>".join(lines)
 
 
-def _get_id(ct: ChunkTiming, multiple: bool) -> str:
-    return f"<{hex(id(ct))}>" if multiple else ""
-
-
 def draw_chunk_timings(
     *timings: ChunkTiming,
     names: str | Iterable[str] | None = None,

--- a/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 from collections.abc import Iterable
 
-from ..quantum_program.quantum_program_result import ChunkTimings
+from ..quantum_program.quantum_program_result import ChunkTimings, ChunkSpan
 from .utils import plotly_module
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ def _apply_tz(dt: datetime, tz: timezone | None) -> datetime:
     return dt.astimezone(tz=tz).replace(tzinfo=None)
 
 
-def _format_hover(name: str, idx: int, chunk, tz: timezone | None) -> str:
+def _format_hover(name: str, idx: int, chunk: ChunkSpan, tz: timezone | None) -> str:
     chunk_size = sum(p.size for p in chunk.parts)
     duration = (chunk.stop - chunk.start).total_seconds()
     lines = [

--- a/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_chunk_timings.py
@@ -82,7 +82,7 @@ def _get_id(ct: ChunkTimings, multiple: bool) -> str:
 
 
 def draw_chunk_timings(
-    *chunk_timings: ChunkTimings,
+    *timings: ChunkTimings,
     names: str | Iterable[str] | None = None,
     common_start: bool = False,
     normalize_y: bool = False,
@@ -104,9 +104,8 @@ def draw_chunk_timings(
         ``result.chunk_timings`` attribute.
 
     Args:
-        chunk_timings: One or more :class:`~.ChunkTimings` collections,
-            e.g. ``result.chunk_timings``.
-        names: Name or names to assign to the respective ``chunk_timings``. When provided, a
+        timings: One or more :class:`~.ChunkTimings` collections.
+        names: Name or names to assign to the respective ``timings``. When provided, a
             legend is shown by default.
         common_start: Whether to shift each collection's chunks so that its first chunk starts
             at :math:`t=0`. Useful for comparing timings from different jobs side by side.
@@ -137,23 +136,20 @@ def draw_chunk_timings(
             all_names.extend(names)
 
     # fill in default names for any without an explicit one
-    multiple = len(chunk_timings) > 1
-    all_names.extend(
-        f"ChunkTimings{_get_id(ct, multiple)}" for ct in chunk_timings[len(all_names) :]
-    )
+    all_names.extend(f"Timings {idx}" for idx in range(len(all_names), len(timings)))
 
-    for ct, color, name in zip(chunk_timings, cycle(colors), all_names):
-        if not ct:
+    for timing, color, name in zip(timings, cycle(colors), all_names):
+        if not timing:
             continue
 
-        sorted_chunks = sorted(enumerate(ct), key=lambda x: x[1].start)
+        sorted_chunks = sorted(enumerate(timing), key=lambda x: x[1].start)
 
         offset = timedelta()
         if common_start:
             first_start = _apply_tz(sorted_chunks[0][1].start, tz)
             offset = first_start - datetime(year=1970, month=1, day=1)
 
-        total_size = sum(sum(p.size for p in c.parts) for c in ct) if normalize_y else 1
+        total_size = sum(sum(p.size for p in c.parts) for c in timing) if normalize_y else 1
         y_value = 0.0
         x_data = []
         y_data = []

--- a/release-notes/unreleased/2727.feat.rst
+++ b/release-notes/unreleased/2727.feat.rst
@@ -1,0 +1,4 @@
+Added :func:`.draw_chunk_timings` to :mod:`qiskit_ibm_runtime.visualization` for plotting
+the execution timing of one or more instances of the new chunk timings container class,
+:class:`.ChunkTimings`, on an interactive barchart. A convenience :meth:`.ChunkTimings.draw`
+method is also available for the single-result case via ``job.result().chunk_timings.draw()``.

--- a/test/unit/quantum_program/test_result.py
+++ b/test/unit/quantum_program/test_result.py
@@ -19,7 +19,7 @@ import numpy as np
 from qiskit_ibm_runtime.quantum_program.quantum_program_result import (
     ChunkPart,
     ChunkSpan,
-    ChunkTimings,
+    ChunkTiming,
     Metadata,
     QuantumProgramResult,
 )
@@ -61,48 +61,47 @@ class TestQuantumProgramResult(IBMTestCase):
         self.assertEqual([result[0], result[1]], [result1, result2])
 
     def test_wraps_metadata_spans(self):
-        """chunk_timings returns a ChunkTimings backed by the metadata's spans."""
+        """Test `timing` returns a ChunkTiming backed by the metadata's spans."""
         spans = [_make_span(0, 1, size=10), _make_span(2, 3, size=5)]
         result = QuantumProgramResult([], metadata=Metadata(chunk_timing=spans))
-        ct = result.chunk_timings
-        self.assertIsInstance(ct, ChunkTimings)
-        self.assertEqual(list(ct), spans)
+        self.assertIsInstance(result.timing, ChunkTiming)
+        self.assertEqual(list(result.timing), spans)
 
     def test_empty_metadata(self):
-        """chunk_timings is empty when no spans are present in metadata."""
+        """Test `timing` is empty when no spans are present in metadata."""
         result = QuantumProgramResult([])
-        self.assertEqual(len(result.chunk_timings), 0)
+        self.assertEqual(len(result.timing), 0)
 
 
-class TestChunkTimings(IBMTestCase):
-    """Tests the ``ChunkTimings`` class."""
+class TestChunkTiming(IBMTestCase):
+    """Tests the ``ChunkTiming`` class."""
 
     def test_len_and_iter(self):
         """Supports len() and iteration over the wrapped spans."""
         spans = [_make_span(0, 1), _make_span(1, 2), _make_span(2, 3)]
-        ct = ChunkTimings(spans)
-        self.assertEqual(len(ct), 3)
-        self.assertEqual(list(ct), spans)
+        timing = ChunkTiming(spans)
+        self.assertEqual(len(timing), 3)
+        self.assertEqual(list(timing), spans)
 
     def test_getitem_int(self):
         """Integer indexing returns the corresponding ChunkSpan."""
         spans = [_make_span(0, 1), _make_span(1, 2)]
-        ct = ChunkTimings(spans)
-        self.assertEqual(ct[0], spans[0])
-        self.assertEqual(ct[1], spans[1])
+        timing = ChunkTiming(spans)
+        self.assertEqual(timing[0], spans[0])
+        self.assertEqual(timing[1], spans[1])
 
     def test_getitem_slice(self):
-        """Slice indexing returns a new ChunkTimings."""
+        """Slice indexing returns a new ChunkTiming."""
         spans = [_make_span(i, i + 1) for i in range(4)]
-        sliced = ChunkTimings(spans)[1:3]
-        self.assertIsInstance(sliced, ChunkTimings)
+        sliced = ChunkTiming(spans)[1:3]
+        self.assertIsInstance(sliced, ChunkTiming)
         self.assertEqual(list(sliced), spans[1:3])
 
     def test_start_stop_duration(self):
         """start, stop, and duration are derived from the spans."""
         spans = [_make_span(10, 20, size=3), _make_span(25, 40, size=7)]
-        ct = ChunkTimings(spans)
+        timing = ChunkTiming(spans)
         epoch = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
-        self.assertEqual(ct.start, epoch + datetime.timedelta(seconds=10))
-        self.assertEqual(ct.stop, epoch + datetime.timedelta(seconds=40))
-        self.assertAlmostEqual(ct.duration, 30.0)
+        self.assertEqual(timing.start, epoch + datetime.timedelta(seconds=10))
+        self.assertEqual(timing.stop, epoch + datetime.timedelta(seconds=40))
+        self.assertAlmostEqual(timing.duration, 30.0)

--- a/test/unit/quantum_program/test_result.py
+++ b/test/unit/quantum_program/test_result.py
@@ -12,11 +12,29 @@
 
 """Tests the class ``QuantumProgramResult``."""
 
+import datetime
+
 import numpy as np
 
-from qiskit_ibm_runtime.quantum_program.quantum_program_result import QuantumProgramResult
+from qiskit_ibm_runtime.quantum_program.quantum_program_result import (
+    ChunkPart,
+    ChunkSpan,
+    ChunkTimings,
+    Metadata,
+    QuantumProgramResult,
+)
 
 from ...ibm_test_case import IBMTestCase
+
+
+def _make_span(start_s: float, stop_s: float, size: int = 1) -> ChunkSpan:
+    """Helper to build a ``ChunkSpan`` with a single ``ChunkPart``."""
+    epoch = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    return ChunkSpan(
+        start=epoch + datetime.timedelta(seconds=start_s),
+        stop=epoch + datetime.timedelta(seconds=stop_s),
+        parts=[ChunkPart(idx_item=0, size=size)],
+    )
 
 
 class TestQuantumProgramResult(IBMTestCase):
@@ -41,3 +59,50 @@ class TestQuantumProgramResult(IBMTestCase):
 
         # test __getitem__
         self.assertEqual([result[0], result[1]], [result1, result2])
+
+    def test_wraps_metadata_spans(self):
+        """chunk_timings returns a ChunkTimings backed by the metadata's spans."""
+        spans = [_make_span(0, 1, size=10), _make_span(2, 3, size=5)]
+        result = QuantumProgramResult([], metadata=Metadata(chunk_timing=spans))
+        ct = result.chunk_timings
+        self.assertIsInstance(ct, ChunkTimings)
+        self.assertEqual(list(ct), spans)
+
+    def test_empty_metadata(self):
+        """chunk_timings is empty when no spans are present in metadata."""
+        result = QuantumProgramResult([])
+        self.assertEqual(len(result.chunk_timings), 0)
+
+
+class TestChunkTimings(IBMTestCase):
+    """Tests the ``ChunkTimings`` class."""
+
+    def test_len_and_iter(self):
+        """Supports len() and iteration over the wrapped spans."""
+        spans = [_make_span(0, 1), _make_span(1, 2), _make_span(2, 3)]
+        ct = ChunkTimings(spans)
+        self.assertEqual(len(ct), 3)
+        self.assertEqual(list(ct), spans)
+
+    def test_getitem_int(self):
+        """Integer indexing returns the corresponding ChunkSpan."""
+        spans = [_make_span(0, 1), _make_span(1, 2)]
+        ct = ChunkTimings(spans)
+        self.assertEqual(ct[0], spans[0])
+        self.assertEqual(ct[1], spans[1])
+
+    def test_getitem_slice(self):
+        """Slice indexing returns a new ChunkTimings."""
+        spans = [_make_span(i, i + 1) for i in range(4)]
+        sliced = ChunkTimings(spans)[1:3]
+        self.assertIsInstance(sliced, ChunkTimings)
+        self.assertEqual(list(sliced), spans[1:3])
+
+    def test_start_stop_duration(self):
+        """start, stop, and duration are derived from the spans."""
+        spans = [_make_span(10, 20, size=3), _make_span(25, 40, size=7)]
+        ct = ChunkTimings(spans)
+        epoch = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        self.assertEqual(ct.start, epoch + datetime.timedelta(seconds=10))
+        self.assertEqual(ct.stop, epoch + datetime.timedelta(seconds=40))
+        self.assertAlmostEqual(ct.duration, 30.0)

--- a/test/unit/visualization/test_draw_chunk_timings.py
+++ b/test/unit/visualization/test_draw_chunk_timings.py
@@ -45,6 +45,7 @@ class TestDrawChunkTiming(IBMTestCase):
     """Tests for ``draw_chunk_timings`` and ``ChunkTiming``."""
 
     def setUp(self):
+        """Set up the test class."""
         self.chunk_timings = _make_chunk_timings()
 
     def test_len(self):

--- a/test/unit/visualization/test_draw_chunk_timings.py
+++ b/test/unit/visualization/test_draw_chunk_timings.py
@@ -19,7 +19,7 @@ import ddt
 from qiskit_ibm_runtime.quantum_program.quantum_program_result import (
     ChunkPart,
     ChunkSpan,
-    ChunkTimings,
+    ChunkTiming,
     Metadata,
     QuantumProgramResult,
 )
@@ -28,8 +28,8 @@ from qiskit_ibm_runtime.visualization import draw_chunk_timings
 from ...ibm_test_case import IBMTestCase
 
 
-def _make_chunk_timings(n: int = 5) -> ChunkTimings:
-    """Create a synthetic ChunkTimings with ``n`` chunks."""
+def _make_chunk_timings(n: int = 5) -> ChunkTiming:
+    """Create a synthetic ChunkTiming with ``n`` chunks."""
     t = datetime(year=2025, month=1, day=1)
     spans = []
     for i in range(n):
@@ -37,18 +37,18 @@ def _make_chunk_timings(n: int = 5) -> ChunkTimings:
         stop = start + timedelta(seconds=5 + i)
         parts = [ChunkPart(idx_item=i % 2, size=10 + i)]
         spans.append(ChunkSpan(start=start, stop=stop, parts=parts))
-    return ChunkTimings(spans)
+    return ChunkTiming(spans)
 
 
 @ddt.ddt
-class TestDrawChunkTimings(IBMTestCase):
-    """Tests for ``draw_chunk_timings`` and ``ChunkTimings``."""
+class TestDrawChunkTiming(IBMTestCase):
+    """Tests for ``draw_chunk_timings`` and ``ChunkTiming``."""
 
     def setUp(self):
         self.chunk_timings = _make_chunk_timings()
 
     def test_len(self):
-        """Assert ChunkTimings reports the number of spans it contains."""
+        """Assert ChunkTiming reports the number of spans it contains."""
         self.assertEqual(len(self.chunk_timings), 5)
 
     def test_getitem_int(self):
@@ -57,9 +57,9 @@ class TestDrawChunkTimings(IBMTestCase):
         self.assertIsInstance(item, ChunkSpan)
 
     def test_getitem_slice(self):
-        """Assert slice indexing returns a new ChunkTimings with the selected spans."""
+        """Assert slice indexing returns a new ChunkTiming with the selected spans."""
         sliced = self.chunk_timings[1:3]
-        self.assertIsInstance(sliced, ChunkTimings)
+        self.assertIsInstance(sliced, ChunkTiming)
         self.assertEqual(len(sliced), 2)
 
     def test_iter(self):
@@ -69,13 +69,13 @@ class TestDrawChunkTimings(IBMTestCase):
         self.assertTrue(all(isinstance(s, ChunkSpan) for s in items))
 
     def test_eq(self):
-        """Assert two ChunkTimings built from the same spans compare equal."""
+        """Assert two ChunkTiming built from the same spans compare equal."""
         other = _make_chunk_timings()
         self.assertEqual(self.chunk_timings, other)
 
     def test_repr(self):
         """Assert repr includes the class name."""
-        self.assertIn("ChunkTimings", repr(self.chunk_timings))
+        self.assertIn("ChunkTiming", repr(self.chunk_timings))
 
     def test_start_stop_duration(self):
         """Assert start and stop are datetimes and duration is positive."""
@@ -100,8 +100,8 @@ class TestDrawChunkTimings(IBMTestCase):
         self.save_plotly_artifact(fig)
 
     def test_draw_empty(self):
-        """Verify draw_chunk_timings handles an empty ChunkTimings without error."""
-        fig = draw_chunk_timings(ChunkTimings([]))
+        """Verify draw_chunk_timings handles an empty ChunkTiming without error."""
+        fig = draw_chunk_timings(ChunkTiming([]))
         self.save_plotly_artifact(fig)
 
     @ddt.data(
@@ -111,7 +111,7 @@ class TestDrawChunkTimings(IBMTestCase):
     )
     @ddt.unpack
     def test_two_chunk_timings(self, normalize_y, common_start, width, names):
-        """Verify draw_chunk_timings renders two ChunkTimings for cross-job comparison."""
+        """Verify draw_chunk_timings renders two ChunkTiming for cross-job comparison."""
         ct2 = _make_chunk_timings(n=3)
         fig = draw_chunk_timings(
             self.chunk_timings,
@@ -124,12 +124,12 @@ class TestDrawChunkTimings(IBMTestCase):
         self.save_plotly_artifact(fig)
 
     def test_draw_method(self):
-        """Verify ChunkTimings.draw() renders without error."""
+        """Verify ChunkTiming.draw() renders without error."""
         fig = self.chunk_timings.draw()
         self.save_plotly_artifact(fig)
 
     def test_draw_method_normalize_y(self):
-        """Verify ChunkTimings.draw() renders without error when normalize_y=True."""
+        """Verify ChunkTiming.draw() renders without error when normalize_y=True."""
         fig = self.chunk_timings.draw(normalize_y=True)
         self.save_plotly_artifact(fig)
 
@@ -137,13 +137,11 @@ class TestDrawChunkTimings(IBMTestCase):
         """Assert QuantumProgramResult.chunk_timings wraps the metadata spans."""
         metadata = Metadata(chunk_timing=list(self.chunk_timings))
         result = QuantumProgramResult(data=[], metadata=metadata)
-        ct = result.chunk_timings
-        self.assertIsInstance(ct, ChunkTimings)
-        self.assertEqual(len(ct), len(self.chunk_timings))
+        self.assertIsInstance(result.timing, ChunkTiming)
+        self.assertEqual(len(result.timing), len(self.chunk_timings))
 
     def test_result_chunk_timings_empty(self):
         """Assert QuantumProgramResult.chunk_timings is empty when no metadata spans are present."""
         result = QuantumProgramResult(data=[])
-        ct = result.chunk_timings
-        self.assertIsInstance(ct, ChunkTimings)
-        self.assertEqual(len(ct), 0)
+        self.assertIsInstance(result.timing, ChunkTiming)
+        self.assertEqual(len(result.timing), 0)

--- a/test/unit/visualization/test_draw_chunk_timings.py
+++ b/test/unit/visualization/test_draw_chunk_timings.py
@@ -1,0 +1,144 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for draw_chunk_timings."""
+
+from datetime import datetime, timedelta
+
+import ddt
+
+from qiskit_ibm_runtime.quantum_program.quantum_program_result import (
+    ChunkPart,
+    ChunkSpan,
+    ChunkTimings,
+    Metadata,
+    QuantumProgramResult,
+)
+from qiskit_ibm_runtime.visualization import draw_chunk_timings
+
+from ...ibm_test_case import IBMTestCase
+
+
+def _make_chunk_timings(n: int = 5) -> ChunkTimings:
+    """Create a synthetic ChunkTimings with ``n`` chunks."""
+    t = datetime(year=2025, month=1, day=1)
+    spans = []
+    for i in range(n):
+        start = t + timedelta(seconds=i * 10)
+        stop = start + timedelta(seconds=5 + i)
+        parts = [ChunkPart(idx_item=i % 2, size=10 + i)]
+        spans.append(ChunkSpan(start=start, stop=stop, parts=parts))
+    return ChunkTimings(spans)
+
+
+@ddt.ddt
+class TestDrawChunkTimings(IBMTestCase):
+    """Tests for ``draw_chunk_timings`` and ``ChunkTimings``."""
+
+    def setUp(self):
+        self.chunk_timings = _make_chunk_timings()
+
+    # --- sequence protocol ---
+
+    def test_len(self):
+        self.assertEqual(len(self.chunk_timings), 5)
+
+    def test_getitem_int(self):
+        item = self.chunk_timings[0]
+        self.assertIsInstance(item, ChunkSpan)
+
+    def test_getitem_slice(self):
+        sliced = self.chunk_timings[1:3]
+        self.assertIsInstance(sliced, ChunkTimings)
+        self.assertEqual(len(sliced), 2)
+
+    def test_iter(self):
+        items = list(self.chunk_timings)
+        self.assertEqual(len(items), 5)
+        self.assertTrue(all(isinstance(s, ChunkSpan) for s in items))
+
+    def test_eq(self):
+        other = _make_chunk_timings()
+        self.assertEqual(self.chunk_timings, other)
+
+    def test_repr(self):
+        self.assertIn("ChunkTimings", repr(self.chunk_timings))
+
+    # --- properties ---
+
+    def test_start_stop_duration(self):
+        self.assertIsInstance(self.chunk_timings.start, datetime)
+        self.assertIsInstance(self.chunk_timings.stop, datetime)
+        self.assertGreater(self.chunk_timings.duration, 0)
+
+    # --- draw_chunk_timings function ---
+
+    @ddt.data(False, True)
+    def test_draw_normalize_y(self, normalize_y):
+        fig = draw_chunk_timings(self.chunk_timings, normalize_y=normalize_y)
+        self.save_plotly_artifact(fig)
+
+    def test_draw_common_start(self):
+        fig = draw_chunk_timings(self.chunk_timings, common_start=True)
+        self.save_plotly_artifact(fig)
+
+    def test_draw_with_name(self):
+        fig = draw_chunk_timings(self.chunk_timings, names="my_job")
+        self.save_plotly_artifact(fig)
+
+    def test_draw_empty(self):
+        fig = draw_chunk_timings(ChunkTimings([]))
+        self.save_plotly_artifact(fig)
+
+    @ddt.data(
+        (False, False, 4, None),
+        (True, True, 8, "alpha"),
+        (True, False, 4, ["alpha", "beta"]),
+    )
+    @ddt.unpack
+    def test_two_chunk_timings(self, normalize_y, common_start, width, names):
+        """Test with two ChunkTimings for cross-job comparison."""
+        ct2 = _make_chunk_timings(n=3)
+        fig = draw_chunk_timings(
+            self.chunk_timings,
+            ct2,
+            normalize_y=normalize_y,
+            common_start=common_start,
+            line_width=width,
+            names=names,
+        )
+        self.save_plotly_artifact(fig)
+
+    # --- ChunkTimings.draw convenience method ---
+
+    def test_draw_method(self):
+        fig = self.chunk_timings.draw()
+        self.save_plotly_artifact(fig)
+
+    def test_draw_method_normalize_y(self):
+        fig = self.chunk_timings.draw(normalize_y=True)
+        self.save_plotly_artifact(fig)
+
+    # --- QuantumProgramResult.chunk_timings property ---
+
+    def test_result_chunk_timings_property(self):
+        metadata = Metadata(chunk_timing=list(self.chunk_timings))
+        result = QuantumProgramResult(data=[], metadata=metadata)
+        ct = result.chunk_timings
+        self.assertIsInstance(ct, ChunkTimings)
+        self.assertEqual(len(ct), len(self.chunk_timings))
+
+    def test_result_chunk_timings_empty(self):
+        result = QuantumProgramResult(data=[])
+        ct = result.chunk_timings
+        self.assertIsInstance(ct, ChunkTimings)
+        self.assertEqual(len(ct), 0)

--- a/test/unit/visualization/test_draw_chunk_timings.py
+++ b/test/unit/visualization/test_draw_chunk_timings.py
@@ -47,55 +47,60 @@ class TestDrawChunkTimings(IBMTestCase):
     def setUp(self):
         self.chunk_timings = _make_chunk_timings()
 
-    # --- sequence protocol ---
-
     def test_len(self):
+        """Assert ChunkTimings reports the number of spans it contains."""
         self.assertEqual(len(self.chunk_timings), 5)
 
     def test_getitem_int(self):
+        """Assert integer indexing returns a ChunkSpan."""
         item = self.chunk_timings[0]
         self.assertIsInstance(item, ChunkSpan)
 
     def test_getitem_slice(self):
+        """Assert slice indexing returns a new ChunkTimings with the selected spans."""
         sliced = self.chunk_timings[1:3]
         self.assertIsInstance(sliced, ChunkTimings)
         self.assertEqual(len(sliced), 2)
 
     def test_iter(self):
+        """Assert iteration yields all ChunkSpan objects."""
         items = list(self.chunk_timings)
         self.assertEqual(len(items), 5)
         self.assertTrue(all(isinstance(s, ChunkSpan) for s in items))
 
     def test_eq(self):
+        """Assert two ChunkTimings built from the same spans compare equal."""
         other = _make_chunk_timings()
         self.assertEqual(self.chunk_timings, other)
 
     def test_repr(self):
+        """Assert repr includes the class name."""
         self.assertIn("ChunkTimings", repr(self.chunk_timings))
 
-    # --- properties ---
-
     def test_start_stop_duration(self):
+        """Assert start and stop are datetimes and duration is positive."""
         self.assertIsInstance(self.chunk_timings.start, datetime)
         self.assertIsInstance(self.chunk_timings.stop, datetime)
         self.assertGreater(self.chunk_timings.duration, 0)
 
-    # --- draw_chunk_timings function ---
-
     @ddt.data(False, True)
     def test_draw_normalize_y(self, normalize_y):
+        """Verify draw_chunk_timings renders without error with normalize_y on and off."""
         fig = draw_chunk_timings(self.chunk_timings, normalize_y=normalize_y)
         self.save_plotly_artifact(fig)
 
     def test_draw_common_start(self):
+        """Verify draw_chunk_timings renders without error when common_start=True."""
         fig = draw_chunk_timings(self.chunk_timings, common_start=True)
         self.save_plotly_artifact(fig)
 
     def test_draw_with_name(self):
+        """Verify draw_chunk_timings renders without error when a name is provided."""
         fig = draw_chunk_timings(self.chunk_timings, names="my_job")
         self.save_plotly_artifact(fig)
 
     def test_draw_empty(self):
+        """Verify draw_chunk_timings handles an empty ChunkTimings without error."""
         fig = draw_chunk_timings(ChunkTimings([]))
         self.save_plotly_artifact(fig)
 
@@ -106,7 +111,7 @@ class TestDrawChunkTimings(IBMTestCase):
     )
     @ddt.unpack
     def test_two_chunk_timings(self, normalize_y, common_start, width, names):
-        """Test with two ChunkTimings for cross-job comparison."""
+        """Verify draw_chunk_timings renders two ChunkTimings for cross-job comparison."""
         ct2 = _make_chunk_timings(n=3)
         fig = draw_chunk_timings(
             self.chunk_timings,
@@ -118,19 +123,18 @@ class TestDrawChunkTimings(IBMTestCase):
         )
         self.save_plotly_artifact(fig)
 
-    # --- ChunkTimings.draw convenience method ---
-
     def test_draw_method(self):
+        """Verify ChunkTimings.draw() renders without error."""
         fig = self.chunk_timings.draw()
         self.save_plotly_artifact(fig)
 
     def test_draw_method_normalize_y(self):
+        """Verify ChunkTimings.draw() renders without error when normalize_y=True."""
         fig = self.chunk_timings.draw(normalize_y=True)
         self.save_plotly_artifact(fig)
 
-    # --- QuantumProgramResult.chunk_timings property ---
-
     def test_result_chunk_timings_property(self):
+        """Assert QuantumProgramResult.chunk_timings wraps the metadata spans."""
         metadata = Metadata(chunk_timing=list(self.chunk_timings))
         result = QuantumProgramResult(data=[], metadata=metadata)
         ct = result.chunk_timings
@@ -138,6 +142,7 @@ class TestDrawChunkTimings(IBMTestCase):
         self.assertEqual(len(ct), len(self.chunk_timings))
 
     def test_result_chunk_timings_empty(self):
+        """Assert QuantumProgramResult.chunk_timings is empty when no metadata spans are present."""
         result = QuantumProgramResult(data=[])
         ct = result.chunk_timings
         self.assertIsInstance(ct, ChunkTimings)


### PR DESCRIPTION


<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR closes #2701 by adding `ChunkTimings` class with a draw method that points to a new function in `.visualization`. The implementation closely mirrors that for `ExecutionSpans`.

### Details and comments

AI tools used: claude opus+sonnet 4.6

Consider:

```python
from qiskit.circuit import QuantumCircuit, Parameter
from qiskit_ibm_runtime import QuantumProgram, QiskitRuntimeService, Executor
import numpy as np

service = QiskitRuntimeService(name="prod")
backend = service.backend('ibm_aachen')

circuit = QuantumCircuit(1)
circuit.rz(Parameter("a") + 1.0, 0)
circuit.measure_all()

program = QuantumProgram(shots=100)
program.append_circuit_item(circuit, circuit_arguments=np.linspace(0, 1, 1000).reshape(-1, 1), chunk_size=30)
program.append_circuit_item(circuit, circuit_arguments=np.linspace(0, 1, 50).reshape(-1, 1), chunk_size=2)

executor = Executor(backend)
job1 = executor.run(program)
job2 = executor.run(program)
```

Then we can do things like
<img width="968" height="789" alt="image" src="https://github.com/user-attachments/assets/07bce58c-1951-4896-9343-da33945b2b5a" />

and
<img width="962" height="783" alt="image" src="https://github.com/user-attachments/assets/0abf9a2d-2c5f-4005-98e3-0baef19da57b" />

and 
<img width="970" height="842" alt="image" src="https://github.com/user-attachments/assets/e089b429-87e8-4a75-8288-c1afc05c0a1d" />


and 


<img width="957" height="967" alt="image" src="https://github.com/user-attachments/assets/287b91d9-2a03-4221-be5e-83021a620857" />
