### PR TITLE
Fix iterator exhaustion issue in NoiseLearner.run()

### DIFF
--- a/qiskit_ibm_runtime/noise_learner/noise_learner.py
+++ b/qiskit_ibm_runtime/noise_learner/noise_learner.py
@@ -167,8 +167,10 @@ class NoiseLearner:
         runtime_options = NoiseLearnerOptions._get_runtime_options(options_dict)
 
         # Define the program inputs
-        inputs = {"circuits": circuits}
-        inputs.update(learner_options)
+        inputs: dict[str, Any] = {
+            "circuits": circuits,
+            **learner_options,
+        }
 
         calibration_id = None
         if self._backend:

--- a/qiskit_ibm_runtime/noise_learner/noise_learner.py
+++ b/qiskit_ibm_runtime/noise_learner/noise_learner.py
@@ -159,8 +159,7 @@ class NoiseLearner:
         # Convert all inputs (QuantumCircuit or EstimatorPubLike) to a list of circuits
         # in a single pass and also supports mixed inputs.
         circuits = [
-            circuit if isinstance(circuit, QuantumCircuit)
-            else EstimatorPub.coerce(circuit).circuit
+            circuit if isinstance(circuit, QuantumCircuit) else EstimatorPub.coerce(circuit).circuit
             for circuit in circuits
         ]
 

--- a/qiskit_ibm_runtime/noise_learner/noise_learner.py
+++ b/qiskit_ibm_runtime/noise_learner/noise_learner.py
@@ -156,10 +156,13 @@ class NoiseLearner:
             The submitted job.
 
         """
-        circuits = circuits if isinstance(circuits, list) else list(circuits)
-        if not all(isinstance(t, QuantumCircuit) for t in circuits):
-            coerced_pubs = [EstimatorPub.coerce(pub) for pub in circuits]
-            circuits = [p.circuit for p in coerced_pubs]
+        # Convert all inputs (QuantumCircuit or EstimatorPubLike) to a list of circuits
+        # in a single pass and also supports mixed inputs.
+        circuits = [
+            circuit if isinstance(circuit, QuantumCircuit)
+            else EstimatorPub.coerce(circuit).circuit
+            for circuit in circuits
+        ]
 
         # Store learner-specific and runtime options in different dictionaries
         options_dict = asdict(self.options)

--- a/qiskit_ibm_runtime/noise_learner/noise_learner.py
+++ b/qiskit_ibm_runtime/noise_learner/noise_learner.py
@@ -156,7 +156,7 @@ class NoiseLearner:
             The submitted job.
 
         """
-        circuits = list(circuits)
+        circuits = circuits if isinstance(circuits, list) else list(circuits)
         if not all(isinstance(t, QuantumCircuit) for t in circuits):
             coerced_pubs = [EstimatorPub.coerce(pub) for pub in circuits]
             circuits = [p.circuit for p in coerced_pubs]

