### PR TITLE
Avoid @property in Executor and NoiseLearnerV3, and other cleanups

### DIFF
--- a/qiskit_ibm_runtime/constants.py
+++ b/qiskit_ibm_runtime/constants.py
@@ -44,9 +44,3 @@ DEFAULT_DECODERS: dict[str, type[ResultDecoder] | list[type[ResultDecoder]]] = {
     "circuit-runner": RunnerResult,
     "qasm3-runner": RunnerResult,
 }
-
-DEFAULT_POST_SELECTION_SUFFIX = "_ps"
-"""The default suffix to append to the names of the classical registers used for post selection."""
-
-DEFAULT_SPECTATOR_CREG_NAME = "spec"
-"""The default name of the classical register used for measuring spectator qubits."""

--- a/qiskit_ibm_runtime/executor.py
+++ b/qiskit_ibm_runtime/executor.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 import logging
+from typing import Any
 
 from ibm_quantum_schemas.common import BaseParamsModel
 
@@ -81,31 +82,36 @@ class Executor:
     _PROGRAM_ID = "executor"
     _DECODER = QuantumProgramResultDecoder
 
+    options: ExecutorOptions
+    """The options of this executor."""
+
     def __init__(
         self,
         mode: IBMBackend | Session | Batch | None,
         *,
         options: ExecutorOptions | dict | None = None,
     ):
-        self.options = options if options is not None else ExecutorOptions()
+        # Coerced to `ExecutorOptions` via `__setattr__()`.
+        self.options = options if options is not None else ExecutorOptions()  # type: ignore[assignment]
 
         self._session, self._service, self._backend = get_mode_service_backend(mode)
         if isinstance(self._service, QiskitRuntimeLocalService):
             raise ValueError("The executor is currently not supported in local mode.")
 
-    @property
-    def options(self) -> ExecutorOptions:
-        """The options of this executor."""
-        return self._options
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Set attribute ``name`` to ``value``.
 
-    @options.setter
-    def options(self, options: ExecutorOptions | dict) -> None:
-        if isinstance(options, dict):
-            self._options = ExecutorOptions(**options)
-        elif isinstance(options, ExecutorOptions):
-            self._options = options
-        else:
-            raise TypeError(f"Expected ExecutorOptions or dict, got {type(options)}")
+        Handle ``options`` as a special case, ensuring it is set to an ``ExecutorOptions`` instance.
+        This is an alternative to using ``@setter``, as the setter causes issues in ``ipython``
+        autocomplete features.
+        """
+        if name == "options":
+            if isinstance(value, dict):
+                value = ExecutorOptions(**value)
+            elif not isinstance(value, ExecutorOptions):
+                raise TypeError(f"Expected ExecutorOptions or dict, got {type(value)}")
+
+        super().__setattr__(name, value)
 
     def _runtime_options(self) -> RuntimeOptions:
         return RuntimeOptions(

--- a/qiskit_ibm_runtime/executor.py
+++ b/qiskit_ibm_runtime/executor.py
@@ -16,22 +16,24 @@ from __future__ import annotations
 
 from dataclasses import asdict
 import logging
-from typing import Any
-
-from ibm_quantum_schemas.common import BaseParamsModel
+from typing import Any, TYPE_CHECKING
 
 from qiskit_ibm_runtime.base_primitive import get_mode_service_backend
 from qiskit_ibm_runtime.fake_provider.local_service import QiskitRuntimeLocalService
-from .ibm_backend import IBMBackend
-from .session import Session
-from .batch import Batch
 from .options.executor_options import ExecutorOptions
-from .quantum_program import QuantumProgram
 from .quantum_program.result_decoders import QuantumProgramResultDecoder
 from .quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
-from .runtime_job_v2 import RuntimeJobV2
 from .runtime_options import RuntimeOptions
 from .utils.default_session import get_cm_session
+
+if TYPE_CHECKING:
+    from ibm_quantum_schemas.common import BaseParamsModel
+    from .batch import Batch
+    from .session import Session
+    from .ibm_backend import IBMBackend
+    from .runtime_job_v2 import RuntimeJobV2
+    from .quantum_program import QuantumProgram
+
 
 logger = logging.getLogger()
 

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -71,27 +71,25 @@ class NoiseLearnerV3:
     _PROGRAM_ID = "noise-learner"
     _DECODER = NoiseLearnerV3ResultDecoder
 
+    options: NoiseLearnerV3Options
+    """The options in this noise learner."""
+
     def __init__(
         self,
         mode: BackendV2 | Session | Batch | None = None,
         options: NoiseLearnerV3Options | None = None,
     ):
-        self._options = options or NoiseLearnerV3Options()
+        self.options = options or NoiseLearnerV3Options()
         if (
-            isinstance(self._options.experimental, UnsetType)
-            or self._options.experimental.get("image") is None
+            isinstance(self.options.experimental, UnsetType)
+            or self.options.experimental.get("image") is None
         ):
-            self._options.experimental = {}
+            self.options.experimental = {}
 
         self._session, self._service, self._backend = get_mode_service_backend(mode)  # type: ignore[assignment]
 
         if isinstance(self._service, QiskitRuntimeLocalService):  # type: ignore[unreachable]
             raise ValueError("``NoiseLearnerV3`` is currently not supported in local mode.")
-
-    @property
-    def options(self) -> NoiseLearnerV3Options:
-        """The options in this noise learner."""
-        return self._options
 
     def run(self, instructions: Iterable[CircuitInstruction]) -> RuntimeJobV2:
         """Submit a request to the noise learner program.

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -85,19 +85,19 @@ class NoiseLearnerV3:
         ):
             self.options.experimental = {}
 
