### PR TITLE
Allow passing use_fractional_gates to least_busy

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -919,16 +919,10 @@ class QiskitRuntimeService:
             name: Name of the backend.
             instance: Specify the IBM Cloud account CRN.
             use_fractional_gates: Set True to allow for the backends to include
-                fractional gates. Currently this feature cannot be used
-                simultaneously with dynamic circuits, PEC, PEA, or gate
-                twirling.  When this flag is set, control flow instructions are
-                automatically removed from the backend.
-                When you use a dynamic circuits feature (e.g. ``if_else``) in your
-                algorithm, you must disable this flag to create executable ISA circuits.
-                This flag might be modified or removed when our backend
-                supports dynamic circuits and fractional gates simultaneously.
-                If ``None``, then both fractional gates and control flow operations are
-                included in the backends.
+                fractional gates. See
+                `When not to use fractional gates
+                <https://quantum.cloud.ibm.com/docs/en/guides/fractional-gates#when-not-to-use-fractional-gates>`_
+                for limitations.
             calibration_id: The calibration id used for instantiating the backend.
 
         Returns:
@@ -1280,6 +1274,7 @@ class QiskitRuntimeService:
         min_num_qubits: int | None = None,
         instance: str | None = None,
         filters: Callable[[ibm_backend.IBMBackend], bool] | None = None,
