### PR TITLE
Add git blame ignore file, revise contribution guide

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# https://github.com/Qiskit/qiskit-ibm-runtime/pull/2495
+1dc1d6fd9ce3f8cb9a749335f845a495a23fbea1
+# https://github.com/Qiskit/qiskit-ibm-runtime/pull/2518
+cd49da0bfb406f3cfdaa54b9d498c44e458422ec
+# https://github.com/Qiskit/qiskit-ibm-runtime/pull/2635
+f1647a17f0572943654af083b6460895c8b5565e
+# https://github.com/Qiskit/qiskit-ibm-runtime/pull/2700
+a80f801bf2107b0033f51ac22eba3be403e7476f
+# https://github.com/Qiskit/qiskit-ibm-runtime/pull/2726
+15faca792e59d34b93d51d4fc8935ccd30a0bd8c

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,7 +262,6 @@ make benchmark
 Please submit clean code and please make effort to follow existing conventions in order to keep it
 as readable as possible. We use:
 
-* [black] as the tool for ensuring consistent code formatting
 * [ruff] as a linter providing deeper analysis for potential style and functionality issues, as
   well as conformance to good practices
 * [mypy] as a static type checker for type hinting
@@ -282,7 +281,7 @@ pre-commit run
 ```
 
 This will run the tools against your staged changes, and will automatically update your code to
-conform to the style in some instances (for the `black` and a subset of the `ruff` issues). For
+conform to the style in some instances (for example, a subset of the `ruff` issues). For
 other errors, you will have to fix the issues manually by updating your code, and re-run again.
 Please refer to the tools' documentation for more information on running them manually and
 customizing your workflow if needed.
@@ -297,6 +296,15 @@ make docs-test
 
 This test also runs on CI and will fail if Vale encounters any spelling mistakes. To add a word to
 the dictionary, add it to `test/docs/dictionary.txt`.
+
+### Using the `git blame` ignored revisions list
+
+This repository contains a list of commits for `git blame` to ignore: commits that are style or
+linting changes that affect formatting, and thus tend to be disruptive when comparing changes in
+the repository history. When issuing a PR that contains a significant amount of style changes,
+please update the `.git-blame-ignore-revs` file adding an entry to the end of the file, and a
+comment pointing to the pull request. Please check the [Ignore commits in the blame view]
+GitHub documentation for instructions on using the ignore list locally and for general information.
 
 ### Development Cycle
 
@@ -357,7 +365,6 @@ qiskit-bot should also automatically create the GitHub Release for you.
 Finally, you need to cherry-pick the release notes prep from `stable/*` to
 the `main` branch, such as from `stable/0.21` to `main`.
 
-[black]: https://github.com/psf/black
 [ruff]: https://github.com/astral-sh/ruff
 [mypy]: http://mypy-lang.org/
 [pytest]: https://pytest.org/
@@ -366,3 +373,4 @@ the `main` branch, such as from `stable/0.21` to `main`.
 [encrypted environment secrets]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment
 [IBM Quantum's writing style guide]: https://github.com/IBM/ibm-quantum-style-guide
 [pyproject.toml]: ./pyproject.toml
+[Ignore commits in the blame view]: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,6 @@
 requires = ["setuptools >= 65.0.2", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 100
-target-version = ['py310', 'py311', 'py312', 'py313']
-
 [tool.towncrier]
 single_file = false
 filename = "release-notes/{version}.rst"
@@ -181,7 +177,6 @@ common = [
     "nbformat>=4.4.0",
     "nbconvert>=5.3.1",
     "qiskit-aer>=0.17.0",
-    "black~=24.1",
     "ruff~=0.14.10",
     "coverage>=6.3",
     "pylatexenc",
@@ -227,7 +222,6 @@ style = [
 ]
 
 style_local = [
-    "black~=24.1",
     "mypy==1.19.0",
     "ruff~=0.14.10",
 ]


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As we had a number of noisy lint/style PRs, add a `.git-blame-ignore-revs` for more convenient tracing of changes in the GitHub interface (and optionally locally). Some of the commits in the list _do_ contain non-style changes (for example, updates to `pyproject.toml` as part of the `ruff` rules enabled): even if this will hide those changes in the interface, the amount of style changes contained in them is significant enough to prefer including them (putting the priority in frequent diffing over the Python files).

Additionally, this PR also fixes some lingering references to `black` that are no longer needed/accurate since #2726.

### Details and comments

Small follow-up to #2726 (taking care of references to `black` that should have been dropped during that PR)
