### PR TITLE
Add `QuantumProgramItemResult` class

### DIFF
--- a/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v0_1/flatten_twirling_axes.py
+++ b/qiskit_ibm_runtime/executor/routines/sampler_v2/post_processors/v0_1/flatten_twirling_axes.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 import numpy as np
 
+from ......quantum_program.quantum_program_result import QuantumProgramItemResult
 
-def flatten_twirling_axes(item: dict[str, np.ndarray], pub_shape: tuple[int, ...]) -> None:
+
+def flatten_twirling_axes(item: QuantumProgramItemResult, pub_shape: tuple[int, ...]) -> None:
     """Flatten the leading ``num_randomizations`` axis into the shots axis in-place.
 
     When twirling is enabled, the executor returns measurement data with shape

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -229,11 +229,16 @@ class QuantumProgramResult:
 
     def __init__(
         self,
-        data: list[dict[str, np.ndarray]],
+        data: list[dict[str, np.ndarray] | QuantumProgramItemResult],
         metadata: Metadata | None = None,
         passthrough_data: DataTree | None = None,
     ):
-        self._data = data
+        self._data = [
+            datum
+            if isinstance(datum, QuantumProgramItemResult)
+            else QuantumProgramItemResult(datum)
+            for datum in data
+        ]
         self.metadata = metadata or Metadata()
         self.passthrough_data = passthrough_data
 
@@ -242,10 +247,10 @@ class QuantumProgramResult:
         # without notice. Third party clients should not set or depend on this value.
         self._semantic_role: str | None = None
 
-    def __iter__(self) -> Iterator[dict[str, np.ndarray]]:
+    def __iter__(self) -> Iterator[QuantumProgramItemResult]:
         yield from self._data
 
-    def __getitem__(self, idx: int) -> dict[str, np.ndarray]:
+    def __getitem__(self, idx: int) -> QuantumProgramItemResult:
         return self._data[idx]
 
     def __len__(self) -> int:

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -208,7 +208,7 @@ class QuantumProgramItemResult(MutableMapping):
     def __delitem__(self, key: str) -> None:
         del self._result[key]
 
-    def __iter__(self) -> np.ndarray:
+    def __iter__(self) -> str:
         return iter(self._result)
 
     def __len__(self) -> int:

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, MutableMapping
+from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from dataclasses import dataclass, field
 import datetime
 from datetime import timezone
@@ -227,7 +227,7 @@ class QuantumProgramResult:
 
     def __init__(
         self,
-        data: list[dict[str, np.ndarray] | QuantumProgramItemResult],
+        data: Sequence[dict[str, np.ndarray] | QuantumProgramItemResult],
         metadata: Metadata | None = None,
         passthrough_data: DataTree | None = None,
     ):

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -14,9 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping
-
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, MutableMapping
 from dataclasses import dataclass, field
 import datetime
 from datetime import timezone
@@ -208,7 +206,7 @@ class QuantumProgramItemResult(MutableMapping):
     def __delitem__(self, key: str) -> None:
         del self._result[key]
 
-    def __iter__(self) -> str:
+    def __iter__(self) -> Iterator[str]:
         return iter(self._result)
 
     def __len__(self) -> int:

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
+
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 import datetime
 from datetime import timezone
-from typing import overload, TYPE_CHECKING
+from typing import overload, TYPE_CHECKING, Any
 import numpy as np
 
 from .datatree import DataTree
@@ -59,6 +61,11 @@ class ChunkSpan:
 
     parts: list[ChunkPart]
     """A description of which parts of a quantum program are contained in this chunk."""
+
+
+@dataclass
+class ItemMetadata:
+    """Metadata about the execution of a single item of a quantum program."""
 
 
 @dataclass
@@ -174,6 +181,41 @@ class ChunkTiming:
         return draw_chunk_timings(
             self, names=name, normalize_y=normalize_y, line_width=line_width, tz=tz
         )
+
+
+class QuantumProgramItemResult(MutableMapping):
+    """A container to store results for a single item of a :class:`QuantumProgram`.
+
+    Args:
+        result: A dictionary with array-valued data.
+        metadata: The metadata produced for the individual item.
+    """
+
+    def __init__(
+        self,
+        result: dict[str, np.ndarray],
+        metadata: ItemMetadata | None = None,
+    ):
+        self._result = result
+        self.metadata = metadata or ItemMetadata()
+
+    def __getitem__(self, key: str) -> np.ndarray:
+        return self._result[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._result[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._result[key]
+
+    def __iter__(self) -> np.ndarray:
+        return iter(self._result)
+
+    def __len__(self) -> int:
+        return len(self._result)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._result}, metadata={self.metadata})"
 
 
 class QuantumProgramResult:

--- a/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program_result.py
@@ -18,7 +18,7 @@ from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from dataclasses import dataclass, field
 import datetime
 from datetime import timezone
-from typing import overload, TYPE_CHECKING, Any
+from typing import overload, TYPE_CHECKING
 import numpy as np
 
 from .datatree import DataTree
@@ -200,7 +200,7 @@ class QuantumProgramItemResult(MutableMapping):
     def __getitem__(self, key: str) -> np.ndarray:
         return self._result[key]
 
-    def __setitem__(self, key: str, value: Any) -> None:
+    def __setitem__(self, key: str, value: np.array) -> None:
         self._result[key] = value
 
     def __delitem__(self, key: str) -> None:

--- a/test/unit/quantum_program/test_result.py
+++ b/test/unit/quantum_program/test_result.py
@@ -22,6 +22,7 @@ from qiskit_ibm_runtime.quantum_program.quantum_program_result import (
     ChunkTiming,
     Metadata,
     QuantumProgramResult,
+    QuantumProgramItemResult,
 )
 
 from ...ibm_test_case import IBMTestCase
@@ -46,8 +47,8 @@ class TestQuantumProgramResult(IBMTestCase):
         meas2 = np.array([[True, True], [True, False], [False, False]])
         meas_flips = np.array([[False, False]])
 
-        result1 = {"meas": meas1}
-        result2 = {"meas": meas2, "measurement_flips.meas": meas_flips}
+        result1 = QuantumProgramItemResult({"meas": meas1})
+        result2 = QuantumProgramItemResult({"meas": meas2, "measurement_flips.meas": meas_flips})
         result = QuantumProgramResult([result1, result2])
 
         # test __len__
@@ -55,7 +56,7 @@ class TestQuantumProgramResult(IBMTestCase):
 
         # test __iter__
         for res, expected_res in zip(result, [result1, result2]):
-            self.assertDictEqual(res, expected_res)
+            self.assertEqual(res, expected_res)
 
         # test __getitem__
         self.assertEqual([result[0], result[1]], [result1, result2])


### PR DESCRIPTION
Currently, the results of a quantum program item are stored in a dictionary:
```python
result = job.result()
result[0] = {"meas": np.array(...)}
```

This format is not sufficient to store execution metadata for individual items.

This PR adds a `QuantumProgramItemResult` class that can store both the dictionary of results and the metadata. This class is an implementation of `MutableMappings`, which ensures full backward compatibility: `result[0]` still behaves like a dictionary, no script needs to change.