### PR TITLE
Allow instance auto selection without warning

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -147,6 +147,10 @@ class QiskitRuntimeService:
             Name (CRN) or the service name. If set, it will define an instance for
             service instantiation, if not set, the service will fetch all instances accessible
             within the account following the specified filtering criteria.
+            Pass ``"auto"`` to explicitly request auto-selection without triggering the
+            "instance not set" warning. This value can also be saved to the account file
+            via :meth:`.save_account` so it takes effect automatically on every
+            instantiation.
         proxies: Proxy configuration. Supported optional keys are ``urls`` (a
             dictionary mapping protocol or protocol and host to the URL of the proxy, documented
             at https://requests.readthedocs.io/en/latest/api/#requests.Session.proxies),
@@ -208,6 +212,9 @@ class QiskitRuntimeService:
         super().__init__()
         self._all_instances: list[dict[str, Any]] = []
         self._saved_instances: list[str] = []
+        self._instance_auto = instance == "auto"
+        if self._instance_auto:
+            instance = None
         self._account = self._discover_account(
             token=token,
             url=url,
@@ -218,6 +225,9 @@ class QiskitRuntimeService:
             proxies=ProxyConfiguration(**proxies) if proxies else None,
             verify=verify,
         )
+        if self._account.instance == "auto":
+            self._account.instance = None
+            self._instance_auto = True
 
         if private_endpoint is not None:
             self._account.private_endpoint = private_endpoint
@@ -273,21 +283,24 @@ class QiskitRuntimeService:
 
             filters = f"(tags: {tags_str}, region: {region_str}{plans_preference_str}"
 
-            logger.warning(
-                "Instance was not set at service instantiation. %s"
-                "Based on the following filters: %s, "
-                "the available account instances are: %s. "
-                "If you need a specific instance set it explicitly either by "
-                "using a saved account with a saved default instance or passing it "
-                "in directly to QiskitRuntimeService().",
-                (
-                    ""
-                    if self._plans_preference
-                    else "Free and trial plan instances will be prioritized. "
-                ),
-                filters,
-                ", ".join(instance_names),
-            )
+            if not self._instance_auto:
+                logger.warning(
+                    "Instance was not set at service instantiation. %s"
+                    "Based on the following filters: %s, "
+                    "the available account instances are: %s. "
+                    "If you need a specific instance set it explicitly either by "
+                    "using a saved account with a saved default instance or passing it "
+                    "in directly to QiskitRuntimeService(). "
+                    "Alternatively, pass instance='auto' or save it to your account for "
+                    "auto-selection without warning.",
+                    (
+                        ""
+                        if self._plans_preference
+                        else "Free and trial plan instances will be prioritized. "
+                    ),
+                    filters,
+                    ", ".join(instance_names),
+                )
             for inst, _ in instance_backends:
                 self._get_or_create_cloud_client(inst)
 
@@ -453,6 +466,7 @@ class QiskitRuntimeService:
         if (
             account.channel in ["ibm_cloud", "ibm_quantum_platform"]
             and account.instance
+            and account.instance != "auto"
             and not is_crn(account.instance)
         ):
             account.instance = self._get_crn_from_instance_name(
@@ -589,7 +603,7 @@ class QiskitRuntimeService:
                 if name not in backends_available:
                     continue
                 backends_available = [name]
-            else:
+            elif not self._instance_auto:
                 for inst_details in self._backend_instance_groups:
                     if inst == inst_details["crn"]:
                         logger.warning(
@@ -600,7 +614,7 @@ class QiskitRuntimeService:
             for backend_name in backends_available:
                 if backend_name in unique_backends:
                     continue
-                if name:
+                if name and not self._instance_auto:
                     for inst_details in self._backend_instance_groups:
                         if inst == inst_details["crn"]:
                             logger.warning(
@@ -819,6 +833,8 @@ class QiskitRuntimeService:
             instance: This is an optional parameter to specify the CRN  or service name.
                 If set, it will define a default instance for service instantiation,
                 if not set, the service will fetch all instances accessible within the account.
+                Set to ``"auto"`` to explicitly save auto-selection as the preference, which
+                suppresses the "instance not set" warning on subsequent instantiations.
             channel: Channel type. ``ibm_cloud`` or ``ibm_quantum_platform``.
             filename: Full path of the file where the account is saved.
             name: Name of the account to save.

--- a/release-notes/unreleased/2854.feat.rst
+++ b/release-notes/unreleased/2854.feat.rst
@@ -1,0 +1,5 @@
+Added support for ``instance="auto"`` in :class:`.QiskitRuntimeService` and
+:meth:`.QiskitRuntimeService.save_account`. Passing ``instance="auto"`` explicitly
+opts in to automatic instance selection without triggering the "instance was not set"
+warning or the "Loading/Using instance" warnings during backend retrieval. The value
+can be saved to the account file so it takes effect on every subsequent instantiation.

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -903,7 +903,9 @@ class TestEnableAccount(IBMTestCase):
 
     def test_instance_auto_flag_set(self):
         """instance='auto' sets _instance_auto and leaves account.instance as None."""
-        service = FakeRuntimeService(channel="ibm_quantum_platform", token="my_token", instance="auto")
+        service = FakeRuntimeService(
+            channel="ibm_quantum_platform", token="my_token", instance="auto"
+        )
         self.assertTrue(service._instance_auto)
         self.assertIsNone(service._account.instance)
 

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -901,6 +901,34 @@ class TestEnableAccount(IBMTestCase):
             with self.assertRaises(IBMInputValueError):
                 _ = FakeRuntimeService(channel="ibm_quantum_platform", instance=instance)
 
+    def test_instance_auto_flag_set(self):
+        """instance='auto' sets _instance_auto and leaves account.instance as None."""
+        service = FakeRuntimeService(channel="ibm_quantum_platform", token="my_token", instance="auto")
+        self.assertTrue(service._instance_auto)
+        self.assertIsNone(service._account.instance)
+
+    def test_instance_auto_suppresses_init_warning(self):
+        """instance='auto' must not trigger the 'instance was not set' warning during init."""
+        # "Loading account with the given token" warning fires regardless; check only for
+        # the absence of the specific instance warning. Contrast with no-instance service.
+        with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
+            FakeRuntimeService(channel="ibm_quantum_platform", token="my_token")
+        self.assertTrue(any("Instance was not set" in msg for msg in logs.output))
+
+        with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
+            FakeRuntimeService(channel="ibm_quantum_platform", token="my_token", instance="auto")
+        self.assertFalse(any("Instance was not set" in msg for msg in logs.output))
+
+    def test_saved_account_instance_auto_sets_flag(self):
+        """A saved account with instance='auto' sets _instance_auto and clears the instance."""
+        saved_account = Account.create_account(
+            channel="ibm_quantum_platform", token="my_token", instance="auto"
+        )
+        with patch.object(FakeRuntimeService, "_discover_account", return_value=saved_account):
+            service = FakeRuntimeService(channel="ibm_quantum_platform", token="my_token")
+        self.assertTrue(service._instance_auto)
+        self.assertIsNone(service._account.instance)
+
     def _verify_prefs(self, prefs, account):
         if "proxies" in prefs:
             self.assertEqual(account.proxies, ProxyConfiguration(**prefs["proxies"]))

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -13,14 +13,22 @@
 """Backends Filtering Test."""
 
 import uuid
+from unittest import mock
+
 from ddt import ddt, named_data
 
+from qiskit_ibm_runtime.accounts import Account
 from qiskit_ibm_runtime.fake_provider import FakeLimaV2
 
 from .mock.fake_runtime_service import FakeRuntimeService
 from .mock.fake_api_backend import FakeApiBackendSpecs
 from ..ibm_test_case import IBMTestCase
 from ..decorators import run_cloud_fake
+
+
+def _make_auto_service():
+    """Return a FakeRuntimeService instantiated with instance='auto'."""
+    return FakeRuntimeService(channel="ibm_quantum_platform", token="my_token", instance="auto")
 
 
 class TestBackendFilters(IBMTestCase):
@@ -36,6 +44,32 @@ class TestBackendFilters(IBMTestCase):
         with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
             service.backend("common_backend")
         self.assertIn("Using instance", logs.output[0])
+
+    def test_instance_auto_suppresses_backends_loading_warning(self):
+        """instance='auto' must suppress 'Loading instance' warnings in backends()."""
+        # Create service outside the log capture so init's "Loading account" doesn't interfere.
+        service = _make_auto_service()
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            service.backends()
+
+    def test_instance_auto_suppresses_backend_using_warning(self):
+        """instance='auto' must suppress 'Using instance' warning when looking up by name."""
+        service = _make_auto_service()
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            service.backend(FakeRuntimeService.DEFAULT_COMMON_BACKEND)
+
+    def test_saved_account_instance_auto_suppresses_warnings(self):
+        """A saved account with instance='auto' must suppress backend instance warnings."""
+        saved_account = Account.create_account(
+            channel="ibm_quantum_platform", token="my_token", instance="auto"
+        )
+        with mock.patch.object(FakeRuntimeService, "_discover_account", return_value=saved_account):
+            service = FakeRuntimeService(channel="ibm_quantum_platform", token="my_token")
+
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            service.backends()
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            service.backend(FakeRuntimeService.DEFAULT_COMMON_BACKEND)
 
     @run_cloud_fake
     def test_no_filter(self, service):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `instance` parameter in `QiskitRuntimeService()` is optional, but if you skip it, you get a warning. This was added by #2374 to emphasize that you should always specify an instance as where you run has implications in billing, priority and limits. But if it's an optional parameter, there should be a way to run it that way without getting a warning. 

### Details and comments

This allows you to specify `instance="auto"` when instantiating `QiskitRuntimeService` and when saving an account. It behaves the same way as specifying `None` but doesn't issue the warning. 

cc @francabrera as we discussed this late last year. 