-        self._session, self._service, self._backend = get_mode_service_backend(mode)  # type: ignore[assignment]
+        self._session, self._service, self._backend = get_mode_service_backend(mode)
 
-        if isinstance(self._service, QiskitRuntimeLocalService):  # type: ignore[unreachable]
+        if isinstance(self._service, QiskitRuntimeLocalService):
             raise ValueError("``NoiseLearnerV3`` is currently not supported in local mode.")
 
     def run(self, instructions: Iterable[CircuitInstruction]) -> RuntimeJobV2:
         """Submit a request to the noise learner program.
 
         Args:
-                instructions: The instructions to learn the noise of.
+            instructions: The instructions to learn the noise of.
 
         Returns:
-                The submitted job.
+            The submitted job.
 
         Raises:
             IBMInputValueError: If an instruction does not contain a box.

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -15,24 +15,23 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
-
-from qiskit.circuit import CircuitInstruction
-from qiskit.providers import BackendV2
 
 from qiskit_ibm_runtime.options.utils import UnsetType
 
 from ..base_primitive import get_mode_service_backend
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options.noise_learner_v3_options import NoiseLearnerV3Options
-from ..runtime_job_v2 import RuntimeJobV2
 from ..utils.default_session import get_cm_session
 from .converters.version_0_1 import noise_learner_v3_inputs_to_0_1
 from .noise_learner_v3_decoders import NoiseLearnerV3ResultDecoder
 from .validation import validate_instruction, validate_options
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from qiskit.circuit import CircuitInstruction
+    from qiskit.providers import BackendV2
+    from ..runtime_job_v2 import RuntimeJobV2
     from ..batch import Batch
     from ..session import Session
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Prefer `__setattr__` as the way to enforce specific checks when setting `Executor.options`, and directly expose `NoiseLearnerV3.options` as a regular field (instead of via a `@property`). This hopefully fix the issues with auto-complete in `ipython` (they seem to currently working in a regular `python` terminal, though), and makes the usage of `.options` a bit more homogeneous (both can be replaced directly by setting the attribute, and both can be mutated by the user).

Additionally, this PR removes a couple of executor-related leftovers in `constant.py`, and makes active use of `if TYPE_CHECKING` (related to #2563) in both files to better behave when it comes to imports.

### Details and comments

Fixes #2719

Tested the auto-completion bits with `ipython`. 
