### PR TITLE
Make `job.inputs` return decoded objects in NLV3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ To enable test cases against external system in your private fork, make sure to 
 
 For example, in your github fork settings, add the environment you want to run tests on
 (`ibm-cloud-production`, `ibm-cloud-staging`). Then add the appropriate environment secrets
-(`QISKIT_IBM_INSTANCE`, `QISKIT_IBM_TOKEN`, `QISKIT_IBM_URL`, `QISKIT_IBM_DEVICE`).
+(`QISKIT_IBM_INSTANCE`, `QISKIT_IBM_TOKEN`, `QISKIT_IBM_URL`, `QISKIT_IBM_QPU`).
 
 #### Benchmarking
 

--- a/qiskit_ibm_runtime/noise_learner_v3/converters/__init__.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/converters/__init__.py
@@ -22,5 +22,5 @@ from .version_0_2 import (
     noise_learner_v3_inputs_from_0_2,
     noise_learner_v3_inputs_to_0_2,
     noise_learner_v3_result_from_0_2,
-    noise_learner_v3_result_to_0_2
+    noise_learner_v3_result_to_0_2,
 )

--- a/qiskit_ibm_runtime/noise_learner_v3/converters/__init__.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/converters/__init__.py
@@ -10,4 +10,17 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Transport conversion functions."""
+"""Converters for NLV3."""
+
+from .version_0_1 import (
+    noise_learner_v3_inputs_to_0_1,
+    noise_learner_v3_inputs_from_0_1,
+    noise_learner_v3_result_from_0_1,
+    noise_learner_v3_result_to_0_1,
+)
+from .version_0_2 import (
+    noise_learner_v3_inputs_from_0_2,
+    noise_learner_v3_inputs_to_0_2,
+    noise_learner_v3_result_from_0_2,
+    noise_learner_v3_result_to_0_2
+)

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -80,7 +80,10 @@ class NoiseLearnerV3:
         options: NoiseLearnerV3Options | None = None,
     ):
         self._options = options or NoiseLearnerV3Options()
-        if self._options.experimental.get("image") is None:
+        if (
+            isinstance(self._options.experimental, UnsetType)
+            or self._options.experimental.get("image") is None
+        ):
             self._options.experimental = {}
 
         self._session, self._service, self._backend = get_mode_service_backend(mode)  # type: ignore[assignment]

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -128,7 +128,7 @@ class NoiseLearnerV3:
             raise ValueError(f"No converters for schema version {DEFAULT_SCHEMA_VERSION}.")
 
         inputs = converter.encoder(instructions, self.options).model_dump()
-        inputs["version"] = 3  # TODO: this is a work-around for the dispatch
+        inputs["version"] = 3
         runtime_options = self.options.to_runtime_options()
         runtime_options["backend"] = self._backend.name
 

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -28,7 +28,7 @@ from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options.noise_learner_v3_options import NoiseLearnerV3Options
 from ..runtime_job_v2 import RuntimeJobV2
 from ..utils.default_session import get_cm_session
-from .converters.version_0_1 import noise_learner_v3_inputs_to_0_1
+from .params_converters import NOISE_LEARNER_V3_PARAMS_CONVERTERS
 from .noise_learner_v3_decoders import NoiseLearnerV3ResultDecoder
 from .validation import validate_instruction, validate_options
 
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
     from ..session import Session
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_SCHEMA_VERSION = "v0.1"
+"""The schema version used by default by NLV3 to encode the input params."""
 
 
 class NoiseLearnerV3:
@@ -77,10 +80,7 @@ class NoiseLearnerV3:
         options: NoiseLearnerV3Options | None = None,
     ):
         self._options = options or NoiseLearnerV3Options()
-        if (
-            isinstance(self._options.experimental, UnsetType)
-            or self._options.experimental.get("image") is None
-        ):
+        if self._options.experimental.get("image") is None:
             self._options.experimental = {}
 
         self._session, self._service, self._backend = get_mode_service_backend(mode)  # type: ignore[assignment]
@@ -119,7 +119,12 @@ class NoiseLearnerV3:
         if configuration := getattr(self._backend, "configuration", None):
             validate_options(self.options, configuration())
 
-        inputs = noise_learner_v3_inputs_to_0_1(instructions, self.options).model_dump()
+        try:
+            converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[DEFAULT_SCHEMA_VERSION]
+        except KeyError:
+            raise ValueError(f"No converters for schema version {DEFAULT_SCHEMA_VERSION}.")
+
+        inputs = converter.encoder(instructions, self.options).model_dump()
         inputs["version"] = 3  # TODO: this is a work-around for the dispatch
         runtime_options = self.options.to_runtime_options()
         runtime_options["backend"] = self._backend.name

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from typing import NamedTuple, Type, TYPE_CHECKING
+from typing import NamedTuple, TYPE_CHECKING
 
 from ibm_quantum_schemas.common import BaseParamsModel
 from ibm_quantum_schemas.noise_learner_v3.version_0_1 import ParamsModel as ParamsModel_0_1
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 class ParamsConverter(NamedTuple):
     """A helper to store params models and converters."""
 
-    model: Type[BaseParamsModel]
+    model: type[BaseParamsModel]
     """The model describing the NLV3 inputs, or 'params'."""
 
     decoder: Callable[[BaseParamsModel], tuple[Iterable[CircuitInstruction], NoiseLearnerV3Options]]

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -40,7 +40,7 @@ class ParamsConverter(NamedTuple):
     model: type[BaseParamsModel]
     """The model describing the NLV3 inputs, or 'params'."""
 
-    decoder: Callable[[BaseParamsModel], tuple[Iterable[CircuitInstruction], NoiseLearnerV3Options]]
+    decoder: Callable[[BaseParamsModel], tuple[list[CircuitInstruction], NoiseLearnerV3Options]]
     """A function to decode the inputs of NLV3."""
 
     encoder: Callable[[Iterable[CircuitInstruction], NoiseLearnerV3Options], BaseParamsModel]

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -48,7 +48,7 @@ class ParamsConverter(NamedTuple):
     """A function to encode the inputs of NLV3."""
 
 
-QUANTUM_PROGRAM_PARAMS_CONVERTERS = {
+NOISE_LEARNER_V3_PARAMS_CONVERTERS = {
     "v0.1": ParamsConverter(ParamsModel_0_1, noise_learner_v3_inputs_from_0_1, noise_learner_v3_inputs_to_0_1),
     "v0.2": ParamsConverter(ParamsModel_0_2, noise_learner_v3_inputs_from_0_2, noise_learner_v3_inputs_to_0_2),
 }

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from typing import NamedTuple, TYPE_CHECKING
+from typing import NamedTuple, Type, TYPE_CHECKING
 
 from ibm_quantum_schemas.common import BaseParamsModel
 from ibm_quantum_schemas.noise_learner_v3.version_0_1 import ParamsModel as ParamsModel_0_1
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 class ParamsConverter(NamedTuple):
     """A helper to store params models and converters."""
 
-    model: BaseParamsModel
+    model: Type[BaseParamsModel]
     """The model describing the NLV3 inputs, or 'params'."""
 
     decoder: Callable[[BaseParamsModel], tuple[Iterable[CircuitInstruction], NoiseLearnerV3Options]]

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -1,0 +1,55 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Converters for NLV3 params."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import NamedTuple, TYPE_CHECKING
+
+from ibm_quantum_schemas.common import BaseParamsModel
+from ibm_quantum_schemas.noise_learner_v3.version_0_1 import ParamsModel as ParamsModel_0_1
+from ibm_quantum_schemas.noise_learner_v3.version_0_2 import ParamsModel as ParamsModel_0_2
+from ibm_quantum_schemas.noise_learner_v3.version_1_0 import ParamsModel as ParamsModel_1_0
+
+
+from .converters import (
+    noise_learner_v3_inputs_from_0_1,
+    noise_learner_v3_inputs_to_0_1,
+    noise_learner_v3_inputs_from_0_2,
+    noise_learner_v3_inputs_to_0_2,
+)
+
+if TYPE_CHECKING:
+    from qiskit.circuit import CircuitInstruction
+    from qiskit_ibm_runtime.options import NoiseLearnerV3Options
+
+
+class ParamsConverter(NamedTuple):
+    """A helper to store params models and converters."""
+
+    model: BaseParamsModel
+    """The model describing the NLV3 inputs, or 'params'."""
+
+    decoder: Callable[[BaseParamsModel], tuple[Iterable[CircuitInstruction], NoiseLearnerV3Options]]
+    """A function to decode the inputs of NLV3."""
+
+    encoder: Callable[[Iterable[CircuitInstruction], NoiseLearnerV3Options], BaseParamsModel]
+    """A function to encode the inputs of NLV3."""
+
+
+QUANTUM_PROGRAM_PARAMS_CONVERTERS = {
+    "v0.1": ParamsConverter(ParamsModel_0_1, noise_learner_v3_inputs_from_0_1, noise_learner_v3_inputs_to_0_1),
+    "v0.2": ParamsConverter(ParamsModel_0_2, noise_learner_v3_inputs_from_0_2, noise_learner_v3_inputs_to_0_2),
+}
+"""Converter to/from schema model for the inputs of NLV3."""

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -20,7 +20,6 @@ from typing import NamedTuple, TYPE_CHECKING
 from ibm_quantum_schemas.common import BaseParamsModel
 from ibm_quantum_schemas.noise_learner_v3.version_0_1 import ParamsModel as ParamsModel_0_1
 from ibm_quantum_schemas.noise_learner_v3.version_0_2 import ParamsModel as ParamsModel_0_2
-from ibm_quantum_schemas.noise_learner_v3.version_1_0 import ParamsModel as ParamsModel_1_0
 
 
 from .converters import (

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -48,7 +48,11 @@ class ParamsConverter(NamedTuple):
 
 
 NOISE_LEARNER_V3_PARAMS_CONVERTERS = {
-    "v0.1": ParamsConverter(ParamsModel_0_1, noise_learner_v3_inputs_from_0_1, noise_learner_v3_inputs_to_0_1),
-    "v0.2": ParamsConverter(ParamsModel_0_2, noise_learner_v3_inputs_from_0_2, noise_learner_v3_inputs_to_0_2),
+    "v0.1": ParamsConverter(
+        ParamsModel_0_1, noise_learner_v3_inputs_from_0_1, noise_learner_v3_inputs_to_0_1
+    ),
+    "v0.2": ParamsConverter(
+        ParamsModel_0_2, noise_learner_v3_inputs_from_0_2, noise_learner_v3_inputs_to_0_2
+    ),
 }
 """Converter to/from schema model for the inputs of NLV3."""

--- a/qiskit_ibm_runtime/options/noise_learner_v3_options.py
+++ b/qiskit_ibm_runtime/options/noise_learner_v3_options.py
@@ -89,7 +89,7 @@ class NoiseLearnerV3Options(BaseOptions):
     """Options for post selecting the results of noise learning circuits.
     """
 
-    experimental: UnsetType | dict = Unset
+    experimental: dict = Field(default_factory=dict)
     """Experimental options.
 
     These options are subject to change without notification, and stability is not guaranteed.

