### PR TITLE
Support scheduler timing and stretch values in WrapperSampler

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_sampler/converters.py
+++ b/qiskit_ibm_runtime/decoders/executor_sampler/converters.py
@@ -14,12 +14,30 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import Any, TYPE_CHECKING, Literal
+from collections.abc import Iterable
 
 from qiskit.primitives.containers import BitArray, DataBin, SamplerPubResult
 
+from ...utils.circuit_schedule import CircuitSchedule
+
 if TYPE_CHECKING:
     from ...results import QuantumProgramItemResult
+
+
+def expanded_values_to_lists(key_value_pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    """Dict factory that converts `expanded_values` tuples to lists.
+
+    Args:
+        key_value_pairs: pairs of (key, value) items
+
+    Returns:
+        A dictionary built from `key_value_pairs`, with the key `expanded_values` containing lists.
+    """
+    stretch_value = dict(key_value_pairs)
+    stretch_value["expanded_values"] = [list(i) for i in stretch_value["expanded_values"]]
+    return stretch_value
 
 
 def quantum_program_item_result_to_sampler_pub_result(
@@ -55,11 +73,23 @@ def quantum_program_item_result_to_sampler_pub_result(
 
     data_bin = DataBin(**arrays, shape=pub_shape)
 
-    # Construct the metadata for the result
+    # Construct the metadata for the result.
     pub_metadata: dict[str, Any] = {"circuit_metadata": {}}
     if circuit_metadata:
         pub_metadata["circuit_metadata"] = circuit_metadata
     if num_randomizations > 0:
         pub_metadata["num_randomizations"] = num_randomizations
+    if item.metadata.scheduler_timing:
+        pub_metadata.setdefault("compilation", {})
+        pub_metadata["compilation"]["scheduler_timing"] = {
+            "timing": CircuitSchedule(item.metadata.scheduler_timing.timing),
+            "circuit_duration": item.metadata.scheduler_timing.circuit_duration,
+        }
+    if item.metadata.stretch_values:
+        pub_metadata.setdefault("compilation", {})
+        pub_metadata["compilation"]["stretch_values"] = [
+            asdict(stretch_value, dict_factory=expanded_values_to_lists)
+            for stretch_value in item.metadata.stretch_values
+        ]
 
     return SamplerPubResult(data=data_bin, metadata=pub_metadata)

--- a/qiskit_ibm_runtime/decoders/executor_sampler/converters.py
+++ b/qiskit_ibm_runtime/decoders/executor_sampler/converters.py
@@ -20,8 +20,6 @@ from collections.abc import Iterable
 
 from qiskit.primitives.containers import BitArray, DataBin, SamplerPubResult
 
-from ...utils.circuit_schedule import CircuitSchedule
-
 if TYPE_CHECKING:
     from ...results import QuantumProgramItemResult
 
@@ -82,7 +80,7 @@ def quantum_program_item_result_to_sampler_pub_result(
     if item.metadata.scheduler_timing:
         pub_metadata.setdefault("compilation", {})
         pub_metadata["compilation"]["scheduler_timing"] = {
-            "timing": CircuitSchedule(item.metadata.scheduler_timing.timing),
+            "timing": item.metadata.scheduler_timing.timing,
             "circuit_duration": item.metadata.scheduler_timing.circuit_duration,
         }
     if item.metadata.stretch_values:

--- a/qiskit_ibm_runtime/options_models/sampler_options.py
+++ b/qiskit_ibm_runtime/options_models/sampler_options.py
@@ -82,4 +82,10 @@ class SamplerOptions:
             executor_options.environment.image = self.experimental.get("image", None)
             executor_options.experimental.update(self.experimental)
 
+            if execution_key := self.experimental.get("execution", {}):
+                if execution_key.get("scheduler_timing", False):
+                    executor_options.execution.scheduler_timing = True
+                if execution_key.get("stretch_values", False):
+                    executor_options.execution.stretch_values = True
+
         return executor_options

--- a/qiskit_ibm_runtime/visualization/draw_circuit_schedule_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_circuit_schedule_timings.py
@@ -16,11 +16,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from ..utils.circuit_schedule import CircuitSchedule
 from .utils import plotly_module
 
 if TYPE_CHECKING:
     from plotly.graph_objects import Figure as PlotlyFigure
-    from ..utils.circuit_schedule import CircuitSchedule
 
 
 def draw_circuit_schedule_timing(
@@ -47,8 +47,6 @@ def draw_circuit_schedule_timing(
     Returns:
         A plotly figure.
     """
-    from ..utils.circuit_schedule import CircuitSchedule
-
     go = plotly_module(".graph_objects")
     fig = go.Figure(layout=go.Layout(width=width))
 

--- a/qiskit_ibm_runtime/visualization/draw_circuit_schedule_timings.py
+++ b/qiskit_ibm_runtime/visualization/draw_circuit_schedule_timings.py
@@ -16,11 +16,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from ..utils.circuit_schedule import CircuitSchedule
 from .utils import plotly_module
 
 if TYPE_CHECKING:
     from plotly.graph_objects import Figure as PlotlyFigure
+    from ..utils.circuit_schedule import CircuitSchedule
 
 
 def draw_circuit_schedule_timing(
@@ -47,6 +47,8 @@ def draw_circuit_schedule_timing(
     Returns:
         A plotly figure.
     """
+    from ..utils.circuit_schedule import CircuitSchedule
+
     go = plotly_module(".graph_objects")
     fig = go.Figure(layout=go.Layout(width=width))
 

--- a/test/unit/decoders/executor_sampler/test_post_processor.py
+++ b/test/unit/decoders/executor_sampler/test_post_processor.py
@@ -27,9 +27,12 @@ from qiskit_ibm_runtime.decoders.executor_sampler.post_processor_v0_1 import (
 )
 from qiskit_ibm_runtime.options_models.sampler_options import SamplerOptions
 from qiskit_ibm_runtime.results.quantum_program import (
+    ItemMetadata,
     Metadata,
     QuantumProgramItemResult,
     QuantumProgramResult,
+    StretchValues,
+    SchedulerTiming,
 )
 
 
@@ -115,6 +118,38 @@ class TestQuantumProgramItemResultToSamplerPubResult(unittest.TestCase):
 
         # Verify the result array contains the same data
         np.testing.assert_array_equal(result.data.meas, meas_data)
+
+    def test_populating_compilation_key(self):
+        """The `compilation` key of metadata must be populated if related fields are present."""
+        meas = np.array([[False], [True], [True]])
+        meas_flips = np.array([[False, False]])
+
+        stretch_values = [StretchValues("name", 2, 3, [(0, 1)])]
+        scheduler_timing = SchedulerTiming("main,rz_0,Qubit 0,1365,0,shift_phase", 10)
+
+        metadata = ItemMetadata(stretch_values=stretch_values, scheduler_timing=scheduler_timing)
+        item = QuantumProgramItemResult(
+            {"meas": meas, "measurement_flips.meas": meas_flips}, metadata
+        )
+
+        # Prepare the output.
+        result = quantum_program_item_result_to_sampler_pub_result(item, 0)
+        # Strech values should contain lists instead of tuples in `expanded_values`.
+        expected_stretch_values = [asdict(stretch_values[0])]
+        expected_stretch_values[0]["expanded_values"] = [
+            list(i) for i in expected_stretch_values[0]["expanded_values"]
+        ]
+
+        # `scheduler_timing` and `stretch_values` should be present and converted in `metadata`.
+        self.assertIn("compilation", result.metadata)
+        self.assertEqual(
+            result.metadata["compilation"]["scheduler_timing"],
+            {
+                "timing": scheduler_timing.timing,
+                "circuit_duration": scheduler_timing.circuit_duration,
+            },
+        )
+        self.assertEqual(result.metadata["compilation"]["stretch_values"], expected_stretch_values)
 
 
 class TestSamplerV2PostProcessor(unittest.TestCase):

--- a/test/unit/executor_sampler/test_sampler_v2_options.py
+++ b/test/unit/executor_sampler/test_sampler_v2_options.py
@@ -83,3 +83,13 @@ class TestSamplerOptionsToExecutorOptions(unittest.TestCase):
         # Check that experimental dict is carried over
         self.assertEqual(executor_options.experimental["custom_key"], "custom_value")
         self.assertEqual(executor_options.experimental["another_key"], 123)
+
+    def test_experimental_dict_execution_mapping(self):
+        """Execution-related entries in `experimental.execution` must map to executor options."""
+        options = SamplerOptions()
+        options.experimental = {"execution": {"stretch_values": True, "scheduler_timing": True}}
+        executor_options = options.to_executor_options()
+
+        # Check that experimental dict is carried over
+        self.assertEqual(executor_options.execution.stretch_values, True)
+        self.assertEqual(executor_options.execution.scheduler_timing, True)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Make use of #2790 for allowing retrieving scheduler timing and stretch values in `WrapperSampler`:
* the options conversion makes use of the `experimental` fields, in the format for non-wrapper sampler, mapping them to the executor options
* `quantum_program_item_result_to_sampler_pub_result` populates the `metadata` field based on the existence of such members

### Details and comments

Fixes #2791