--- a/qiskit_ibm_runtime/noise_learner/noise_learner.py
+++ b/qiskit_ibm_runtime/noise_learner/noise_learner.py
@@ -156,6 +156,7 @@ class NoiseLearner:
             The submitted job.
 
         """
+        circuits = list(circuits)
         if not all(isinstance(t, QuantumCircuit) for t in circuits):
             coerced_pubs = [EstimatorPub.coerce(pub) for pub in circuits]
             circuits = [p.circuit for p in coerced_pubs]

--- a/release-notes/unreleased/2759.bug.rst
+++ b/release-notes/unreleased/2759.bug.rst
@@ -1,7 +1,4 @@
-NoiseLearner
-~~~~~~~~~~~~
-
-- ``NoiseLearner.run()`` now correctly supports generators, ``map``,
+ ``NoiseLearner.run()`` now correctly supports generators, ``map``,
   ``filter``, generator expressions and other single-pass iterators.
   Previously these were exhausted after the initial type check, causing
   jobs to be submitted with zero circuits.

--- a/release-notes/unreleased/2759.bug.rst
+++ b/release-notes/unreleased/2759.bug.rst
@@ -1,4 +1,4 @@
-- ``NoiseLearner.run()`` now correctly supports generators, ``map``,
-  ``filter``, generator expressions and other single-pass iterators.
-  Previously these were exhausted after the initial type check, causing
-  jobs to be submitted with zero circuits.
+``NoiseLearner.run()`` now correctly supports generators, ``map``,
+``filter``, generator expressions and other single-pass iterators.
+Previously these were exhausted after the initial type check, causing
+jobs to be submitted with zero circuits.

--- a/release-notes/unreleased/2759.bug.rst
+++ b/release-notes/unreleased/2759.bug.rst
@@ -1,0 +1,7 @@
+NoiseLearner
+~~~~~~~~~~~~
+
+- ``NoiseLearner.run()`` now correctly supports generators, ``map``,
+  ``filter``, generator expressions and other single-pass iterators.
+  Previously these were exhausted after the initial type check, causing
+  jobs to be submitted with zero circuits.

--- a/release-notes/unreleased/2759.bug.rst
+++ b/release-notes/unreleased/2759.bug.rst
@@ -1,4 +1,4 @@
- ``NoiseLearner.run()`` now correctly supports generators, ``map``,
+- ``NoiseLearner.run()`` now correctly supports generators, ``map``,
   ``filter``, generator expressions and other single-pass iterators.
   Previously these were exhausted after the initial type check, causing
   jobs to be submitted with zero circuits.

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -83,13 +83,27 @@ class TestNoiseLearner(IBMTestCase):
 
     @combine(task_type=["circs", "pubs"])
     def test_run_program_inputs_with_default_options(self, task_type):
-        """Test a circuit with default options."""
+        """Test a circuit with default options.
+        Also tests support for generators/iterators
+        """
         backend = get_mocked_backend()
+
+        def circuit_generator(circuits):
+            for c in circuits:
+                yield c
+
+        def pub_generator(circuits):
+            for c in circuits:
+                yield (c, "Z" * c.num_qubits)
 
         if task_type == "circs":
             tasks = [transpile(c) for c in self.circuits]
-        else:
+        elif task_type == "circs_iterator":
+            tasks = circuit_generator([transpile(c) for c in self.circuits])
+        elif task_type == "pubs":
             tasks = [(transpile(c), "Z" * c.num_qubits) for c in self.circuits]
+        else:
+            tasks = pub_generator([transpile(c) for c in self.circuits])
 
         inst = NoiseLearner(backend)
         inst.run(tasks)
@@ -134,23 +148,3 @@ class TestNoiseLearner(IBMTestCase):
         backend = get_mocked_backend()
         inst = NoiseLearner(backend)
         self.assertEqual(inst.backend().name, backend.name)
-
-    def test_run_supports_generator(self):
-        """Regression test for iterator exhaustion issue."""
-        backend = get_mocked_backend()
-
-        def circuit_generator(n: int) -> Iterator[QuantumCircuit]:
-            for _ in range(n):
-                qc = QuantumCircuit(2)
-                qc.cx(0, 1)
-                yield qc
-
-        inst = NoiseLearner(backend)
-        inst.run(circuit_generator(4))
-
-        input_params = backend.service._run.call_args.kwargs["inputs"]
-        self.assertEqual(
-            len(input_params["circuits"]),
-            4,
-            "Generator should not be exhausted - all 4 circuits must be present",
-        )

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -79,7 +79,7 @@ class TestNoiseLearner(IBMTestCase):
         expected["support_qiskit"] = True
         self.assertEqual(input_params["options"], expected)
 
-    @combine(task_type=["circs", "pubs"])
+    @combine(task_type=["circs", "pubs", "circs_iterator", "pubs_iterator"])
     def test_run_program_inputs_with_default_options(self, task_type):
         """Test a circuit with default options.
         Also tests support for generators/iterators

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -12,8 +12,6 @@
 
 """Tests for the noise learner."""
 
-from collections.abc import Iterator
-
 from ddt import ddt
 
 from qiskit import QuantumCircuit, transpile

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -87,8 +87,7 @@ class TestNoiseLearner(IBMTestCase):
         backend = get_mocked_backend()
 
         def circuit_generator(circuits):
