### PR TITLE
Add `ResilienceOptions` to wrapper estimator options

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -148,7 +148,14 @@ class EstimatorV2(BaseEstimatorV2):
         else:
             shots = int(np.ceil(1.0 / (self.options.default_precision**2)))
 
-        quantum_program = prepare(coerced_pubs, self.options.twirling, shots)
+        quantum_program = prepare(
+            pubs=coerced_pubs,
+            twirling_options=self.options.twirling,
+            shots=shots,
+            measure_noise_learning=self.options.resilience.measure_noise_learning
+            if self.options.resilience.measure_mitigation
+            else None,
+        )
         executor_options = self.options.to_executor_options()
 
         # Set executor options

--- a/qiskit_ibm_runtime/options_models/estimator_options.py
+++ b/qiskit_ibm_runtime/options_models/estimator_options.py
@@ -23,7 +23,7 @@ from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
 
 from .environment_options import EnvironmentOptions
-from .resilience_options import ResilienceOptionsV2
+from .resilience_options import ResilienceOptions
 from .twirling_options import TwirlingOptions
 from .utils import PRIMITIVES_CONFIG
 
@@ -82,10 +82,10 @@ class EstimatorOptions:
     environment: EnvironmentOptions = Field(default_factory=EnvironmentOptions)
     """Options related to the execution environment."""
 
-    resilience: ResilienceOptionsV2 = Field(default_factory=ResilienceOptionsV2)
+    resilience: ResilienceOptions = Field(default_factory=ResilienceOptions)
     """Advanced resilience options to fine-tune the resilience strategy.
 
-    See :class:`ResilienceOptionsV2` for all available options.
+    See :class:`ResilienceOptions` for all available options.
     """
 
     def to_executor_options(self) -> ExecutorOptions:

--- a/qiskit_ibm_runtime/options_models/estimator_options.py
+++ b/qiskit_ibm_runtime/options_models/estimator_options.py
@@ -23,6 +23,7 @@ from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
 
 from .environment_options import EnvironmentOptions
+from .resilience_options import ResilienceOptionsV2
 from .twirling_options import TwirlingOptions
 from .utils import PRIMITIVES_CONFIG
 
@@ -80,6 +81,12 @@ class EstimatorOptions:
 
     environment: EnvironmentOptions = Field(default_factory=EnvironmentOptions)
     """Options related to the execution environment."""
+
+    resilience: ResilienceOptionsV2 = Field(default_factory=ResilienceOptionsV2)
+    """Advanced resilience options to fine-tune the resilience strategy.
+
+    See :class:`ResilienceOptionsV2` for all available options.
+    """
 
     def to_executor_options(self) -> ExecutorOptions:
         """Map EstimatorOptions to ExecutorOptions, ignoring all irrelevant fields.

--- a/qiskit_ibm_runtime/options_models/estimator_options.py
+++ b/qiskit_ibm_runtime/options_models/estimator_options.py
@@ -85,7 +85,7 @@ class EstimatorOptions:
     resilience: ResilienceOptions = Field(default_factory=ResilienceOptions)
     """Advanced resilience options to fine-tune the resilience strategy.
 
-    See :class:`ResilienceOptions` for all available options.
+    See :class:`.~ResilienceOptions` for all available options.
     """
 
     def to_executor_options(self) -> ExecutorOptions:

--- a/qiskit_ibm_runtime/options_models/resilience_options.py
+++ b/qiskit_ibm_runtime/options_models/resilience_options.py
@@ -32,7 +32,7 @@ class ResilienceOptions:
     by using :attr:`~measure_noise_learning`. See :class:`.~MeasureNoiseLearningOptions`
     for all measurement mitigation noise learning options.
     """
-    
+
     measure_noise_learning: MeasureNoiseLearningOptions = Field(
         default_factory=MeasureNoiseLearningOptions
     )

