### PR TITLE
Minor modifications to wrapper sampler post-processor

### DIFF
--- a/qiskit_ibm_runtime/executor_sampler/converters.py
+++ b/qiskit_ibm_runtime/executor_sampler/converters.py
@@ -15,16 +15,15 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
-from qiskit.primitives import PrimitiveResult
 from qiskit.primitives.containers import BitArray, DataBin, SamplerPubResult
 
 from ..options_models import EnvironmentOptions, ExecutionOptions, ExecutorOptions
 
 if TYPE_CHECKING:
     from ..options_models import SamplerOptions
-    from ..quantum_program import QuantumProgramResult, QuantumProgramItemResult
+    from ..quantum_program import QuantumProgramItemResult
 
 
 def sampler_options_to_executor_options(options: SamplerOptions) -> ExecutorOptions:
@@ -89,75 +88,3 @@ def quantum_program_item_result_to_sampler_pub_result(
         pub_metadata["circuit_metadata"] = circuit_metadata
 
     return SamplerPubResult(data=data_bin, metadata=pub_metadata)
-
-
-def quantum_program_result_to_primitive_result(
-    result: QuantumProgramResult,
-    metadata: dict[str, Any] | None = None,
-    meas_type: Literal["classified", "kerneled", "avg_kerneled"] = "classified",
-    circuits_metadata: list[dict] | None = None,
-) -> PrimitiveResult:
-    """Convert :class:`~.QuantumProgramResult` to :class:`~qiskit.primitives.PrimitiveResult`.
-
-    Args:
-        result: The (possibly post-processed) quantum program result.
-        metadata: The metadata to attach to the result.
-        meas_type: How to process and return measurement results. This option sets the return
-            type of all classical registers in all sampler pub results.
-
-        * ``"classified"``: Returns a BitArray with classified measurement outcomes.
-        * ``"kerneled"``: Returns complex IQ data points from kerneling the measurement
-            trace, in arbitrary units.
-        * ``"avg_kerneled"``: Returns complex IQ data points averaged over shots,
-            in arbitrary units.
-        circuits_metadata: Optional list of circuit metadata dicts, one per pub.
-
-    Returns:
-        The converted primitive result.
-
-    Raises:
-        ValueError: If data is malformed or inconsistent, or if ``circuits_metadata``
-            length doesn't match number of pubs.
-    """
-    # Validate circuits_metadata length if provided
-    circuits_metadata = circuits_metadata or [None] * len(result)
-    if circuits_metadata is not None and len(circuits_metadata) != len(result):
-        raise ValueError(
-            f"Number of circuit metadata items ({len(circuits_metadata)}) does not match "
-            f"number of pubs ({len(result)})."
-        )
-
-    # Build SamplerPubResult for each pub
-    pub_results = []
-    for idx, item_data in enumerate(result):
-        # Validate that measurement data exists
-        if not item_data:
-            raise ValueError(f"Pub {idx} has no measurement data")
-
-        # Infer pub_shape from the first classical register's data
-        # meas_data shape: (...pub_shape..., num_shots, num_bits)
-        first_meas_data = next(iter(item_data.values()))
-        pub_shape = first_meas_data.shape[:-2]
-
-        arrays = {}
-        for creg_name, meas_data in item_data.items():
-            if meas_type == "classified":
-                arrays[creg_name] = BitArray.from_bool_array(meas_data)
-            elif meas_type == "kerneled":
-                arrays[creg_name.removesuffix("_iq")] = meas_data
-            elif meas_type == "avg_kerneled":
-                arrays[creg_name.removesuffix("_avg_iq")] = meas_data
-
-        data_bin = DataBin(**arrays, shape=pub_shape)
-
-        # Get circuit metadata for this pub if available
-        pub_metadata = {}
-        if circuits_metadata is not None:
-            circuit_meta = circuits_metadata[idx]
-            if circuit_meta is not None:
-                pub_metadata["circuit_metadata"] = circuit_meta
-
-        pub_result = SamplerPubResult(data=data_bin, metadata=pub_metadata)
-        pub_results.append(pub_result)
-
-    return PrimitiveResult(pub_results, metadata=metadata or {})

--- a/qiskit_ibm_runtime/executor_sampler/converters.py
+++ b/qiskit_ibm_runtime/executor_sampler/converters.py
@@ -24,7 +24,7 @@ from ..options_models import EnvironmentOptions, ExecutionOptions, ExecutorOptio
 
 if TYPE_CHECKING:
     from ..options_models import SamplerOptions
-    from ..quantum_program import QuantumProgramResult
+    from ..quantum_program import QuantumProgramResult, QuantumProgramItemResult
 
 
 def sampler_options_to_executor_options(options: SamplerOptions) -> ExecutorOptions:
@@ -50,6 +50,45 @@ def sampler_options_to_executor_options(options: SamplerOptions) -> ExecutorOpti
         executor_options.experimental.update(options.experimental)
 
     return executor_options
+
+
+def quantum_program_item_result_to_sampler_pub_result(
+    item: QuantumProgramItemResult,
+    meas_type: Literal["classified", "kerneled", "avg_kerneled"] = "classified",
+    circuit_metadata: dict | None = None,
+) -> SamplerPubResult:
+    """Convert a quantum program item result to a sampler pub result.
+
+    Args:
+        item: The result of a single item of a quantum program.
+        meas_type: The measurement type.
+        circuit_metadata: The metadata attached to the circuit in the input PUB.
+
+    Returns:
+        A sampler pub result.
+    """
+    # Infer pub_shape from the first classical register's data
+    # meas_data shape: (...pub_shape..., num_shots, num_bits)
+    first_meas_data = next(iter(item.values()))
+    pub_shape = first_meas_data.shape[:-2]
+
+    arrays = {}
+    for creg_name, meas_data in item.items():
+        if meas_type == "classified":
+            arrays[creg_name] = BitArray.from_bool_array(meas_data)
+        elif meas_type == "kerneled":
+            arrays[creg_name.removesuffix("_iq")] = meas_data
+        elif meas_type == "avg_kerneled":
+            arrays[creg_name.removesuffix("_avg_iq")] = meas_data
+
+    data_bin = DataBin(**arrays, shape=pub_shape)
+
+    # Get circuit metadata for this pub if available
+    pub_metadata = {}
+    if circuit_metadata is not None:
+        pub_metadata["circuit_metadata"] = circuit_metadata
+
+    return SamplerPubResult(data=data_bin, metadata=pub_metadata)
 
 
 def quantum_program_result_to_primitive_result(

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -62,7 +62,7 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     # Compute the ``num_randomizations`` from the left-most axis of the result arrays
     if twirling:
         if len(set_num_randomizations := {array.shape[0] for array in result[0].values()}) != 1:
-            raise ValueError("Unable to uniquely identity the number of randomizations.")
+            raise ValueError("Unable to uniquely identify the number of randomizations.")
         num_randomizations = next(iter(set_num_randomizations))
     else:
         num_randomizations = 0

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -59,6 +59,14 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     if (meas_type := post_processor_data.get("meas_type", None)) is None:
         raise ValueError("Missing 'meas_type' in passthrough data.")
 
+    # Compute the ``num_randomizations`` from the left-most axis of the result arrays
+    if twirling:
+        if len(set_num_randomizations := {array.shape[0] for array in result[0].values()}) != 1:
+            raise ValueError("Unable to uniquely identity the number of randomizations.")
+        num_randomizations = next(iter(set_num_randomizations))
+    else:
+        num_randomizations = 0
+
     for item in result:
         if len(item) == 0:
             raise ValueError("Found an item without data.")
@@ -75,14 +83,6 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     if len(set_shots := {array.shape[-2] for array in result[0].values()}) != 1:
         raise ValueError("Unable to uniquely identify the shots per PUB.")
     shots = next(iter(set_shots))
-
-    # Compute the ``num_randomizations`` from the left-most axis of the result arrays
-    if twirling:
-        if len(set_num_randomizations := {array.shape[0] for array in result[0].values()}) != 1:
-            raise ValueError("Unable to uniquely identity the number of randomizations.")
-        num_randomizations = next(iter(set_num_randomizations))
-    else:
-        num_randomizations = 0
 
     if twirling:
         for item, shape in zip(result, pub_shapes):

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, cast
 
 from qiskit.primitives import PrimitiveResult
 
-from ..converters import quantum_program_result_to_primitive_result
+from ..converters import quantum_program_item_result_to_sampler_pub_result
 from .utils import executor_metadata_to_sampler_metadata, flatten_twirling_axes, undo_twirling
 
 if TYPE_CHECKING:
@@ -76,7 +76,16 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     # Compute the shape of the input PUBs
     pub_shapes = [next(iter(item.values())).shape[1 if twirling else 0 : -2] for item in result]
 
-    for item, pub_shape in zip(result, pub_shapes):
+    # Extract circuit metadata if present and validate length
+    circuits_metadata = post_processor_data.get("circuits_metadata", None) or [None] * len(result)
+    if circuits_metadata is not None and len(circuits_metadata) != len(result):
+        raise ValueError(
+            f"Number of circuit metadata items ({len(circuits_metadata)}) does not match "
+            f"number of pubs ({len(result)})."
+        )
+
+    pub_results = []
+    for item, circuits_metadata, pub_shape in zip(result, circuits_metadata, pub_shapes):
         if len(item) == 0:
             raise ValueError("Found an item without data.")
 
@@ -85,14 +94,12 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
         if twirling:
             flatten_twirling_axes(item, pub_shape)
 
-    # Extract circuit metadata if present
-    circuits_metadata = post_processor_data.get("circuits_metadata", None)
+        pub_results.append(
+            quantum_program_item_result_to_sampler_pub_result(item, meas_type, circuits_metadata)
+        )
 
     metadata = executor_metadata_to_sampler_metadata(
         result.metadata, num_randomizations, shots, pub_shapes
     )
 
-    sampler_result = quantum_program_result_to_primitive_result(
-        result, metadata, meas_type, circuits_metadata
-    )
-    return sampler_result
+    return PrimitiveResult(pub_results, metadata=metadata or {})

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -67,6 +67,12 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     else:
         num_randomizations = 0
 
+    # Compute the shots from the second-to-last axis of the result arrays; this corresponds to
+    # PUB shots if twirling is OFF, and to ``shots_per_randomization`` if twirling is ON.
+    if len(set_shots := {array.shape[-2] for array in result[0].values()}) != 1:
+        raise ValueError("Unable to uniquely identify the shots per PUB.")
+    shots = next(iter(set_shots))
+
     for item in result:
         if len(item) == 0:
             raise ValueError("Found an item without data.")
@@ -77,12 +83,6 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     circuits_metadata = post_processor_data.get("circuits_metadata", None)
 
     pub_shapes = [next(iter(item.values())).shape[1 if twirling else 0 : -2] for item in result]
-
-    # Compute the shots from the second-to-last axis of the result arrays; this corresponds to
-    # PUB shots if twirling is OFF, and to ``shots_per_randomization`` if twirling is ON.
-    if len(set_shots := {array.shape[-2] for array in result[0].values()}) != 1:
-        raise ValueError("Unable to uniquely identify the shots per PUB.")
-    shots = next(iter(set_shots))
 
     if twirling:
         for item, shape in zip(result, pub_shapes):

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, cast
 from qiskit.primitives import PrimitiveResult
 
 from ..converters import quantum_program_result_to_primitive_result
-from .utils import executor_metadata_to_sampler_metadata, flatten_twirling_axes
+from .utils import executor_metadata_to_sampler_metadata, flatten_twirling_axes, undo_twirling
 
 if TYPE_CHECKING:
     from ...quantum_program.quantum_program_result import QuantumProgramResult
@@ -45,25 +45,6 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
     if len(result) == 0:
         return PrimitiveResult([])
 
-    # Apply measurement twirling bit flips
-    prefix = "measurement_flips."
-    for item in result:
-        flip_keys = [key for key in item.keys() if key.startswith(prefix)]
-
-        for flip_key in flip_keys:
-            target_key = flip_key[len(prefix) :]
-
-            # Validate that target key exists
-            if target_key not in item:
-                raise ValueError(
-                    f"Measurement flip key '{flip_key}' references non-existent "
-                    f"register '{target_key}'. Available registers: {list(item.keys())}"
-                )
-
-            # Apply XOR and remove flip key
-            flip_data = item.pop(flip_key)
-            item[target_key] ^= flip_data
-
     if not isinstance(result.passthrough_data, dict):
         raise ValueError(
             "Wrong type for passthrough data: Expected a 'dict', found "
@@ -77,6 +58,9 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
         raise ValueError("Missing 'twirling' in passthrough data.")
     if (meas_type := post_processor_data.get("meas_type", None)) is None:
         raise ValueError("Missing 'meas_type' in passthrough data.")
+
+    for item in result:
+        undo_twirling(item)
 
     # Extract circuit metadata if present
     circuits_metadata = post_processor_data.get("circuits_metadata", None)

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -73,20 +73,20 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
         raise ValueError("Unable to uniquely identify the shots per PUB.")
     shots = next(iter(set_shots))
 
-    for item in result:
+    # Compute the shape of the input PUBs
+    pub_shapes = [next(iter(item.values())).shape[1 if twirling else 0 : -2] for item in result]
+
+    for item, pub_shape in zip(result, pub_shapes):
         if len(item) == 0:
             raise ValueError("Found an item without data.")
 
         undo_twirling(item)
 
+        if twirling:
+            flatten_twirling_axes(item, pub_shape)
+
     # Extract circuit metadata if present
     circuits_metadata = post_processor_data.get("circuits_metadata", None)
-
-    pub_shapes = [next(iter(item.values())).shape[1 if twirling else 0 : -2] for item in result]
-
-    if twirling:
-        for item, shape in zip(result, pub_shapes):
-            flatten_twirling_axes(item, shape)
 
     metadata = executor_metadata_to_sampler_metadata(
         result.metadata, num_randomizations, shots, pub_shapes

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -60,13 +60,14 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
         raise ValueError("Missing 'meas_type' in passthrough data.")
 
     for item in result:
+        if len(item) == 0:
+            raise ValueError("Found an item without data.")
+
         undo_twirling(item)
 
     # Extract circuit metadata if present
     circuits_metadata = post_processor_data.get("circuits_metadata", None)
 
-    # TODO: This will fail for PUBs with no measurements, but it will also fail in many other
-    # places.
     pub_shapes = [next(iter(item.values())).shape[1 if twirling else 0 : -2] for item in result]
 
     # Compute the shots from the second-to-last axis of the result arrays; this corresponds to

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/post_processor_v0_1.py
@@ -85,7 +85,7 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
         )
 
     pub_results = []
-    for item, circuits_metadata, pub_shape in zip(result, circuits_metadata, pub_shapes):
+    for item, metadatum, pub_shape in zip(result, circuits_metadata, pub_shapes):
         if len(item) == 0:
             raise ValueError("Found an item without data.")
 
@@ -94,9 +94,8 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
         if twirling:
             flatten_twirling_axes(item, pub_shape)
 
-        pub_results.append(
-            quantum_program_item_result_to_sampler_pub_result(item, meas_type, circuits_metadata)
-        )
+        pub_result = quantum_program_item_result_to_sampler_pub_result(item, meas_type, metadatum)
+        pub_results.append(pub_result)
 
     metadata = executor_metadata_to_sampler_metadata(
         result.metadata, num_randomizations, shots, pub_shapes

--- a/qiskit_ibm_runtime/executor_sampler/post_processors/utils.py
+++ b/qiskit_ibm_runtime/executor_sampler/post_processors/utils.py
@@ -30,6 +30,32 @@ if TYPE_CHECKING:
         QuantumProgramItemResult,
     )
 
+TWIRLING_PREFIX = "measurement_flips."
+"""The prefix used to store the twirling bitflips."""
+
+
+def undo_twirling(item: QuantumProgramItemResult) -> None:
+    """Undo twirling bit flips.
+
+    This function modifies ``item`` in place, mutating the measurement results and
+    popping the arrays that store the bitflips.
+    """
+    flip_keys = [key for key in item.keys() if key.startswith(TWIRLING_PREFIX)]
+
+    for flip_key in flip_keys:
+        target_key = flip_key[len(TWIRLING_PREFIX) :]
+
+        # Validate that target key exists
+        if target_key not in item:
+            raise ValueError(
+                f"Measurement flip key '{flip_key}' references non-existent "
+                f"register '{target_key}'. Available registers: {list(item.keys())}"
+            )
+
+        # Apply XOR and remove flip key
+        flip_data = item.pop(flip_key)
+        item[target_key] ^= flip_data
+
 
 def executor_metadata_to_sampler_metadata(
     metadata: Metadata,

--- a/test/unit/sampler_v2/test_sampler_v2_post_processor.py
+++ b/test/unit/sampler_v2/test_sampler_v2_post_processor.py
@@ -21,7 +21,7 @@ from ddt import data, ddt
 from qiskit.primitives import PrimitiveResult
 
 from qiskit_ibm_runtime.executor_sampler.converters import (
-    quantum_program_result_to_primitive_result,
+    quantum_program_item_result_to_sampler_pub_result,
 )
 from qiskit_ibm_runtime.executor_sampler.post_processors.post_processor_v0_1 import (
     sampler_v2_post_processor_v0_1,
@@ -29,17 +29,14 @@ from qiskit_ibm_runtime.executor_sampler.post_processors.post_processor_v0_1 imp
 from qiskit_ibm_runtime.options_models.sampler_options import SamplerOptions
 from qiskit_ibm_runtime.quantum_program.quantum_program_result import (
     QuantumProgramResult,
+    QuantumProgramItemResult,
     Metadata,
 )
 
 
 @ddt
-class TestSamplerV2StaticMethod(unittest.TestCase):
-    """Test SamplerV2.quantum_program_result_to_primitive_result() static method.
-
-    This class contains comprehensive tests for the static method that performs
-    the actual conversion logic from QuantumProgramResult to PrimitiveResult.
-    """
+class TestQuantumProgramItemResultToSamplerPubResult(unittest.TestCase):
+    """Test ``quantum_program_item_result_to_sampler_pub_result``."""
 
     def test_single_pub_multiple_registers(self):
         """Test conversion with single pub and multiple classical registers."""
@@ -52,28 +49,10 @@ class TestSamplerV2StaticMethod(unittest.TestCase):
             0, 2, size=(num_rands, num_shots_per_rand, 3), dtype=np.uint8
         )
 
-        options = SamplerOptions()
-        options.twirling.enable_gates = True
-        passthrough_data = {
-            "post_processor": {
-                "version": "v0.1",
-                "options": asdict(options),
-                "twirling": True,
-                "meas_type": "classified",
-            }
-        }
-
-        qp_result = QuantumProgramResult(
-            data=[{"c1": meas_data_c1, "c2": meas_data_c2}],
-            metadata=Metadata(),
-            passthrough_data=passthrough_data,
-        )
-        qp_result._semantic_role = "sampler_v2"
-
-        result = quantum_program_result_to_primitive_result(qp_result)
+        item = QuantumProgramItemResult({"c1": meas_data_c1, "c2": meas_data_c2})
+        pub_result = quantum_program_item_result_to_sampler_pub_result(item)
 
         # Verify both registers are present
-        pub_result = result[0]
         self.assertIn("c1", pub_result.data)
         self.assertIn("c2", pub_result.data)
 
@@ -81,188 +60,28 @@ class TestSamplerV2StaticMethod(unittest.TestCase):
         self.assertEqual(pub_result.data.c1.num_bits, 2)
         self.assertEqual(pub_result.data.c2.num_bits, 3)
 
-    def test_multiple_pubs(self):
-        """Test conversion with multiple pubs."""
-        num_shots = 100
-        meas_data_1 = np.random.randint(0, 2, size=(num_shots, 2), dtype=np.uint8)
-        meas_data_2 = np.random.randint(0, 2, size=(num_shots, 3), dtype=np.uint8)
-        meas_data_3 = np.random.randint(0, 2, size=(num_shots, 4), dtype=np.uint8)
-
-        qp_result = QuantumProgramResult(
-            data=[
-                {"meas": meas_data_1},
-                {"meas": meas_data_2},
-                {"meas": meas_data_3},
-            ],
-            metadata=Metadata(),
+    @data("circuit_metadata", [None, {"metadata": "val"}])
+    def test_metadata_preservation(self, circuit_metadata):
+        """Test that circuit metadata is attached correctly to the result."""
+        item = QuantumProgramItemResult({"c": np.array([[5]], dtype=np.uint8)})
+        result = quantum_program_item_result_to_sampler_pub_result(
+            item, "kerneled", circuit_metadata
         )
-
-        result = quantum_program_result_to_primitive_result(qp_result)
-
-        # Verify number of pubs
-        self.assertEqual(len(result), 3)
-
-        # Verify each pub
-        self.assertEqual(result[0].data.meas.num_bits, 2)
-        self.assertEqual(result[1].data.meas.num_bits, 3)
-        self.assertEqual(result[2].data.meas.num_bits, 4)
-
-    def test_missing_measurement_data(self):
-        """Test error when measurement data is missing."""
-        qp_result = QuantumProgramResult(
-            data=[{}],  # Empty data
-            metadata=Metadata(),
-        )
-
-        with self.assertRaises(ValueError) as context:
-            quantum_program_result_to_primitive_result(qp_result)
-
-        self.assertIn("no measurement data", str(context.exception).lower())
-
-    def test_metadata_preservation(self):
-        """Test that metadata is preserved in the result."""
-        qp_result = QuantumProgramResult(
-            data=[{"c": np.array([[5]], dtype=np.uint8)}],  # 1 byte
-            metadata=Metadata(),
-        )
-
-        metadata = {"metadata": "val"}
-        result = quantum_program_result_to_primitive_result(qp_result, metadata)
 
         # Verify metadata is present
-        self.assertEqual(result.metadata, metadata)
-
-    def test_circuit_metadata_multiple_pubs(self):
-        """Test that circuit metadata is correctly placed for multiple pubs."""
-        qp_result = QuantumProgramResult(
-            data=[
-                {"c": np.array([[5]], dtype=np.uint8)},
-                {"c": np.array([[3]], dtype=np.uint8)},
-                {"c": np.array([[7]], dtype=np.uint8)},
-            ],
-            metadata=Metadata(),
-        )
-
-        circuits_metadata = [
-            {"experiment_id": "exp_001", "param": 1},
-            {"experiment_id": "exp_002", "param": 2},
-            {},
-        ]
-
-        result = quantum_program_result_to_primitive_result(
-            qp_result, metadata=None, circuits_metadata=circuits_metadata
-        )
-
-        # Verify each pub has correct circuit metadata
-        self.assertEqual(len(result), 3)
-        for idx, pub_result in enumerate(result):
-            self.assertIn("circuit_metadata", pub_result.metadata)
-            self.assertEqual(pub_result.metadata["circuit_metadata"], circuits_metadata[idx])
-
-    def test_circuit_metadata_none(self):
-        """Test that None circuit metadata is handled correctly."""
-        qp_result = QuantumProgramResult(
-            data=[{"c": np.array([[5]], dtype=np.uint8)}],
-            metadata=Metadata(),
-        )
-
-        circuits_metadata = [None]
-
-        result = quantum_program_result_to_primitive_result(
-            qp_result, metadata=None, circuits_metadata=circuits_metadata
-        )
-
-        # Verify pub result has empty metadata when circuit metadata is None
-        pub_result = result[0]
-        self.assertNotIn("circuit_metadata", pub_result.metadata)
-        self.assertEqual(pub_result.metadata, {})
-
-    def test_circuit_metadata_missing(self):
-        """Test that missing circuits_metadata parameter results in empty pub metadata."""
-        qp_result = QuantumProgramResult(
-            data=[{"c": np.array([[5]], dtype=np.uint8)}],
-            metadata=Metadata(),
-        )
-
-        result = quantum_program_result_to_primitive_result(
-            qp_result, metadata=None, circuits_metadata=None
-        )
-
-        # Verify pub result has empty metadata
-        pub_result = result[0]
-        self.assertEqual(pub_result.metadata, {})
-
-    def test_circuit_metadata_length_mismatch(self):
-        """Test that mismatched circuits_metadata length raises ValueError."""
-        qp_result = QuantumProgramResult(
-            data=[
-                {"c": np.array([[5]], dtype=np.uint8)},
-                {"c": np.array([[3]], dtype=np.uint8)},
-                {"c": np.array([[7]], dtype=np.uint8)},
-            ],
-            metadata=Metadata(),
-        )
-
-        # Provide metadata for only 2 pubs when there are 3
-        circuits_metadata = [
-            {"experiment_id": "exp_001"},
-            {"experiment_id": "exp_002"},
-        ]
-
-        with self.assertRaises(ValueError) as context:
-            quantum_program_result_to_primitive_result(
-                qp_result, metadata=None, circuits_metadata=circuits_metadata
-            )
-
-        self.assertIn("does not match", str(context.exception))
-
-    def test_different_register_names(self):
-        """Test that any register name works (not hardcoded)."""
-        num_shots = 50
-        # Use unusual register names: 2 bits, 3 bits
-        meas_data_custom1 = np.random.randint(0, 2, size=(num_shots, 2), dtype=np.uint8)
-        meas_data_custom2 = np.random.randint(0, 2, size=(num_shots, 3), dtype=np.uint8)
-
-        qp_result = QuantumProgramResult(
-            data=[{"my_reg": meas_data_custom1, "another_reg": meas_data_custom2}],
-            metadata=Metadata(),
-        )
-
-        result = quantum_program_result_to_primitive_result(qp_result)
-
-        # Verify custom register names are preserved
-        pub_result = result[0]
-        self.assertIn("my_reg", pub_result.data)
-        self.assertIn("another_reg", pub_result.data)
+        self.assertEqual(result.metadata["circuit_metadata"], circuit_metadata)
 
     def test_bit_array_data_integrity(self):
         """Test that BitArray data matches input measurement data."""
         num_shots = 10
         num_bits = 4
-        # Create specific measurement data to verify integrity
-        meas_data = np.array(
-            [
-                [1, 0, 1, 0],
-                [0, 1, 0, 1],
-                [1, 1, 0, 0],
-                [0, 0, 1, 1],
-                [1, 0, 0, 1],
-                [0, 1, 1, 0],
-                [1, 1, 1, 1],
-                [0, 0, 0, 0],
-                [1, 0, 1, 1],
-                [0, 1, 0, 0],
-            ],
-            dtype=np.uint8,
-        )
 
-        qp_result = QuantumProgramResult(
-            data=[{"meas": meas_data}],
-            metadata=Metadata(),
+        item = QuantumProgramItemResult(
+            {"meas": np.random.randint(0, 2, size=(num_shots, num_bits), dtype=np.uint8)}
         )
+        result = quantum_program_item_result_to_sampler_pub_result(item)
 
-        result = quantum_program_result_to_primitive_result(qp_result)
-        bit_array = result[0].data.meas
+        bit_array = result.data.meas
 
         # Verify the BitArray contains the same data
         self.assertEqual(bit_array.num_shots, num_shots)
@@ -288,58 +107,15 @@ class TestSamplerV2StaticMethod(unittest.TestCase):
         suffix = "_avg_iq" if meas_type == "avg_kerneled" else "_iq"
         register_name_with_suffix = f"meas{suffix}"
 
-        qp_result = QuantumProgramResult(
-            data=[{register_name_with_suffix: meas_data}],
-            metadata=Metadata(),
-        )
-
-        result = quantum_program_result_to_primitive_result(qp_result, meas_type=meas_type)
+        item = QuantumProgramItemResult({register_name_with_suffix: meas_data})
+        result = quantum_program_item_result_to_sampler_pub_result(item, meas_type=meas_type)
 
         # Verify suffix was removed and data is accessible without suffix
-        self.assertIn("meas", result[0].data)
-        self.assertNotIn(register_name_with_suffix, result[0].data)
-        result_array = result[0].data.meas
+        self.assertIn("meas", result.data)
+        self.assertNotIn(register_name_with_suffix, result.data)
 
         # Verify the result array contains the same data
-        np.testing.assert_array_equal(result_array, meas_data)
-
-    def test_empty_pub_shape(self):
-        """Test conversion with empty pub shape (non-parametric circuit)."""
-        num_shots = 50
-        num_bits = 2
-        # Shape is () for non-parametric circuits
-        meas_data = np.random.randint(0, 2, size=(num_shots, num_bits), dtype=np.uint8)
-
-        qp_result = QuantumProgramResult(
-            data=[{"c": meas_data}],
-            metadata=Metadata(),
-        )
-
-        result = quantum_program_result_to_primitive_result(qp_result)
-
-        # Verify pub shape is empty tuple
-        pub_result = result[0]
-        self.assertEqual(pub_result.data.shape, ())
-
-    def test_complex_parameter_sweep_shape(self):
-        """Test conversion with complex multi-dimensional parameter sweep."""
-        num_shots = 100
-        num_bits = 2
-        sweep_shape = (2, 3, 4)  # 3D parameter sweep
-        meas_data = np.random.randint(
-            0, 2, size=sweep_shape + (num_shots, num_bits), dtype=np.uint8
-        )
-
-        qp_result = QuantumProgramResult(
-            data=[{"c": meas_data}],
-            metadata=Metadata(),
-        )
-
-        result = quantum_program_result_to_primitive_result(qp_result)
-
-        # Verify complex shape is preserved
-        pub_result = result[0]
-        self.assertEqual(pub_result.data.shape, sweep_shape)
+        np.testing.assert_array_equal(result.data.meas, meas_data)
 
 
 class TestSamplerV2PostProcessor(unittest.TestCase):


### PR DESCRIPTION
This PR:

1. Tweaks post-processing utility functions so that they act on `QuantumProgramItemResult` objects, as opposed to `QuantumProgramResult` objects. (This simplifies life with [this issue](https://github.com/Qiskit/qiskit-ibm-runtime/issues/2791))
2. Removes the last remaining TODO.