-            for c in circuits:
-                yield c
+            yield from circuits
 
         def pub_generator(circuits):
             for c in circuits:

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -12,6 +12,8 @@
 
 """Tests for the noise learner."""
 
+from collections.abc import Iterator
+
 from ddt import ddt
 
 from qiskit import QuantumCircuit, transpile
@@ -137,7 +139,7 @@ class TestNoiseLearner(IBMTestCase):
         """Regression test for iterator exhaustion issue."""
         backend = get_mocked_backend()
 
-        def circuit_generator(n: int):
+        def circuit_generator(n: int) -> Iterator[QuantumCircuit]:
             for _ in range(n):
                 qc = QuantumCircuit(2)
                 qc.cx(0, 1)

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -82,8 +82,9 @@ class TestNoiseLearner(IBMTestCase):
     @combine(task_type=["circs", "pubs", "circs_iterator", "pubs_iterator"])
     def test_run_program_inputs_with_default_options(self, task_type):
         """Test a circuit with default options.
+        """Test a circuit with default options.
 
-        Also tests support for generators/iterators
+        Also tests support for generators/iterators.
         """
         backend = get_mocked_backend()
 

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -82,6 +82,7 @@ class TestNoiseLearner(IBMTestCase):
     @combine(task_type=["circs", "pubs", "circs_iterator", "pubs_iterator"])
     def test_run_program_inputs_with_default_options(self, task_type):
         """Test a circuit with default options.
+
         Also tests support for generators/iterators
         """
         backend = get_mocked_backend()

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -132,3 +132,23 @@ class TestNoiseLearner(IBMTestCase):
         backend = get_mocked_backend()
         inst = NoiseLearner(backend)
         self.assertEqual(inst.backend().name, backend.name)
+
+    def test_run_supports_generator(self):
+        """Regression test for iterator exhaustion issue."""
+        backend = get_mocked_backend()
+
+        def circuit_generator(n: int):
+            for _ in range(n):
+                qc = QuantumCircuit(2)
+                qc.cx(0, 1)
+                yield qc
+
+        inst = NoiseLearner(backend)
+        inst.run(circuit_generator(4))
+
+        input_params = backend.service._run.call_args.kwargs["inputs"]
+        self.assertEqual(
+            len(input_params["circuits"]),
+            4,
+            "Generator should not be exhausted - all 4 circuits must be present",
+        )

--- a/test/unit/test_noise_learner.py
+++ b/test/unit/test_noise_learner.py
@@ -82,7 +82,6 @@ class TestNoiseLearner(IBMTestCase):
     @combine(task_type=["circs", "pubs", "circs_iterator", "pubs_iterator"])
     def test_run_program_inputs_with_default_options(self, task_type):
         """Test a circuit with default options.
-        """Test a circuit with default options.
 
         Also tests support for generators/iterators.
         """


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

whenever a user pass generator,map,filter or any single pass iterator in `NoiseLearner.run()`, `all(isinstance(...))` check consumes all the circuits due to which job used to get submit with 0 circuits

this PR resolves this issue

the bug can be generated using 
```
from qiskit import QuantumCircuit
from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
from qiskit_ibm_runtime import QiskitRuntimeService
from qiskit_ibm_runtime.noise_learner import NoiseLearner

service = QiskitRuntimeService()
backend = service.least_busy(operational=True, simulator=False, min_num_qubits=2)

print("backend:", backend.name)

pm = generate_preset_pass_manager(backend=backend, optimization_level=1)

learner = NoiseLearner(backend)


def circuit_generator(n):
    for _ in range(n):
        qc = QuantumCircuit(2)
        qc.h(0)
        qc.cx(0, 1)
        transpiled_qc = pm.run(qc)
        yield transpiled_qc

job = learner.run(circuit_generator(3))

print("job",len(job.inputs["circuits"]))
print("job id:", job.job_id)
```

### Details and comments
Fixes #
replaced the previous iterator handling logic in `NoiseLearner.run()` with a single list comprehension:

```python
circuits = [
    circuit if isinstance(circuit, QuantumCircuit)
    else EstimatorPub.coerce(circuit).circuit
    for circuit in circuits
]
