### PR TITLE
Use runtime time imports to break some import cycles

### DIFF
--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -137,7 +137,7 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
         Returns:
             Submitted job.
         """
-        # Use runtime imports, to prevent `BasePrimitiveV2` to depend on `QiskitRuntimeService`.
+        # Use runtime imports, to prevent `BasePrimitiveV2` to depend on several core objects.
         from .ibm_backend import IBMBackend
         from .qiskit_runtime_service import QiskitRuntimeService
 

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -12,20 +12,18 @@
 
 """Base class for Qiskit Runtime primitives."""
 
-from abc import ABC, abstractmethod
-from typing import TypeVar, Generic
-import logging
-from dataclasses import asdict, replace
+from __future__ import annotations
 
-from qiskit.primitives.containers.estimator_pub import EstimatorPub
-from qiskit.primitives.containers.sampler_pub import SamplerPub
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import asdict, replace
+from typing import TYPE_CHECKING, Generic, TypeVar
+
 from qiskit.providers.backend import BackendV2
 
+from .decoders.defaults import DEFAULT_DECODERS
 from .options.options import BaseOptions, OptionsV2
 from .options.utils import merge_options_v2
-from .runtime_job_v2 import RuntimeJobV2
-from .ibm_backend import IBMBackend
-
 from .utils import (
     validate_isa_circuits,
     validate_no_dd_with_dynamic_circuits,
@@ -33,12 +31,16 @@ from .utils import (
 )
 from .utils.default_session import get_cm_session
 from .utils.utils import is_simulator
-from .decoders.defaults import DEFAULT_DECODERS
-from .qiskit_runtime_service import QiskitRuntimeService
-from .fake_provider.local_service import QiskitRuntimeLocalService
 
-from .session import Session
-from .batch import Batch
+if TYPE_CHECKING:
+    from qiskit.primitives.containers.estimator_pub import EstimatorPub
+    from qiskit.primitives.containers.sampler_pub import SamplerPub
+
+    from .batch import Batch
+    from .fake_provider.local_service import QiskitRuntimeLocalService
+    from .qiskit_runtime_service import QiskitRuntimeService
+    from .runtime_job_v2 import RuntimeJobV2
+    from .session import Session
 
 logger = logging.getLogger(__name__)
 OptionsT = TypeVar("OptionsT", bound=BaseOptions)
@@ -60,6 +62,12 @@ def get_mode_service_backend(
             * A :class:`Session` if you are using session execution mode.
             * A :class:`Batch` if you are using batch execution mode.
     """
+    # Use runtime imports, to prevent `base_primitive.py` to depend on several core objects.
+    from .batch import Batch
+    from .fake_provider.local_service import QiskitRuntimeLocalService
+    from .ibm_backend import IBMBackend
+    from .session import Session
+
     if isinstance(mode, (Session, Batch)):
         return mode, mode.service, mode._backend
     elif isinstance(mode, IBMBackend):
