### PR TITLE
make local-mode ZNE (and other error mitigation) raise rather than warn-and-continue

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/local_service.py
+++ b/qiskit_ibm_runtime/fake_provider/local_service.py
@@ -218,6 +218,30 @@ class QiskitRuntimeLocalService:
         """
         options_copy = copy.deepcopy(options)
 
+        # Resilience options materially change the *meaning* of estimator results.
+        # Local mode does not implement them, so silently dropping them produces
+        # misleading output. Raise instead of warn for these.
+        if primitive == "estimator":
+            resilience = options_copy.get("resilience", {})
+            unsupported = [
+                name for name in (
+                    "zne_mitigation",
+                    "pec_mitigation",
+                    "measure_mitigation",
+                    "measure_noise_learning",
+                    "layer_noise_learning",
+                    "zne",
+                    "pec",
+                )
+                if resilience.get(name)
+            ]
+            if unsupported:
+                raise ValueError(
+                    f"The following resilience options are not supported in local "
+                    f"testing mode: {unsupported}. To use these mitigations, run on "
+                    f"a real backend via QiskitRuntimeService."
+                )
+
         prim_options = {}
         sim_options = options_copy.get("simulator", {})
         if seed_simulator := sim_options.pop("seed_simulator", None):

--- a/release-notes/notes/change.yaml
+++ b/release-notes/notes/change.yaml
@@ -1,0 +1,9 @@
+upgrade:
+  - |
+    :class:`~qiskit_ibm_runtime.EstimatorV2` now raises ``ValueError`` when
+    resilience options such as ``zne_mitigation`` or ``pec_mitigation`` are
+    set while running in local testing mode (i.e. with a non-cloud backend
+    such as :class:`~qiskit_aer.AerSimulator` or a fake backend). Previously
+    these options were silently dropped with only a generic warning, which
+    could lead users to believe their results were error-mitigated when they
+    were not.

--- a/test/unit/test_local_mode.py
+++ b/test/unit/test_local_mode.py
@@ -113,6 +113,27 @@ class TestLocalModeV2(IBMTestCase):
             warning_messages = "".join([str(warn.message) for warn in warns])
             self.assertIn("dynamical_decoupling", warning_messages)
 
+    @combine(
+        backend=[FakeManilaV2(), AerSimulator()],
+        resilience_option=[
+            "zne_mitigation",
+            "pec_mitigation",
+            "measure_mitigation",
+        ],
+    )
+    def test_estimator_v2_rejects_unsupported_resilience_options(
+        self, backend, resilience_option
+    ):
+        """Resilience options that change the meaning of the result are not
+        supported in local testing mode and must raise rather than be silently
+        dropped. See issue #2777."""
+        options = {"resilience": {resilience_option: True}}
+        inst = EstimatorV2(mode=backend, options=options)
+        with self.assertRaisesRegex(
+            ValueError, "not supported in local testing mode"
+        ):
+            inst.run(**get_primitive_inputs(inst, backend=backend))
+
     @combine(session_cls=[Session, Batch], backend=[FakeManilaV2(), AerSimulator()])
     def test_sampler_v2_session(self, session_cls, backend):
         """Testing running v2 sampler inside session."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now, anything in `options` that local mode doesn't understand falls through to a generic warning at line 273–274:

```
if options_copy:
    warnings.warn(f"Options {options_copy} have no effect in local testing mode.")
```

For option like `dynamical_decoupling`, "warn and continue" is reasonable. For resilience options that change the meaning of the result (ZNE, PEC, PEA, measurement twirling, gate twirling), silently dropping them is dangerous — the user thinks they got a mitigated estimate but didn't, and the bug is invisible unless they read the warning.


### Details and comments
Fixes #2777 
