### PR TITLE
Fix integration tests

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/__init__.py
+++ b/qiskit_ibm_runtime/quantum_program/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -33,10 +33,12 @@ Classes
     :toctree: ../stubs/
     :nosignatures:
 
+    ItemMetadata
     QuantumProgram
     QuantumProgramItem
+    QuantumProgramItemResult
     QuantumProgramResult
 """
 
 from .quantum_program import QuantumProgram, QuantumProgramItem
-from .quantum_program_result import QuantumProgramResult
+from .quantum_program_result import QuantumProgramResult, QuantumProgramItemResult, ItemMetadata

--- a/test/integration/executor/test_executor.py
+++ b/test/integration/executor/test_executor.py
@@ -22,7 +22,7 @@ from samplomatic import build
 from samplomatic.transpiler import generate_boxing_pass_manager
 
 from qiskit_ibm_runtime import Executor, QuantumProgram
-from qiskit_ibm_runtime.quantum_program import QuantumProgramResult
+from qiskit_ibm_runtime.quantum_program import QuantumProgramResult, QuantumProgramItemResult
 from ...ibm_test_case import IBMIntegrationTestCase
 
 
@@ -76,7 +76,7 @@ class TestExecutor(IBMIntegrationTestCase):
         self.assertEqual(results.passthrough_data, passthrough_data)
 
         result = results[0]
-        self.assertIsInstance(result, dict)
+        self.assertIsInstance(result, QuantumProgramItemResult)
         self.assertEqual(list(result.keys()), ["meas"])
         self.assertIsInstance(result["meas"], np.ndarray)
         self.assertEqual(result["meas"].shape, shape + (shots, circuit.num_qubits))
@@ -123,7 +123,7 @@ class TestExecutor(IBMIntegrationTestCase):
         self.assertEqual(results.passthrough_data, passthrough_data)
 
         result = results[0]
-        self.assertIsInstance(result, dict)
+        self.assertIsInstance(result, QuantumProgramItemResult)
         self.assertEqual(len(result.keys()), 2)
         self.assertEqual(set(result.keys()), {"meas", "measurement_flips.meas"})
         self.assertIsInstance(result["meas"], np.ndarray)


### PR DESCRIPTION
The PR introducing `QuantumProgramItemResult` broke the integration tests. This PR fixes them back.

In addition, it adds `QuantumProgramItemResult` and `ItemMetadata` to the `__init__.py` file to include them in the docs