--- a/qiskit_ibm_runtime/options/noise_learner_v3_options.py
+++ b/qiskit_ibm_runtime/options/noise_learner_v3_options.py
@@ -89,7 +89,7 @@ class NoiseLearnerV3Options(BaseOptions):
     """Options for post selecting the results of noise learning circuits.
     """
 
-    experimental: dict = Field(default_factory=dict)
+    experimental: UnsetType | dict = Unset
     """Experimental options.
 
     These options are subject to change without notification, and stability is not guaranteed.

--- a/qiskit_ibm_runtime/quantum_program/params_converters.py
+++ b/qiskit_ibm_runtime/quantum_program/params_converters.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import NamedTuple, TYPE_CHECKING
+from typing import NamedTuple, Type, TYPE_CHECKING
 
 from ibm_quantum_schemas.common import BaseParamsModel
 from ibm_quantum_schemas.executor.version_0_1 import ParamsModel as ParamsModel_0_1
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 class ParamsConverter(NamedTuple):
     """A helper to store params models and converters."""
 
-    model: BaseParamsModel
+    model: Type[BaseParamsModel]
     """The model describing the executor inputs, or 'params'."""
 
     decoder: Callable[[BaseParamsModel], tuple[QuantumProgram, ExecutorOptions]]

--- a/qiskit_ibm_runtime/quantum_program/params_converters.py
+++ b/qiskit_ibm_runtime/quantum_program/params_converters.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import NamedTuple, Type, TYPE_CHECKING
+from typing import NamedTuple, TYPE_CHECKING
 
 from ibm_quantum_schemas.common import BaseParamsModel
 from ibm_quantum_schemas.executor.version_0_1 import ParamsModel as ParamsModel_0_1
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 class ParamsConverter(NamedTuple):
     """A helper to store params models and converters."""
 
-    model: Type[BaseParamsModel]
+    model: type[BaseParamsModel]
     """The model describing the executor inputs, or 'params'."""
 
     decoder: Callable[[BaseParamsModel], tuple[QuantumProgram, ExecutorOptions]]

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -32,7 +32,6 @@ from qiskit_ibm_runtime.quantum_program.params_converters import (
     QUANTUM_PROGRAM_PARAMS_CONVERTERS,
 )
 
-
 try:
     from qiskit.quantum_info import PauliLindbladMap
 

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -451,17 +451,16 @@ class RuntimeDecoder(json.JSONDecoder):
                 # `decoded` represents the input to an executor program. We use the converters to
                 # decode its inputs, or 'params'
                 try:
-                    qp_converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[params["schema_version"]]
-                    quantum_program, qp_options = qp_converter.decoder(qp_converter.model(**params))
+                    converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[params["schema_version"]]
+                    quantum_program, options = converter.decoder(converter.model(**params))
                     decoded["params"]["quantum_program"] = quantum_program
-                    decoded["params"]["options"] = qp_options
+                    decoded["params"]["options"] = options
                 except Exception as exception:
                     warnings.warn(
                         "Unable to convert executor 'params' to a pair of quantum program and "
                         f"options due to the following exception: {exception}"
                     )
-
-            if program_id == "noise-learner" and params and "schema_version" in params:
+            elif program_id == "noise-learner" and params and "schema_version" in params:
                 # `decoded` represents the input to an NLV3 program. We use the converters to
                 # decode its inputs, or 'params'
                 try:
@@ -471,10 +470,10 @@ class RuntimeDecoder(json.JSONDecoder):
                         NOISE_LEARNER_V3_PARAMS_CONVERTERS,
                     )
 
-                    nl_converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
-                    instructions, nl_options = nl_converter.decoder(nl_converter.model(**params))
+                    converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
+                    instructions, options = converter.decoder(converter.model(**params))
                     decoded["params"]["instructions"] = instructions
-                    decoded["params"]["options"] = nl_options
+                    decoded["params"]["options"] = options
                 except Exception as exception:
                     warnings.warn(
                         "Unable to convert NLV3 'params' to a pair of instructions and "

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -470,8 +470,8 @@ class RuntimeDecoder(json.JSONDecoder):
                         NOISE_LEARNER_V3_PARAMS_CONVERTERS,
                     )
 
-                    converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
-                    instructions, options = converter.decoder(converter.model(**params))
+                    converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]  # type: ignore[assignment]
+                    instructions, options = converter.decoder(converter.model(**params))  # type: ignore[assignment]
                     decoded["params"]["instructions"] = instructions
                     decoded["params"]["options"] = options
                 except Exception as exception:

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -451,8 +451,8 @@ class RuntimeDecoder(json.JSONDecoder):
                 # `decoded` represents the input to an executor program. We use the converters to
                 # decode its inputs, or 'params'
                 try:
-                    converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[params["schema_version"]]
-                    quantum_program, options = converter.decoder(converter.model(**params))
+                    qp_converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[params["schema_version"]]
+                    quantum_program, options = qp_converter.decoder(qp_converter.model(**params))
                     decoded["params"]["quantum_program"] = quantum_program
                     decoded["params"]["options"] = options
                 except Exception as exception:
@@ -471,8 +471,8 @@ class RuntimeDecoder(json.JSONDecoder):
                         NOISE_LEARNER_V3_PARAMS_CONVERTERS,
                     )
 
-                    converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
-                    instructions, options = converter.decoder(converter.model(**params))
+                    nl_converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
+                    instructions, options = nl_converter.decoder(nl_converter.model(**params))
                     decoded["params"]["instructions"] = instructions
                     decoded["params"]["options"] = options
                 except Exception as exception:

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -452,9 +452,9 @@ class RuntimeDecoder(json.JSONDecoder):
                 # decode its inputs, or 'params'
                 try:
                     qp_converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[params["schema_version"]]
-                    quantum_program, options = qp_converter.decoder(qp_converter.model(**params))
+                    quantum_program, qp_options = qp_converter.decoder(qp_converter.model(**params))
                     decoded["params"]["quantum_program"] = quantum_program
-                    decoded["params"]["options"] = options
+                    decoded["params"]["options"] = qp_options
                 except Exception as exception:
                     warnings.warn(
                         "Unable to convert executor 'params' to a pair of quantum program and "
@@ -472,9 +472,9 @@ class RuntimeDecoder(json.JSONDecoder):
                     )
 
                     nl_converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
-                    instructions, options = nl_converter.decoder(nl_converter.model(**params))
+                    instructions, nl_options = nl_converter.decoder(nl_converter.model(**params))
                     decoded["params"]["instructions"] = instructions
-                    decoded["params"]["options"] = options
+                    decoded["params"]["options"] = nl_options
                 except Exception as exception:
                     warnings.warn(
                         "Unable to convert NLV3 'params' to a pair of instructions and "

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -477,7 +477,7 @@ class RuntimeDecoder(json.JSONDecoder):
                     decoded["params"]["options"] = options
                 except Exception as exception:
                     warnings.warn(
-                        "Unable to convert executor 'params' to a pair of quantum program and "
+                        "Unable to convert NLV3 'params' to a pair of instructions and "
                         f"options due to the following exception: {exception}"
                     )
 

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -470,6 +470,7 @@ class RuntimeDecoder(json.JSONDecoder):
                     from qiskit_ibm_runtime.noise_learner_v3.params_converters import (
                         NOISE_LEARNER_V3_PARAMS_CONVERTERS,
                     )
+
                     converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
                     instructions, options = converter.decoder(converter.model(**params))
                     decoded["params"]["instructions"] = instructions

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -32,6 +32,7 @@ from qiskit_ibm_runtime.quantum_program.params_converters import (
     QUANTUM_PROGRAM_PARAMS_CONVERTERS,
 )
 
+
 try:
     from qiskit.quantum_info import PauliLindbladMap
 
@@ -437,7 +438,7 @@ class RuntimeDecoder(json.JSONDecoder):
     def decode(self, s: str) -> Any:  # type: ignore[override]
         """Return the Python representation of a string ``s`` containing a JSON document.
 
