### PR TITLE
Remove `DAGCircuit.substitute_node`'s `propagate_condition` argument

### DIFF
--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -506,16 +506,14 @@ class PadDynamicalDecoupling(BlockBasePadder):
                     op = next_node.op
                     theta_r, phi_r, lam_r = op.params
                     op.params = Optimize1qGates.compose_u3(theta_r, phi_r, lam_r, theta, phi, lam)
-                    self._block_dag.substitute_node(next_node, op, propagate_condition=False)
+                    self._block_dag.substitute_node(next_node, op)
                     sequence_gphase += phase
                 elif isinstance(prev_node, DAGOpNode) and isinstance(prev_node.op, (UGate, U3Gate)):
                     # Absorb the inverse into the predecessor (from right in circuit)
                     op = prev_node.op
                     theta_l, phi_l, lam_l = op.params
                     op.params = Optimize1qGates.compose_u3(theta, phi, lam, theta_l, phi_l, lam_l)
-                    new_prev_node = self._block_dag.substitute_node(
-                        prev_node, op, propagate_condition=False
-                    )
+                    new_prev_node = self._block_dag.substitute_node(prev_node, op)
                     start_time = self.property_set["node_start_time"].pop(prev_node)
                     if start_time is not None:
                         self.property_set["node_start_time"][new_prev_node] = start_time


### PR DESCRIPTION
### Summary
The argument was deprecated in Qiskit 2.0.0 and has no effect. We require Qiskit > 2.2.0 so it is safe to remove the argument.
