### PR TITLE
Avoid running integration tests in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   code-quality:
-    if: github.repository_owner == 'Qiskit' && ${{ !startsWith(github.ref_name, 'chore') }}
+    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'chore') }}
     name: Run code quality checks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pre-commit run
       - uses: pre-commit/action@v3.0.1
   documentation:
-    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'chore') }}
+    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'diego-plan9:chore') }}
     name: Build documentation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[style]'
-          echo "${{ github.ref }}"
       - name: Run pre-comming
         run: pre-commit run
       - uses: pre-commit/action@v3.0.1
   documentation:
-    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'diego-plan9:chore') }}
+    if: github.repository_owner == 'Qiskit'
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
@@ -110,7 +109,7 @@ jobs:
           file: coverage.lcov
           fail-on-error: false
   integration-tests:
-    if: github.event_name == 'push' && github.repository_owner == 'Qiskit'
+    if: ${{github.event_name == 'push' && github.repository_owner == 'Qiskit' && !contains(github.ref, 'gh-readonly-queue') }}
     # only kick-off resource intensive integration tests if unit tests and all basic checks succeeded
     needs: [ "unit-tests"  ]
     name: Run integration tests - ${{ matrix.environment }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[style]'
-          echo "${{ github.ref_name }}"
+          echo "${{ github.ref }}"
       - name: Run pre-comming
         run: pre-commit run
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   code-quality:
-    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'chore') }}
+    if: github.repository_owner == 'Qiskit'
     name: Run code quality checks
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
         run: pre-commit run
       - uses: pre-commit/action@v3.0.1
   documentation:
-    if: github.repository_owner == 'Qiskit'
+    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'chore') }}
     name: Build documentation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[style]'
+          echo "${{ github.ref_name }}"
       - name: Run pre-comming
         run: pre-commit run
       - uses: pre-commit/action@v3.0.1
   documentation:
-    if: ${{github.repository_owner == 'Qiskit' && !startsWith('diego-plan9:chore', github.ref_name) }}
+    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'diego-plan9:chore') }}
     name: Build documentation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   code-quality:
-    if: github.repository_owner == 'Qiskit'
+    if: github.repository_owner == 'Qiskit' && ${{ !startsWith(github.ref_name, 'chore') }}
     name: Run code quality checks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[style]'
-      - name: Run pre-comming
+      - name: Run pre-commit
         run: pre-commit run
       - uses: pre-commit/action@v3.0.1
   documentation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pre-commit run
       - uses: pre-commit/action@v3.0.1
   documentation:
-    if: ${{github.repository_owner == 'Qiskit' && !startsWith(github.ref_name, 'diego-plan9:chore') }}
+    if: ${{github.repository_owner == 'Qiskit' && !startsWith('diego-plan9:chore', github.ref_name) }}
     name: Build documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add an extra check in the `integration-tests` stage of `ci.yml`, which prevents integration tests being run in commits coming from the merge queue.

### Details and comments

Fixes N/A

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