+        use_fractional_gates: bool | None = False,
         **kwargs: Any,
     ) -> ibm_backend.IBMBackend:
         """Return the least busy available backend.
@@ -1292,10 +1287,16 @@ class QiskitRuntimeService:
 
                     QiskitRuntimeService.least_busy(n_qubits=5, operational=True)
 
+            use_fractional_gates: When ``True``, only backends that include
+                fractional gates are considered, and fractional gates are included
+                in the returned backend. See
+                `When not to use fractional gates
+                <https://quantum.cloud.ibm.com/docs/en/guides/fractional-gates#when-not-to-use-fractional-gates>`_
+                for limitations.
             kwargs: Additional arguments passed to the backend query.
 
         Returns:
-            The backend with the fewest number of pending jobs.
+            The least busy backend with the fewest number of pending jobs.
 
         Raises:
             QiskitBackendNotFoundError: If no backend matches the criteria.
@@ -1340,7 +1341,10 @@ class QiskitRuntimeService:
         for back in sorted_backends:
             # We don't know whether or not the backend has a valid config
             try:
-                return self.backend(name=back["name"])
+                backend = self.backend(name=back["name"], use_fractional_gates=use_fractional_gates)
+                if use_fractional_gates and "rzz" not in backend.basis_gates:
+                    continue
+                return backend
             except Exception:
                 pass
         raise QiskitBackendNotFoundError("No backend matches the criteria.")

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -1296,7 +1296,7 @@ class QiskitRuntimeService:
             kwargs: Additional arguments passed to the backend query.
 
         Returns:
-            The least busy backend with the fewest number of pending jobs.
+            The backend with the fewest number of pending jobs.
 
         Raises:
             QiskitBackendNotFoundError: If no backend matches the criteria.
@@ -1341,10 +1341,7 @@ class QiskitRuntimeService:
         for back in sorted_backends:
             # We don't know whether or not the backend has a valid config
             try:
-                backend = self.backend(name=back["name"], use_fractional_gates=use_fractional_gates)
-                if use_fractional_gates and "rzz" not in backend.basis_gates:
-                    continue
-                return backend
+                return self.backend(name=back["name"], use_fractional_gates=use_fractional_gates)
             except Exception:
                 pass
         raise QiskitBackendNotFoundError("No backend matches the criteria.")

--- a/release-notes/unreleased/2855.feat.rst
+++ b/release-notes/unreleased/2855.feat.rst
@@ -1,0 +1,5 @@
+Added a ``use_fractional_gates`` parameter to :meth:`.QiskitRuntimeService.least_busy`,
+matching the behavior of the same parameter in :meth:`.QiskitRuntimeService.backend`.
+When set to ``True``, only backends that include fractional gates in their basis gates are
+considered; backends without it are skipped in favor of the next least busy qualifying
+backend.

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -98,13 +98,11 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(n_qubits=n_qubits, local=True),
         ]
 
-        services = self._get_services(fake_backends)
-        for service in services:
-            with self.subTest(service=service.channel):
-                filtered_backends = service.backends(n_qubits=n_qubits, local=False)
-                self.assertTrue(len(filtered_backends), 1)
-                self.assertEqual(n_qubits, filtered_backends[0].configuration().n_qubits)
-                self.assertFalse(filtered_backends[0].configuration().local)
+        service = self._get_services(fake_backends)
+        filtered_backends = service.backends(n_qubits=n_qubits, local=False)
+        self.assertTrue(len(filtered_backends), 1)
+        self.assertEqual(n_qubits, filtered_backends[0].configuration().n_qubits)
+        self.assertFalse(filtered_backends[0].configuration().local)
 
     def test_filter_status_dict(self):
         """Test filtering by dictionary of mixed status/configuration properties."""
@@ -115,17 +113,15 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(operational=False, simulator=False),
         ]
 
-        services = self._get_services(fake_backends)
-        for service in services:
-            with self.subTest(service=service.channel):
-                filtered_backends = service.backends(
-                    operational=True,  # from status
-                    simulator=True,  # from configuration
-                )
-                self.assertTrue(len(filtered_backends), 2)
-                for backend in filtered_backends:
-                    self.assertTrue(backend.status().operational)
-                    self.assertTrue(backend.configuration().simulator)
+        service = self._get_services(fake_backends)
+        filtered_backends = service.backends(
+            operational=True,  # from status
+            simulator=True,  # from configuration
+        )
+        self.assertTrue(len(filtered_backends), 2)
+        for backend in filtered_backends:
+            self.assertTrue(backend.status().operational)
+            self.assertTrue(backend.configuration().simulator)
 
     def test_filter_config_callable(self):
         """Test filtering by lambda function on configuration properties."""
@@ -136,15 +132,88 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(n_qubits=n_qubits - 1),
         ]
 
-        services = self._get_services(fake_backends)
-        for service in services:
-            with self.subTest(service=service.channel):
-                filtered_backends = service.backends(
-                    filters=lambda x: (x.configuration().n_qubits >= 5)
-                )
-                self.assertTrue(len(filtered_backends), 2)
-                for backend in filtered_backends:
-                    self.assertGreaterEqual(backend.configuration().n_qubits, n_qubits)
+        service = self._get_services(fake_backends)
+        filtered_backends = service.backends(
+            filters=lambda x: (x.configuration().n_qubits >= 5)
+        )
+        self.assertTrue(len(filtered_backends), 2)
+        for backend in filtered_backends:
+            self.assertGreaterEqual(backend.configuration().n_qubits, n_qubits)
+
+    def test_least_busy_use_fractional_gates_skips_backend_without_rzz(self):
+        """When use_fractional_gates=True, least_busy skips backends missing rzz."""
+        backends_list = [
+            {
+                "name": "fake_torino",
+                "status": {"name": "online"},
+                "queue_length": 5,
+            },
+            {
+                "name": "fake_fractional",
+                "status": {"name": "online"},
+                "queue_length": 10,
+            },
+        ]
+        fake_backends = [
+            FakeApiBackendSpecs(backend_name="FakeTorino"),
+            FakeApiBackendSpecs(backend_name="FakeFractionalBackend"),
+        ]
+
+        service = self._get_services(fake_backends)
+        service._backends_list = backends_list
+        backend = service.least_busy(use_fractional_gates=True)
+        self.assertEqual(backend.name, "fake_fractional")
+        self.assertIn("rzz", backend.basis_gates)
+
+    def test_least_busy_use_fractional_gates_no_qualifying_backend(self):
+        """When use_fractional_gates=True and no backend has rzz, raise QiskitBackendNotFoundError."""
+        from qiskit.providers.exceptions import QiskitBackendNotFoundError
+
+        backends_list = [
+            {
+                "name": "fake_torino",
+                "status": {"name": "online"},
+                "queue_length": 5,
+            },
+            {
+                "name": "fake_lima",
+                "status": {"name": "online"},
+                "queue_length": 10,
+            },
+        ]
+        fake_backends = [
+            FakeApiBackendSpecs(backend_name="FakeTorino"),
+            FakeApiBackendSpecs(backend_name="FakeLimaV2"),
+        ]
+
+        service = self._get_services(fake_backends)
+        service._backends_list = backends_list
+        with self.assertRaises(QiskitBackendNotFoundError):
+            service.least_busy(use_fractional_gates=True)
+
+    def test_least_busy_use_fractional_gates_false_ignores_rzz(self):
+        """When use_fractional_gates=False (default), least_busy returns the least busy backend."""
+        backends_list = [
+            {
+                "name": "fake_torino",
+                "status": {"name": "online"},
+                "queue_length": 5,
+            },
+            {
+                "name": "fake_fractional",
+                "status": {"name": "online"},
+                "queue_length": 10,
+            },
+        ]
+        fake_backends = [
+            FakeApiBackendSpecs(backend_name="FakeTorino"),
+            FakeApiBackendSpecs(backend_name="FakeFractionalBackend"),
+        ]
+
+        service = self._get_services(fake_backends)
+        service._backends_list = backends_list
+        backend = service.least_busy(use_fractional_gates=False)
+        self.assertEqual(backend.name, "fake_torino")
 
     def test_filter_least_busy(self):
         """Test filtering by least busy function."""
@@ -178,12 +247,10 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(**{**default_stat, "backend_name": "test_backend4"}),
         ]
 
-        services = self._get_services(fake_backends)
-        for service in services:
-            with self.subTest(service=service.channel):
-                service._backends_list = backends_list
-                backend = service.least_busy()
-                self.assertEqual(backend.name, "test_backend1")
+        service = self._get_services(fake_backends)
+        service._backends_list = backends_list
+        backend = service.least_busy()
+        self.assertEqual(backend.name, "test_backend1")
 
     def test_filter_min_num_qubits(self):
         """Test filtering by minimum number of qubits."""
@@ -194,13 +261,11 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(n_qubits=n_qubits - 1),
         ]
 
-        services = self._get_services(fake_backends)
-        for service in services:
-            with self.subTest(service=service.channel):
-                filtered_backends = service.backends(min_num_qubits=n_qubits)
-                self.assertTrue(len(filtered_backends), 2)
-                for backend in filtered_backends:
-                    self.assertGreaterEqual(backend.configuration().n_qubits, n_qubits)
+        service = self._get_services(fake_backends)
+        filtered_backends = service.backends(min_num_qubits=n_qubits)
+        self.assertTrue(len(filtered_backends), 2)
+        for backend in filtered_backends:
+            self.assertGreaterEqual(backend.configuration().n_qubits, n_qubits)
 
     def _get_fake_backend_specs(self, crns=None, **kwargs):
         """Get the backend specs to pass to the fake client."""
@@ -220,14 +285,13 @@ class TestBackendFilters(IBMTestCase):
         )
 
     def _get_services(self, fake_backend_specs):
-        """Get ibm_cloud services initialized with fake backends."""
-        cloud_service = FakeRuntimeService(
+        """Get an ibm_cloud service initialized with fake backends."""
+        return FakeRuntimeService(
             channel="ibm_cloud",
             token="my_token",
             instance="crn:v1:bluemix:public:quantum-computing:my-region:a/...:...::",
             backend_specs=fake_backend_specs,
         )
-        return [cloud_service]
 
 
 @ddt

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -98,7 +98,7 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(n_qubits=n_qubits, local=True),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         filtered_backends = service.backends(n_qubits=n_qubits, local=False)
         self.assertTrue(len(filtered_backends), 1)
         self.assertEqual(n_qubits, filtered_backends[0].configuration().n_qubits)
@@ -113,7 +113,7 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(operational=False, simulator=False),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         filtered_backends = service.backends(
             operational=True,  # from status
             simulator=True,  # from configuration
@@ -132,7 +132,7 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(n_qubits=n_qubits - 1),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         filtered_backends = service.backends(
             filters=lambda x: (x.configuration().n_qubits >= 5)
         )
@@ -159,7 +159,7 @@ class TestBackendFilters(IBMTestCase):
             FakeApiBackendSpecs(backend_name="FakeFractionalBackend"),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         service._backends_list = backends_list
         backend = service.least_busy(use_fractional_gates=True)
         self.assertEqual(backend.name, "fake_fractional")
@@ -186,7 +186,7 @@ class TestBackendFilters(IBMTestCase):
             FakeApiBackendSpecs(backend_name="FakeLimaV2"),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         service._backends_list = backends_list
         with self.assertRaises(QiskitBackendNotFoundError):
             service.least_busy(use_fractional_gates=True)
@@ -210,7 +210,7 @@ class TestBackendFilters(IBMTestCase):
             FakeApiBackendSpecs(backend_name="FakeFractionalBackend"),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         service._backends_list = backends_list
         backend = service.least_busy(use_fractional_gates=False)
         self.assertEqual(backend.name, "fake_torino")
@@ -247,7 +247,7 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(**{**default_stat, "backend_name": "test_backend4"}),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         service._backends_list = backends_list
         backend = service.least_busy()
         self.assertEqual(backend.name, "test_backend1")
@@ -261,7 +261,7 @@ class TestBackendFilters(IBMTestCase):
             self._get_fake_backend_specs(n_qubits=n_qubits - 1),
         ]
 
-        service = self._get_services(fake_backends)
+        service = self._get_service(fake_backends)
         filtered_backends = service.backends(min_num_qubits=n_qubits)
         self.assertTrue(len(filtered_backends), 2)
         for backend in filtered_backends:
@@ -284,7 +284,7 @@ class TestBackendFilters(IBMTestCase):
             backend_name=name, configuration=config, status=status, crns=crns
         )
 
-    def _get_services(self, fake_backend_specs):
+    def _get_service(self, fake_backend_specs):
         """Get an ibm_cloud service initialized with fake backends."""
         return FakeRuntimeService(
             channel="ibm_cloud",

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -133,9 +133,7 @@ class TestBackendFilters(IBMTestCase):
         ]
 
         service = self._get_service(fake_backends)
-        filtered_backends = service.backends(
-            filters=lambda x: (x.configuration().n_qubits >= 5)
-        )
+        filtered_backends = service.backends(filters=lambda x: (x.configuration().n_qubits >= 5))
         self.assertTrue(len(filtered_backends), 2)
         for backend in filtered_backends:
             self.assertGreaterEqual(backend.configuration().n_qubits, n_qubits)

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -166,7 +166,7 @@ class TestBackendFilters(IBMTestCase):
         self.assertIn("rzz", backend.basis_gates)
 
     def test_least_busy_use_fractional_gates_no_qualifying_backend(self):
-        """When use_fractional_gates=True and no backend has rzz, raise QiskitBackendNotFoundError."""
+        """When use_fractional_gates=True and no backend has rzz, raise an error."""
         from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
         backends_list = [


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Support `use_fractional_gates` flag in `least_busy`.

### Details and comments

Today `least_busy()` doesn't support the `use_fractional_gates` flag. You can add a filter to look for rzz in the basis gates, but the returned backend still wouldn't include fractional gates. This PR adds that parameter to `least_busy()` and, when set to True, return the least busy backend that supports FG. 

Note 
1. the parameter is better suited _before_ `filters`, but that'd break people using positional args. 
2. this PR also updates the `_get_services()` method to return the fake service directly instead of a list, since we only have 1 channel now (and I didn't want to write a useless loop). 
