### PR TITLE
broken link in release notes for 0.47.0

### DIFF
--- a/release-notes/0.47.0.rst
+++ b/release-notes/0.47.0.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added the `Executor` and `QuantumProgram` classes, which allow taking full advantage of the set of
-  capabilities offered by the `Samplomatic <https://github.com/Qiskit/samplomatic>`__ package.
+  capabilities offered by the `Samplomatic <https://github.com/Qiskit/samplomatic>`_ package.
 - Added the `NoiseLearnerV3` class to learn the noise of instructions that contain annotated boxes.
 - Added a script to fetch configuration and properties of a real backend.
 - One new fake backend, ``FakeKingston``, has been added. This is a 156-qubit Heron r2 device. (`2711 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2711>`__)

--- a/release-notes/0.47.0.rst
+++ b/release-notes/0.47.0.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added the `Executor` and `QuantumProgram` classes, which allow taking full advantage of the set of
-  capabilities offered by the `Samplomatic <https://github.com/Qiskit/samplomatic>_` package.
+  capabilities offered by the `Samplomatic <https://github.com/Qiskit/samplomatic>`__ package.
 - Added the `NoiseLearnerV3` class to learn the noise of instructions that contain annotated boxes.
 - Added a script to fetch configuration and properties of a real backend.
 - One new fake backend, ``FakeKingston``, has been added. This is a 156-qubit Heron r2 device. (`2711 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/2711>`__)


### PR DESCRIPTION
Fix rst in release notes so that the link to the Samplomatic repo will work properly now.

<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