-        Applies additional conversion for executor program's ``params``, preserving the
+        Applies additional conversion for executor program and NLV3's ``params``, preserving the
         superclass ``decode()`` output in all other cases.
 
         Args:
@@ -446,6 +447,7 @@ class RuntimeDecoder(json.JSONDecoder):
         if isinstance(decoded := super().decode(s), dict):
             program_id = decoded.get("program", {}).get("id", None)
             params = decoded.get("params", {})
+
             if program_id == "executor" and params:
                 # `decoded` represents the input to an executor program. We use the converters to
                 # decode its inputs, or 'params'
@@ -453,6 +455,25 @@ class RuntimeDecoder(json.JSONDecoder):
                     converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[params["schema_version"]]
                     quantum_program, options = converter.decoder(converter.model(**params))
                     decoded["params"]["quantum_program"] = quantum_program
+                    decoded["params"]["options"] = options
+                except Exception as exception:
+                    warnings.warn(
+                        "Unable to convert executor 'params' to a pair of quantum program and "
+                        f"options due to the following exception: {exception}"
+                    )
+
+            if program_id == "noise-learner" and params:
+                # `decoded` represents the input to an NLV3 program. We use the converters to
+                # decode its inputs, or 'params'
+                try:
+                    # importing here and not at the top of the file,
+                    # to prevent circular imports
+                    from qiskit_ibm_runtime.noise_learner_v3.params_converters import (
+                        NOISE_LEARNER_V3_PARAMS_CONVERTERS,
+                    )
+                    converter = NOISE_LEARNER_V3_PARAMS_CONVERTERS[params["schema_version"]]
+                    instructions, options = converter.decoder(converter.model(**params))
+                    decoded["params"]["instructions"] = instructions
                     decoded["params"]["options"] = options
                 except Exception as exception:
                     warnings.warn(

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -461,7 +461,7 @@ class RuntimeDecoder(json.JSONDecoder):
                         f"options due to the following exception: {exception}"
                     )
 
