### PR TITLE
Removed integration test that fails due to missing measurements

### DIFF
--- a/test/integration/test_sampler_v2.py
+++ b/test/integration/test_sampler_v2.py
@@ -444,11 +444,6 @@ class TestSampler(IBMIntegrationTestCase):
             b = ClassicalRegister(2, "b")
             c = ClassicalRegister(3, "c")
 
-            qc = QuantumCircuit(QuantumRegister(3), a, b, c)
-            qc.h(range(3))
-            target = {"a": {0: 10000}, "b": {0: 10000}, "c": {0: 10000}}
-            cases.append(("no measure", pm.run(qc), target))
-
             for title, qc, target in cases:
                 with self.subTest(title):
                     sampler = Sampler(mode=session, options=self._options)


### PR DESCRIPTION
Recently, the server started raising validation errors when it finds circuits without measurements, as a way to ensure that customer jobs yield value