### PR TITLE
Force registering of sampler_v2_post_processor_v_0_1

### DIFF
--- a/qiskit_ibm_runtime/executor_sampler/post_processors/__init__.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/__init__.py
@@ -11,3 +11,6 @@
 # that they have been altered from the originals.
 
 """V0.1 post processor for executor-based SamplerV2"""
+
+# Import in order to register.
+from .post_processor_v0_1 import sampler_v2_post_processor_v0_1


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

During #2779 , the reorganizing of imports led to `sampler_v2_post_processor_v0_1()` not being imported unless explicitly used - which implied that the `@register_post_processor` decorator did not kick in, leaving the registry empty (and causing integration tests to fail). This adds an import in a path that is traversed when the registry is used.


### Details and comments

Followup to #2779 (for #2750). A bit related to #2781 