-            if program_id == "noise-learner" and params:
+            if program_id == "noise-learner" and params and "schema_version" in params:
                 # `decoded` represents the input to an NLV3 program. We use the converters to
                 # decode its inputs, or 'params'
                 try:

--- a/test/integration/test_noise_learner_v3.py
+++ b/test/integration/test_noise_learner_v3.py
@@ -59,6 +59,10 @@ class TestNoiseLearnerV3(IBMIntegrationTestCase):
 
         job = learner.run(instructions)
 
+        params = job.inputs
+        assert params["instructions"] == instructions
+        assert params["options"] == learner.options
+
         result = job.result()
         assert isinstance(result, NoiseLearnerV3Results)
         assert all(isinstance(datum, NoiseLearnerV3Result) for datum in result)

--- a/test/integration/test_noise_learner_v3.py
+++ b/test/integration/test_noise_learner_v3.py
@@ -60,6 +60,9 @@ class TestNoiseLearnerV3(IBMIntegrationTestCase):
         job = learner.run(instructions)
 
         params = job.inputs
+        # default option of experimental is Unset, and is then converted to {}
+        params["options"].experimental = {}
+
         assert params["instructions"] == instructions
         assert params["options"] == learner.options
 

--- a/test/unit/noise_learner_v3/test_params_converters.py
+++ b/test/unit/noise_learner_v3/test_params_converters.py
@@ -29,17 +29,6 @@ from ddt import data, ddt
 @ddt
 class TestParamsConverters(IBMTestCase):
     """Tests for ParamConverters."""