@@ -129,6 +137,10 @@ class BasePrimitiveV2(ABC, Generic[OptionsT]):
         Returns:
             Submitted job.
         """
+        # Use runtime imports, to prevent `BasePrimitiveV2` to depend on `QiskitRuntimeService`.
+        from .ibm_backend import IBMBackend
+        from .qiskit_runtime_service import QiskitRuntimeService
+
         primitive_inputs = {"pubs": pubs}
         options_dict = asdict(self.options)
         self._validate_options(options_dict)

--- a/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
@@ -12,10 +12,16 @@
 
 """Fake Nighthawk device (120 qubit)."""
 
+from __future__ import annotations
+
 import os
 import warnings
+from typing import TYPE_CHECKING
+
 from qiskit_ibm_runtime.fake_provider import fake_backend
-from qiskit_ibm_runtime import QiskitRuntimeService
+
+if TYPE_CHECKING:
+    from qiskit_ibm_runtime import QiskitRuntimeService
 
 DISPLAY_WARNING = True
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from qiskit.providers import Job, Options
     from qiskit.transpiler import Target
 
-    from .. import QiskitRuntimeService
+    from ..qiskit_runtime_service import QiskitRuntimeService
     from ..models import (
         QasmBackendConfiguration,
     )

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -12,20 +12,17 @@
 
 """Base class for dummy backends."""
 
-from typing import Any
-import logging
-import warnings
+from __future__ import annotations
+
 import json
+import logging
 import os
+import warnings
+from typing import TYPE_CHECKING, Any
 
-from qiskit import QuantumCircuit
-
-from qiskit.providers import BackendV2, Job
-from qiskit.utils import optionals as _optionals
-from qiskit.transpiler import Target
-from qiskit.providers import Options
-
+from qiskit.providers import BackendV2
 from qiskit.providers.basic_provider import BasicSimulator
+from qiskit.utils import optionals as _optionals
 
 from qiskit_ibm_runtime.utils.backend_converter import convert_to_target
 from qiskit_ibm_runtime.utils.backend_decoder import (
@@ -34,18 +31,25 @@ from qiskit_ibm_runtime.utils.backend_decoder import (
 )
 
 from .. import QiskitRuntimeService
-from ..utils.backend_encoder import BackendEncoder
-from ..utils.backend_decoder import configuration_from_server_data
-
 from ..models import (
-    BackendProperties,
     BackendConfiguration,
+    BackendProperties,
     BackendStatus,
-    QasmBackendConfiguration,
 )
 from ..models.exceptions import (
     BackendPropertyError,
 )
+from ..utils.backend_decoder import configuration_from_server_data
+from ..utils.backend_encoder import BackendEncoder
+
+if TYPE_CHECKING:
+    from qiskit import QuantumCircuit
+    from qiskit.providers import Job, Options
+    from qiskit.transpiler import Target
+
+    from ..models import (
+        QasmBackendConfiguration,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -401,7 +401,7 @@ class FakeBackendV2(BackendV2):
             ValueError: if the provided service is a non-QiskitRuntimeService instance.
             Exception: If the real target doesn't exist or can't be accessed
         """
-        # Use runtime imports, to prevent FakeBackendV2 to depend on QiskitRuntimeService.
+        # Use runtime imports, to prevent `FakeBackendV2` to depend on `QiskitRuntimeService``.
         from ..qiskit_runtime_service import QiskitRuntimeService
 
         if not isinstance(service, QiskitRuntimeService):

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -24,13 +24,6 @@ from qiskit.providers import BackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.utils import optionals as _optionals
 
