### PR TITLE
Bump schemas dependency to >=0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dependencies = [
     "urllib3>=2.4.0",
     "python-dateutil>=2.9.0",
     "ibm-platform-services>=0.61.1",
-    "ibm-quantum-schemas==0.7rc1",
+    "ibm-quantum-schemas>=0.7.20260419,<1",
     "pydantic>=2.7.0",
     "qiskit>=2.2.0",
     "pybase64>=1.4",


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Bump the `ibm-quantum-schemas` dependency to the latest released package.


### Details and comments
Related to #2743 