-
-    def setUp(self):
-        """Test level setup."""
-        super().setUp()
-
-        self.boxing_pm = generate_preset_pass_manager(backend=FakeFez(), optimization_level=0)
-        self.boxing_pm.post_scheduling = generate_boxing_pass_manager(
-            enable_gates=True,
-            enable_measures=True,
-        )
-
     @data(*list(NOISE_LEARNER_V3_PARAMS_CONVERTERS))
     def test_round_trip(self, schema_version):
         """Test a round trip."""
@@ -52,7 +41,12 @@ class TestParamsConverters(IBMTestCase):
         circuit.rz(Parameter("lam"), 2)
         circuit.measure_all()
 
-        boxed_circuit = self.boxing_pm.run(circuit)
+        boxing_pm = generate_preset_pass_manager(backend=FakeFez(), optimization_level=0)
+        boxing_pm.post_scheduling = generate_boxing_pass_manager(
+            enable_gates=True,
+            enable_measures=True,
+        )
+        boxed_circuit = boxing_pm.run(circuit)
         instructions = find_unique_box_instructions(boxed_circuit)
 
         options = NoiseLearnerV3Options()

--- a/test/unit/noise_learner_v3/test_params_converters.py
+++ b/test/unit/noise_learner_v3/test_params_converters.py
@@ -29,6 +29,7 @@ from ddt import data, ddt
 @ddt
 class TestParamsConverters(IBMTestCase):
     """Tests for ParamConverters."""