-from qiskit_ibm_runtime.utils.backend_converter import convert_to_target
-from qiskit_ibm_runtime.utils.backend_decoder import (
-    decode_backend_configuration,
-    properties_from_server_data,
-)
-
-from .. import QiskitRuntimeService
 from ..models import (
     BackendConfiguration,
     BackendProperties,
@@ -39,7 +32,12 @@ from ..models import (
 from ..models.exceptions import (
     BackendPropertyError,
 )
-from ..utils.backend_decoder import configuration_from_server_data
+from ..utils.backend_converter import convert_to_target
+from ..utils.backend_decoder import (
+    configuration_from_server_data,
+    decode_backend_configuration,
+    properties_from_server_data,
+)
 from ..utils.backend_encoder import BackendEncoder
 
 if TYPE_CHECKING:
@@ -47,6 +45,7 @@ if TYPE_CHECKING:
     from qiskit.providers import Job, Options
     from qiskit.transpiler import Target
 
+    from .. import QiskitRuntimeService
     from ..models import (
         QasmBackendConfiguration,
     )
@@ -402,6 +401,9 @@ class FakeBackendV2(BackendV2):
             ValueError: if the provided service is a non-QiskitRuntimeService instance.
             Exception: If the real target doesn't exist or can't be accessed
         """
+        # Use runtime imports, to prevent FakeBackendV2 to depend on QiskitRuntimeService.
+        from ..qiskit_runtime_service import QiskitRuntimeService
+
         if not isinstance(service, QiskitRuntimeService):
             raise ValueError(
                 "The provided service to update the fake backend is invalid. A "

--- a/qiskit_ibm_runtime/fake_provider/fake_provider.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_provider.py
@@ -14,11 +14,16 @@
 
 """Fake provider class that provides access to fake backends."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 from .backends import *  # noqa: F403 undefined-local-with-import-star
-from .fake_backend import FakeBackendV2
+
+if TYPE_CHECKING:
+    from .fake_backend import FakeBackendV2
 
 
 class FakeProviderForBackendV2:

--- a/qiskit_ibm_runtime/fake_provider/local_runtime_job.py
+++ b/qiskit_ibm_runtime/fake_provider/local_runtime_job.py
@@ -12,12 +12,17 @@
 
 """Qiskit runtime local mode job class."""
 
-from typing import Any, Literal
+from __future__ import annotations
+
 from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal
 
 from qiskit.primitives.primitive_job import PrimitiveJob
-from qiskit_ibm_runtime.models import BackendProperties
-from .fake_backend import FakeBackendV2
+
+if TYPE_CHECKING:
+    from qiskit_ibm_runtime.models import BackendProperties
+
+    from .fake_backend import FakeBackendV2
 
 
 class LocalRuntimeJob(PrimitiveJob):

--- a/qiskit_ibm_runtime/fake_provider/local_service.py
+++ b/qiskit_ibm_runtime/fake_provider/local_service.py
@@ -12,28 +12,34 @@
 
 """Qiskit runtime service."""
 
-import math
+from __future__ import annotations
+
 import copy
 import logging
+import math
 import warnings
 from dataclasses import asdict
-from typing import Literal
-from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
 
 from qiskit.primitives import (
     BackendEstimatorV2,
     BackendSamplerV2,
 )
-from qiskit.primitives.primitive_job import PrimitiveJob
-from qiskit.providers.backend import BackendV2
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
 
-from .fake_backend import FakeBackendV2
+from ..ibm_backend import IBMBackend
 from .fake_provider import FakeProviderForBackendV2
 from .local_runtime_job import LocalRuntimeJob
-from ..ibm_backend import IBMBackend
-from ..runtime_options import RuntimeOptions
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from qiskit.primitives.primitive_job import PrimitiveJob
+    from qiskit.providers.backend import BackendV2
+
+    from ..runtime_options import RuntimeOptions
+    from .fake_backend import FakeBackendV2
 
 logger = logging.getLogger(__name__)
 

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -140,7 +140,9 @@ class TestPrimitivesV2(IBMTestCase):
             def __new__(cls, *args, **kwargs):
                 return mock_service_inst
 
-        with patch("qiskit_ibm_runtime.base_primitive.QiskitRuntimeService", new=MockQRTService):
+        with patch(
+            "qiskit_ibm_runtime.qiskit_runtime_service.QiskitRuntimeService", new=MockQRTService
+        ):
             inst = primitive(mode=mock_backend)
             self.assertIsNone(inst.mode)
             inst.run(**get_primitive_inputs(inst))
@@ -259,7 +261,7 @@ class TestPrimitivesV2(IBMTestCase):
 
     @data(EstimatorV2, SamplerV2)
     def test_parameters_single_circuit(self, primitive):
-        """Test parameters for a single cirucit."""
+        """Test parameters for a single circuit."""
         circ = real_amplitudes(num_qubits=2, reps=1)
         backend = get_mocked_backend()
         circ = transpile(circ, backend=backend)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Move some imports to runtime imports in:
* `get_mode_service_backend()`
* `BasePrimitiveV2._run()`
* `FakeBackendV2.refresh()`

As they are quite central classes, the goal is to reduce the import surface among them. Runtime imports is not the best mechanism ever, but the benefit in the import graph pays off.  


### Details and comments

`get_mode_service_backend()` could use a revamp in general, to be tackled outside this PR.

The rest of the line changes come from `TC` / `I` ruff rules.

Related to #2749
