### PR TITLE
Fix a bug in executor's converters to "v1.0" models

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/converters/converters_1_0.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_1_0.py
@@ -147,6 +147,7 @@ def quantum_program_to_1_0(program: QuantumProgram, options: ExecutorOptions) ->
             items=model_items,
             meas_level=program.meas_level,
             passthrough_data=program.passthrough_data,
+            semantic_role=program._semantic_role,
         ),
         options=options_dict,
     )

--- a/test/unit/quantum_program/converters/test_converters_1_0.py
+++ b/test/unit/quantum_program/converters/test_converters_1_0.py
@@ -64,6 +64,7 @@ class TestQuantumProgramConverters(IBMTestCase):
             meas_level=meas_level,
             passthrough_data=passthrough_data,
         )
+        quantum_program._semantic_role = (semantic_role := "sampler-v2")
 
         circuit1 = QuantumCircuit(1)
         circuit1.rx(Parameter("p"), 0)
@@ -105,6 +106,7 @@ class TestQuantumProgramConverters(IBMTestCase):
         quantum_program_model = params_model.quantum_program
         self.assertEqual(quantum_program_model.shots, shots)
         self.assertEqual(quantum_program_model.passthrough_data, passthrough_data)
+        self.assertEqual(quantum_program_model.semantic_role, semantic_role)
         self.assertEqual(quantum_program_model.meas_level, meas_level)
 
         circuit_item_model = quantum_program_model.items[0]


### PR DESCRIPTION
This PR fixes a bug where the executor's converters to "v1.0" models forget to set the `_semantic_role` of the quantum program