--- a/qiskit_ibm_runtime/options_models/resilience_options.py
+++ b/qiskit_ibm_runtime/options_models/resilience_options.py
@@ -1,0 +1,42 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Resilience options."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+from .measure_noise_learning_options import MeasureNoiseLearningOptions
+from .utils import PRIMITIVES_CONFIG
+
+
+@dataclass(config=PRIMITIVES_CONFIG)
+class ResilienceOptionsV2:
+    """Resilience options for V2 Estimator."""
+
+    measure_mitigation: bool = True
+    """Whether to enable measurement error mitigation method.
+
+    If you enable measurement mitigation, you can fine-tune its noise learning
+    by using :attr:`~measure_noise_learning`. See :class:`MeasureNoiseLearningOptions`
+    for all measurement mitigation noise learning options.
+    """
+    measure_noise_learning: MeasureNoiseLearningOptions = Field(
+        default_factory=MeasureNoiseLearningOptions
+    )
+
+    """Additional measurement noise learning options.
+
+    See :class:`MeasureNoiseLearningOptions` for all options.
+    """

--- a/qiskit_ibm_runtime/options_models/resilience_options.py
+++ b/qiskit_ibm_runtime/options_models/resilience_options.py
@@ -38,5 +38,5 @@ class ResilienceOptions:
     )
     """Additional measurement noise learning options.
 
-    See :class:`MeasureNoiseLearningOptions` for all options.
+    See :class:`~.MeasureNoiseLearningOptions` for all options.
     """

--- a/qiskit_ibm_runtime/options_models/resilience_options.py
+++ b/qiskit_ibm_runtime/options_models/resilience_options.py
@@ -29,13 +29,13 @@ class ResilienceOptions:
     """Whether to enable measurement error mitigation method.
 
     If you enable measurement mitigation, you can fine-tune its noise learning
-    by using :attr:`~measure_noise_learning`. See :class:`MeasureNoiseLearningOptions`
+    by using :attr:`~measure_noise_learning`. See :class:`.~MeasureNoiseLearningOptions`
     for all measurement mitigation noise learning options.
     """
+    
     measure_noise_learning: MeasureNoiseLearningOptions = Field(
         default_factory=MeasureNoiseLearningOptions
     )
-
     """Additional measurement noise learning options.
 
     See :class:`MeasureNoiseLearningOptions` for all options.

--- a/qiskit_ibm_runtime/options_models/resilience_options.py
+++ b/qiskit_ibm_runtime/options_models/resilience_options.py
@@ -22,7 +22,7 @@ from .utils import PRIMITIVES_CONFIG
 
 
 @dataclass(config=PRIMITIVES_CONFIG)
-class ResilienceOptionsV2:
+class ResilienceOptions:
     """Resilience options for V2 Estimator."""
 
     measure_mitigation: bool = True

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -16,6 +16,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+from ddt import data, ddt
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
@@ -30,6 +31,7 @@ from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
 
 
+@ddt
 class TestEstimatorV2Run(unittest.TestCase):
     """Tests for the EstimatorV2.run() method."""
 
@@ -156,10 +158,11 @@ class TestEstimatorV2Run(unittest.TestCase):
         self.mock_executor_instance.run.assert_called_once()
         self.assertEqual(job, self.mock_job)
 
-    def test_run_multiple_pubs(self):
+    @data(True, False)
+    def test_run_multiple_pubs(self, measure_mitigation):
         """Test run with multiple pubs."""
         estimator = EstimatorV2(mode=self.backend)
-
+        estimator.options.resilience.measure_mitigation = measure_mitigation
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
 
@@ -178,7 +181,7 @@ class TestEstimatorV2Run(unittest.TestCase):
         # Verify multiple items in quantum program
         call_args = self.mock_executor_instance.run.call_args
         quantum_program = call_args[0][0]
-        self.assertEqual(len(quantum_program.items), 2)
+        self.assertEqual(len(quantum_program.items), 2 + measure_mitigation)
 
     def test_run_with_default_precision(self):
         """Test that run uses the default precision value from options."""

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -33,6 +33,9 @@ class TestEstimatorOptions(unittest.TestCase):
         self.assertIsNone(options.experimental)
         self.assertIsNone(options.max_execution_time)
         self.assertIsInstance(options.environment, EnvironmentOptions)
+        self.assertTrue(options.resilience.measure_mitigation)
+        self.assertEqual(options.resilience.measure_noise_learning.num_randomizations, 32)
+        self.assertEqual(options.resilience.measure_noise_learning.shots_per_randomization, "auto")
 
     def test_set_default_precision(self):
         """Test setting default_precision."""


### PR DESCRIPTION
### Summary
This adds the resilience options to the estimator options, and passes them to the prepare function.

### AI/LLM disclosure

- [X] I used the following tool to generate or modify code: IBM BOB
