### PR TITLE
Introduce `backend.calibrate`

### DIFF
--- a/qiskit_ibm_runtime/constants.py
+++ b/qiskit_ibm_runtime/constants.py
@@ -27,5 +27,5 @@ DEFAULT_DECODERS: dict[str, type[ResultDecoder] | list[type[ResultDecoder]]] = {
     "noise-learner": NoiseLearnerResultDecoder,
     "circuit-runner": RunnerResult,
     "qasm3-runner": RunnerResult,
-    "calibrations": ResultDecoder
+    "calibrations": ResultDecoder,
 }

--- a/qiskit_ibm_runtime/constants.py
+++ b/qiskit_ibm_runtime/constants.py
@@ -27,4 +27,5 @@ DEFAULT_DECODERS: dict[str, type[ResultDecoder] | list[type[ResultDecoder]]] = {
     "noise-learner": NoiseLearnerResultDecoder,
     "circuit-runner": RunnerResult,
     "qasm3-runner": RunnerResult,
+    "calibrations": ResultDecoder
 }

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -506,6 +506,7 @@ class IBMBackend(Backend):
         return self._service._run(
             program_id="calibrations",
             inputs={},
+            options={"backend": self},
             result_decoder=ResultDecoder,
         )
 

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -23,6 +23,7 @@ from qiskit.result import MeasLevel, MeasReturnType
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
 from qiskit_ibm_runtime.utils.result_decoder import ResultDecoder
+from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
 from qiskit_ibm_runtime.default_session import get_cm_session
 
 from .exceptions import (

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -22,6 +22,8 @@ from copy import deepcopy
 from qiskit.result import MeasLevel, MeasReturnType
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
+from qiskit_ibm_runtime.utils.result_decoder import ResultDecoder
+from qiskit_ibm_runtime.default_session import get_cm_session
 
 from .exceptions import (
     IBMBackendApiProtocolError,
@@ -492,6 +494,29 @@ class IBMBackend(Backend):
             "Support for backend.run() has been removed. Please see our migration guide "
             "https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime for instructions "
             "on how to migrate to the primitives interface."
+        )
+
+    def calibrate(self) -> RuntimeJobV2:
+        """Calibrates the backend.
+
+        Returns:
+            A job.
+        """
+        if self._session:
+            _run = self._session._run
+        else:
+            _run = self._service._run
+
+            if get_cm_session():
+                logger.warning(
+                    "Even though a session/batch context manager is open this job will run in job "
+                    "mode.",
+                )
+
+        return _run(
+            program_id="calibrations",
+            inputs={},
+            result_decoder=ResultDecoder,
         )
 
     def get_translation_stage_plugin(self) -> str:

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -23,8 +23,8 @@ from qiskit.result import MeasLevel, MeasReturnType
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
 from qiskit_ibm_runtime.utils.result_decoder import ResultDecoder
+from qiskit_ibm_runtime.utils.default_session import get_cm_session
 from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
-from qiskit_ibm_runtime.default_session import get_cm_session
 
 from .exceptions import (
     IBMBackendApiProtocolError,

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -503,18 +503,7 @@ class IBMBackend(Backend):
         Returns:
             A job.
         """
-        if self._session:
-            _run = self._session._run
-        else:
-            _run = self._service._run
-
-            if get_cm_session():
-                logger.warning(
-                    "Even though a session/batch context manager is open this job will run in job "
-                    "mode.",
-                )
-
-        return _run(
+        return self._service._run(
             program_id="calibrations",
             inputs={},
             result_decoder=ResultDecoder,


### PR DESCRIPTION
### Summary

Allows the following:
```python
cal_job = backend.calibrate()
cal_job.result()
```

### Details and comments
Fixes #2829
