### PR TITLE
Pass mode to sampler in failing integration test

### DIFF
--- a/test/integration/test_sampler_v2.py
+++ b/test/integration/test_sampler_v2.py
@@ -329,7 +329,7 @@ class TestSampler(IBMIntegrationTestCase):
         """Test with per-pub shots option."""
         shots1 = 100
         shots2 = 200
-        sampler = Sampler()
+        sampler = Sampler(mode=self._backend)
         result = sampler.run(
             [
                 SamplerPub(self._isa_bell, shots=shots1),


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix an oversight in the new (split) integration test introduced in recent commits, which is causing the integration tests to fail

### Details and comments

Fixes N/A

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