+
     @data(*list(NOISE_LEARNER_V3_PARAMS_CONVERTERS))
     def test_round_trip(self, schema_version):
         """Test a round trip."""

--- a/test/unit/noise_learner_v3/test_params_converters.py
+++ b/test/unit/noise_learner_v3/test_params_converters.py
@@ -1,0 +1,66 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests the decoder for the quantum program result model."""
+
+from qiskit.circuit import QuantumCircuit, Parameter
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+
+from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import find_unique_box_instructions
+
+from qiskit_ibm_runtime.options import NoiseLearnerV3Options
+from qiskit_ibm_runtime.noise_learner_v3.params_converters import NOISE_LEARNER_V3_PARAMS_CONVERTERS
+from qiskit_ibm_runtime.fake_provider import FakeFez
+from ...ibm_test_case import IBMTestCase
+
+from ddt import data, ddt
+
+
+@ddt
+class TestParamsConverters(IBMTestCase):
+    """Tests for ParamConverters."""
+
+    def setUp(self):
+        """Test level setup."""
+        super().setUp()
+
+        self.boxing_pm = generate_preset_pass_manager(backend=FakeFez(), optimization_level=0)
+        self.boxing_pm.post_scheduling = generate_boxing_pass_manager(
+            enable_gates=True,
+            enable_measures=True,
+        )
+
+    @data(*list(NOISE_LEARNER_V3_PARAMS_CONVERTERS))
+    def test_round_trip(self, schema_version):
+        """Test a round trip."""
+        circuit = QuantumCircuit(3, name="GHZ with params")
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(1, 2)
+        circuit.rz(Parameter("theta"), 0)
+        circuit.rz(Parameter("phi"), 1)
+        circuit.rz(Parameter("lam"), 2)
+        circuit.measure_all()
+
+        boxed_circuit = self.boxing_pm.run(circuit)
+        instructions = find_unique_box_instructions(boxed_circuit)
+
+        options = NoiseLearnerV3Options()
+        options.layer_pair_depths = [0, 2, 4]
+
+        converters = NOISE_LEARNER_V3_PARAMS_CONVERTERS[schema_version]
+        encoded = converters.encoder(instructions, options).model_dump()
+        decoded = converters.decoder(converters.model(**encoded))
+
+        assert decoded[0] == instructions
+        assert decoded[1] == options

--- a/test/unit/quantum_program/test_params_converters.py
+++ b/test/unit/quantum_program/test_params_converters.py
@@ -22,7 +22,7 @@ from ddt import data, ddt
 
 
 @ddt
-class TestParamConverters(IBMTestCase):
+class TestParamsConverters(IBMTestCase):
     """Tests for ParamConverters."""
 
     @data(*list(QUANTUM_PROGRAM_PARAMS_CONVERTERS))

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -25,7 +25,6 @@ from ddt import data, ddt
 
 from qiskit.circuit import Parameter, ParameterVector, QuantumCircuit
 from qiskit.circuit.library import CXGate, PhaseGate, U2Gate, efficient_su2
-
 import qiskit.quantum_info as qi
 from qiskit.quantum_info import SparsePauliOp, Pauli, PauliList, PauliLindbladMap
 from qiskit.result import Result, Counts
@@ -41,6 +40,11 @@ from qiskit.primitives.containers import (
     PrimitiveResult,
 )
 from qiskit_aer.noise import NoiseModel
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+
+from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import find_unique_box_instructions
+
 from qiskit_ibm_runtime.utils import RuntimeEncoder, RuntimeDecoder
 from qiskit_ibm_runtime.utils.estimator_pub_result import EstimatorPubResult
 from qiskit_ibm_runtime.utils.noise_learner_result import (
@@ -70,7 +74,8 @@ from ..utils import mock_wait_for_final_state, bell
 
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
-from qiskit_ibm_runtime.options import ExecutorOptions
+from qiskit_ibm_runtime.options import ExecutorOptions, NoiseLearnerV3Options
+from qiskit_ibm_runtime.noise_learner_v3.params_converters import NOISE_LEARNER_V3_PARAMS_CONVERTERS
 
 
 @ddt
@@ -782,7 +787,7 @@ class TestExecutionSpansSerialization(IBMTestCase):
 
 @ddt
 class TestRuntimeDecoder(IBMTestCase):
-    """Tests for RuntimeDecoder class."""
+    """Tests for RuntimeDecoder class."""       
 
     @data(*list(QUANTUM_PROGRAM_PARAMS_CONVERTERS))
     def test_decoding_executor_params(self, schema_version):
@@ -831,4 +836,68 @@ class TestRuntimeDecoder(IBMTestCase):
             decoded = json.loads(encoded, cls=RuntimeDecoder)
 
         assert decoded["params"]["quantum_program"] == "foo"
+        assert decoded["params"]["options"] == "bar"
+
+    @data(*list(NOISE_LEARNER_V3_PARAMS_CONVERTERS))
+    def test_decoding_noise_learner_v3_params(self, schema_version):
+        """Test that inputs (or 'params') of NLV3 jobs can be decoded correctly.
+
+        The goal of this test is to check that when these 'params' are in the correct format,
+        i.e. the format in which they are returned when calling `job.inputs`,
+        the `RuntimeDecoder.encode` function returns a list of `CircuitInstruction` objects.
+        """
+        boxing_pm = generate_preset_pass_manager(backend=FakeNairobiV2(), optimization_level=0)
+        boxing_pm.post_scheduling = generate_boxing_pass_manager(
+            enable_gates=True,
+            enable_measures=True,
+        )
+
+        circuit = QuantumCircuit(3, name="GHZ with params")
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(1, 2)
+        circuit.rz(Parameter("theta"), 0)
+        circuit.rz(Parameter("phi"), 1)
+        circuit.rz(Parameter("lam"), 2)
+        circuit.measure_all()
+
+        boxed_circuit = boxing_pm.run(circuit)
+        instructions = find_unique_box_instructions(boxed_circuit)
+
+        options = NoiseLearnerV3Options()
+        options.layer_pair_depths = [0, 2, 4]
+
+        # This is the format expected by `RuntimeDecoder.encode` when deserializing inputs of
+        # an NLV3 job        
+        params = {
+            "program": {"id": "noise-learner"},
+            "params": NOISE_LEARNER_V3_PARAMS_CONVERTERS[schema_version]
+            .encoder(instructions, options)
+            .model_dump(),
+        }
+        encoded = json.dumps(params, cls=RuntimeEncoder)
+        decoded = json.loads(encoded, cls=RuntimeDecoder)
+
+        assert decoded["params"]["instructions"] == instructions
+        assert decoded["params"]["options"] == options
+
+    @data(*list(NOISE_LEARNER_V3_PARAMS_CONVERTERS))
+    def test_decoding_incorrect_noise_learner_v3_params_warns(self, schema_version):
+        """Test that inputs (or 'params') of NLV3 jobs can be decoded correctly.
+
+        The goal of this test is to check that when these 'params' are in an incorrect format,
+        the `RuntimeDecoder.encode` function raises a warning instead of an error.
+        """
+        # This is the format expected by `RuntimeDecoder.encode` when deserializing inputs of
+        # an executor job, but with program and options in an incorrect format.
+        params = {
+            "program": {"id": "executor"},
+            "params": {"instructions": "foo", "options": "bar"},
+        }
+        encoded = json.dumps(params, cls=RuntimeEncoder)
+
+        with self.assertWarnsRegex(Warning, "Unable to convert"):
+            decoded = json.loads(encoded, cls=RuntimeDecoder)
+
+        assert decoded["params"]["instructions"] == "foo"
         assert decoded["params"]["options"] == "bar"

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -787,7 +787,7 @@ class TestExecutionSpansSerialization(IBMTestCase):
 
 @ddt
 class TestRuntimeDecoder(IBMTestCase):
-    """Tests for RuntimeDecoder class."""       
+    """Tests for RuntimeDecoder class."""
 
     @data(*list(QUANTUM_PROGRAM_PARAMS_CONVERTERS))
     def test_decoding_executor_params(self, schema_version):

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -868,7 +868,7 @@ class TestRuntimeDecoder(IBMTestCase):
         options.layer_pair_depths = [0, 2, 4]
 
         # This is the format expected by `RuntimeDecoder.encode` when deserializing inputs of
-        # an NLV3 job        
+        # an NLV3 job
         params = {
             "program": {"id": "noise-learner"},
             "params": NOISE_LEARNER_V3_PARAMS_CONVERTERS[schema_version]


### PR DESCRIPTION
### Summary

Fixes #2740.

### Details and comments

Essentially mimicking #2731.
