### PR TITLE
Executor submits jobs via 1.0 encoders

### DIFF
--- a/qiskit_ibm_runtime/executor.py
+++ b/qiskit_ibm_runtime/executor.py
@@ -79,7 +79,7 @@ class Executor:
 
     _PROGRAM_ID = "executor"
     _DECODER = QuantumProgramResultDecoder
-    _SCHEMA_VERSION = "v0.2"
+    _SCHEMA_VERSION = "v1.0"
 
     options: ExecutorOptions
     """The options of this executor."""


### PR DESCRIPTION
This PR switches the default schema version to 1.0