### PR TITLE
Fix wrapper sampler experimental image in sequential runs

### DIFF
--- a/qiskit_ibm_runtime/options_models/sampler_options.py
+++ b/qiskit_ibm_runtime/options_models/sampler_options.py
@@ -79,7 +79,7 @@ class SamplerOptions:
 
         executor_options.environment.max_execution_time = self.max_execution_time
         if self.experimental:
-            executor_options.environment.image = self.experimental.pop("image", None)
+            executor_options.environment.image = self.experimental.get("image", None)
             executor_options.experimental.update(self.experimental)
 
         return executor_options


### PR DESCRIPTION
### Summary
When converting to `ExecutorOptions` the `SamplerOptions` pop the `image` field from the experimental options. This mutates the options and causes subsequent runs to not use the desired image as the first run. This PR swaps the pop for a get.