### PR TITLE
Avoid options as property in WrapperEstimator

### DIFF
--- a/qiskit_ibm_runtime/decoders/quantum_program/decoder.py
+++ b/qiskit_ibm_runtime/decoders/quantum_program/decoder.py
@@ -44,12 +44,6 @@ from .converters import (
     quantum_program_result_from_1_1,
 )
 
-"""
-The available post processors.
-
-This is a dictionary mapping semantic roles to maps between
-versions and functions.
-"""
 SUPPORTED_POST_PROCESSORS = {
     "sampler_v2": {
         "v0.1": sampler_v2_post_processor_v0_1,
@@ -58,6 +52,10 @@ SUPPORTED_POST_PROCESSORS = {
         "v0.1": estimator_v2_post_processor_v0_1,
     },
 }
+"""The available post processors.
+
+This is a dictionary mapping semantic roles to maps between versions and functions.
+"""
 
 
 if TYPE_CHECKING:

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from qiskit.primitives.base import BaseEstimatorV2
@@ -90,6 +90,9 @@ class EstimatorV2(BaseEstimatorV2):
             for all available options.
     """
 
+    options: EstimatorOptions
+    """The options of this Estimator."""
+
     def __init__(
         self,
         mode: BackendV2 | Session | Batch | None = None,
@@ -99,13 +102,23 @@ class EstimatorV2(BaseEstimatorV2):
 
         self._executor = Executor(mode=mode)
 
-        # Initialize options
-        if options is None:
-            self._options = EstimatorOptions()
-        elif isinstance(options, dict):
-            self._options = EstimatorOptions(**options)
-        else:
-            self._options = options
+        # Coerced to `SampEstimatorOptionslerOptions` via `__setattr__()`.
+        self.options = options if options is not None else EstimatorOptions()  # type: ignore[assignment]
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Set attribute ``name`` to ``value``.
+
+        Handle ``options`` as a special case, ensuring it is set to an ``EstimatorOptions``
+        instance. This is an alternative to using ``@setter``, as the setter causes issues in
+        ``ipython`` autocomplete features.
+        """
+        if name == "options":
+            if isinstance(value, dict):
+                value = EstimatorOptions(**value)
+            elif not isinstance(value, EstimatorOptions):
+                raise TypeError(f"Expected EstimatorOptions or dict, got {type(value)}")
+
+        super().__setattr__(name, value)
 
     def run(
         self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None
@@ -187,12 +200,3 @@ class EstimatorV2(BaseEstimatorV2):
         )
 
         return self._executor.run(quantum_program)
-
-    @property
-    def options(self) -> EstimatorOptions:
-        """Return the options.
-
-        Returns:
-            The estimator options.
-        """
-        return self._options

--- a/qiskit_ibm_runtime/options_models/dynamical_decoupling_options.py
+++ b/qiskit_ibm_runtime/options_models/dynamical_decoupling_options.py
@@ -52,6 +52,7 @@ class DynamicalDecouplingOptions:
 
     skip_reset_qubits: bool = False
     """Whether to insert DD on idle periods that immediately follow initialized/reset qubits.
+
     Since qubits in the ground state are less susceptible to decoherence, it can be beneficial
     to let them be while they are known to be in this state.
     """

--- a/qiskit_ibm_runtime/options_models/estimator_options.py
+++ b/qiskit_ibm_runtime/options_models/estimator_options.py
@@ -61,14 +61,16 @@ class EstimatorOptions:
     execution: ExecutionOptions = Field(default_factory=ExecutionOptions)
     """Execution options.
 
-    See :class:`.ExecutionOptions` for all available options."""
+    See :class:`.ExecutionOptions` for all available options.
+    """
 
     twirling: TwirlingOptions = Field(default_factory=TwirlingOptions)
     """Twirling options.
 
     Currently only enable_measure=False is supported.
 
-    See :class:`.TwirlingOptions` for all available options."""
+    See :class:`.TwirlingOptions` for all available options.
+    """
 
     dynamical_decoupling: DynamicalDecouplingOptions = Field(
         default_factory=DynamicalDecouplingOptions

--- a/qiskit_ibm_runtime/options_models/estimator_options.py
+++ b/qiskit_ibm_runtime/options_models/estimator_options.py
@@ -78,7 +78,7 @@ class EstimatorOptions:
     See :class:`~.DynamicalDecouplingOptions` for all available options.
     """
 
-    experimental: dict | None = None
+    experimental: dict = Field(default_factory=dict)
     """Experimental options."""
 
     max_execution_time: int | None = None

--- a/qiskit_ibm_runtime/options_models/execution_options.py
+++ b/qiskit_ibm_runtime/options_models/execution_options.py
@@ -76,3 +76,13 @@ class SamplerExecutionOptions(ExecutionOptions):
     """
 
     meas_type: Literal["classified", "kerneled", "avg_kerneled"] = "classified"
+    """How to process and return measurement results.
+    
+    This option sets the return type of all classical registers in all sampler pub results.
+
+    * ``"classified"``: Returns a BitArray with classified measurement outcomes.
+    * ``"kerneled"``: Returns complex IQ data points from kerneling the measurement
+        trace, in arbitrary units.
+    * ``"avg_kerneled"``: Returns complex IQ data points averaged over shots,
+        in arbitrary units.
+    """

--- a/qiskit_ibm_runtime/options_models/execution_options.py
+++ b/qiskit_ibm_runtime/options_models/execution_options.py
@@ -77,7 +77,7 @@ class SamplerExecutionOptions(ExecutionOptions):
 
     meas_type: Literal["classified", "kerneled", "avg_kerneled"] = "classified"
     """How to process and return measurement results.
-    
+
     This option sets the return type of all classical registers in all sampler pub results.
 
     * ``"classified"``: Returns a BitArray with classified measurement outcomes.

--- a/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
+++ b/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
@@ -28,12 +28,10 @@ class MeasureNoiseLearningOptions:
     .. note::
         These options are only used when the resilience level or options specify a
         technique that requires measurement noise learning.
-
     """
 
     num_randomizations: int = 32
-    """The number of random circuits to draw for the measurement learning experiment.
-    """
+    """The number of random circuits to draw for the measurement learning experiment."""
 
     shots_per_randomization: int | Literal["auto"] = "auto"
     """The number of shots to use for the learning experiment per random circuit.

--- a/qiskit_ibm_runtime/options_models/noise_learner_v3_options.py
+++ b/qiskit_ibm_runtime/options_models/noise_learner_v3_options.py
@@ -57,8 +57,7 @@ class NoiseLearnerV3Options:
     """
 
     post_selection: PostSelectionOptions = Field(default_factory=PostSelectionOptions)
-    """Options for post selecting the results of noise learning circuits.
-    """
+    """Options for post selecting the results of noise learning circuits."""
 
     experimental: dict = Field(default_factory=dict)
     """Experimental options.

--- a/qiskit_ibm_runtime/options_models/pec_options.py
+++ b/qiskit_ibm_runtime/options_models/pec_options.py
@@ -37,7 +37,9 @@ class PecOptions:
     """
 
     noise_gain: NonNegativeFloat | Literal["auto"] = "auto"
-    """The amount by which to scale the noise, where:
+    """The amount by which to scale the noise.
+
+    The amount by which to scale the noise, where:
 
     * A value of ``0`` corresponds to removing the full learned noise.
     * A value of ``1`` corresponds to no removal of the learned noise.

--- a/qiskit_ibm_runtime/options_models/post_selection_options.py
+++ b/qiskit_ibm_runtime/options_models/post_selection_options.py
@@ -57,6 +57,4 @@ class PostSelectionOptions:
 
     See the dosctrings of :class:`.PostSelector` and :meth:`.PostSelector.compute_mask` for more
     details.
-
-    Defaults to ``node``.
     """

--- a/qiskit_ibm_runtime/options_models/sampler_options.py
+++ b/qiskit_ibm_runtime/options_models/sampler_options.py
@@ -53,7 +53,7 @@ class SamplerOptions:
     See :class:`~.TwirlingOptions` for all available options.
     """
 
-    experimental: dict | None = None
+    experimental: dict = Field(default_factory=dict)
     """Experimental options."""
 
     max_execution_time: int | None = None

--- a/qiskit_ibm_runtime/options_models/sampler_options.py
+++ b/qiskit_ibm_runtime/options_models/sampler_options.py
@@ -45,7 +45,8 @@ class SamplerOptions:
     execution: SamplerExecutionOptions = Field(default_factory=SamplerExecutionOptions)
     """Execution options.
 
-    See :class:`~.SamplerExecutionOptions` for all available options."""
+    See :class:`~.SamplerExecutionOptions` for all available options.
+    """
 
     twirling: TwirlingOptions = Field(default_factory=TwirlingOptions)
     """Pauli twirling options.
@@ -57,8 +58,7 @@ class SamplerOptions:
     """Experimental options."""
 
     max_execution_time: int | None = None
-    """Maximum execution time in seconds, based on system execution time (not wall clock time).
-    """
+    """Maximum execution time in seconds, based on system execution time (not wall clock time)."""
 
     environment: SamplerEnvironmentOptions = Field(default_factory=SamplerEnvironmentOptions)
     """Options related to the execution environment."""

--- a/test/unit/executor/test_executor.py
+++ b/test/unit/executor/test_executor.py
@@ -19,10 +19,8 @@ from qiskit.circuit import QuantumCircuit
 
 from qiskit_ibm_runtime.executor import Executor
 from qiskit_ibm_runtime.options_models.environment_options import EnvironmentOptions
-from qiskit_ibm_runtime.options_models.executor_options import (
-    ExecutionOptions,
-    ExecutorOptions,
-)
+from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
+from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from test.utils import get_mocked_backend, get_mocked_session
 

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -38,7 +38,7 @@ class TestEstimatorOptions(unittest.TestCase):
         self.assertEqual(options.default_precision, 0.015625)
         self.assertIsInstance(options.dynamical_decoupling, DynamicalDecouplingOptions)
         self.assertIsInstance(options.execution, ExecutionOptions)
-        self.assertIsNone(options.experimental)
+        self.assertEqual(options.experimental, {})
         self.assertIsNone(options.max_execution_time)
         self.assertIsInstance(options.environment, EnvironmentOptions)
         self.assertTrue(options.resilience.measure_mitigation)

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -14,15 +14,19 @@
 
 import unittest
 
+from pydantic import ValidationError
+
+from qiskit_ibm_runtime.executor_estimator.estimator import EstimatorV2
 from qiskit_ibm_runtime.options_models.dynamical_decoupling_options import (
     DynamicalDecouplingOptions,
 )
 from qiskit_ibm_runtime.options_models.environment_options import EnvironmentOptions
-from qiskit_ibm_runtime.options_models.estimator_options import (
-    EstimatorOptions,
-)
+from qiskit_ibm_runtime.options_models.estimator_options import EstimatorOptions
 from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
+from test.utils import get_mocked_backend
+
+from ...ibm_test_case import IBMTestCase
 
 
 class TestEstimatorOptions(unittest.TestCase):
@@ -86,3 +90,111 @@ class TestEstimatorOptions(unittest.TestCase):
 
         self.assertEqual(executor_options.environment.image, "custom:image")
         self.assertEqual(executor_options.experimental.get("other"), "value")
+
+
+class TestEstimatorUsingOptions(IBMTestCase):
+    """Tests option setting on the ``Estimator`` class."""
+
+    def test_default_options(self):
+        """Test that default options are set when none are provided."""
+        estimator = EstimatorV2(mode=get_mocked_backend())
+        self.assertIsInstance(estimator.options, EstimatorOptions)
+        self.assertEqual(estimator.options, EstimatorOptions())
+
+    def test_options_from_instance(self):
+        """Test constructing with an EstimatorOptions instance."""
+        opts = EstimatorOptions(execution=ExecutionOptions(init_qubits=False))
+        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts)
+        self.assertIs(estimator.options, opts)
+        self.assertFalse(estimator.options.execution.init_qubits)
+
+    def test_options_from_dict(self):
+        """Test constructing with a nested dict."""
+        opts_dict = {
+            "execution": {"init_qubits": False, "rep_delay": 0.5},
+            "environment": {"log_level": "DEBUG", "job_tags": ["tag1"]},
+        }
+        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts_dict)
+        self.assertFalse(estimator.options.execution.init_qubits)
+        self.assertEqual(estimator.options.execution.rep_delay, 0.5)
+        self.assertEqual(estimator.options.environment.log_level, "DEBUG")
+        self.assertEqual(estimator.options.environment.job_tags, ["tag1"])
+
+    def test_options_from_partial_dict(self):
+        """Test constructing with a nested dict when only specifying some of the options."""
+        estimator = EstimatorV2(
+            mode=get_mocked_backend(), options={"execution": {"init_qubits": False}}
+        )
+        self.assertFalse(estimator.options.execution.init_qubits)
+        self.assertIsNone(estimator.options.execution.rep_delay)
+        self.assertEqual(estimator.options.environment, EnvironmentOptions())
+
+    def test_options_constructor_invalid_type(self):
+        """Test that an invalid options type raises TypeError."""
+        with self.assertRaisesRegex(TypeError, "Expected EstimatorOptions or dict"):
+            EstimatorV2(mode=get_mocked_backend(), options="invalid")
+
+    def test_setter_with_instance(self):
+        """Test setting options via the setter with an EstimatorOptions instance."""
+        estimator = EstimatorV2(mode=get_mocked_backend())
+        new_opts = EstimatorOptions(execution=ExecutionOptions(init_qubits=False))
+        estimator.options = new_opts
+        self.assertIs(estimator.options, new_opts)
+
+    def test_setter_with_dict(self):
+        """Test setting options via the setter with a dict."""
+        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator.options = {"execution": {"init_qubits": False}}
+        self.assertIsInstance(estimator.options, EstimatorOptions)
+        self.assertFalse(estimator.options.execution.init_qubits)
+
+    def test_setter_invalid_type(self):
+        """Test that setting options with an invalid type raises TypeError."""
+        estimator = EstimatorV2(mode=get_mocked_backend())
+        with self.assertRaisesRegex(TypeError, "Expected EstimatorOptions or dict"):
+            estimator.options = 42
+
+    def test_setter_replaces_options(self):
+        """Test that the setter replaces (not updates) the options."""
+        estimator = EstimatorV2(
+            mode=get_mocked_backend(), options={"environment": {"log_level": "DEBUG"}}
+        )
+        estimator.options = {"execution": {"init_qubits": False}}
+        # environment should be back to defaults since we replaced, not updated
+        self.assertEqual(estimator.options.environment.log_level, "WARNING")
+        self.assertFalse(estimator.options.execution.init_qubits)
+
+    def test_experimental_options_default_empty(self):
+        """Test that experimental options default to empty dict."""
+        estimator = EstimatorV2(mode=get_mocked_backend())
+        self.assertEqual(estimator.options.experimental, {})
+
+    def test_experimental_options_from_dict(self):
+        """Test constructing with experimental options in dict."""
+        opts_dict = {"experimental": {"foo": "bar", "baz": 123}}
+        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts_dict)
+        self.assertEqual(estimator.options.experimental, {"foo": "bar", "baz": 123})
+
+    def test_experimental_options_from_instance(self):
+        """Test constructing with an EstimatorOptions instance with experimental options."""
+        opts = EstimatorOptions(experimental={"custom_key": "custom_value"})
+        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts)
+        self.assertEqual(estimator.options.experimental, {"custom_key": "custom_value"})
+
+    def test_experimental_options_setter(self):
+        """Test setting experimental options via the setter."""
+        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator.options = {"experimental": {"test": "value"}}
+        self.assertEqual(estimator.options.experimental, {"test": "value"})
+
+    def test_validation_on_mutation(self):
+        """Test validation errors are raised on mutation, not just construction."""
+        options = ExecutionOptions(init_qubits=False)
+        with self.assertRaises(ValidationError):
+            options.init_qubits = [0, 1]
+
+    def test_extra_variables_are_forbidden(self):
+        """Test that we can not set variables undefined by the model."""
+        options = ExecutionOptions()
+        with self.assertRaises(ValidationError):
+            options.not_a_variable = 0

--- a/test/unit/executor_sampler/test_sampler_v2_options.py
+++ b/test/unit/executor_sampler/test_sampler_v2_options.py
@@ -45,9 +45,9 @@ class TestSamplerOptionsToExecutorOptions(unittest.TestCase):
         self.assertIsNone(executor_options.environment.image)
 
     def test_experimental_image_not_set(self):
-        """Test that image is None when experimental is None."""
+        """Test that image is None when experimental is empty."""
         options = SamplerOptions()
-        options.experimental = None
+        options.experimental = {}
         executor_options = options.to_executor_options()
 
         self.assertIsNone(executor_options.environment.image)

--- a/test/unit/executor_sampler/test_sampler_v2_options.py
+++ b/test/unit/executor_sampler/test_sampler_v2_options.py
@@ -14,7 +14,15 @@
 
 import unittest
 
-from qiskit_ibm_runtime.options_models import SamplerOptions
+from pydantic import ValidationError
+
+from qiskit_ibm_runtime.executor_sampler import SamplerV2
+from qiskit_ibm_runtime.options_models.environment_options import SamplerEnvironmentOptions
+from qiskit_ibm_runtime.options_models.execution_options import SamplerExecutionOptions
+from qiskit_ibm_runtime.options_models.sampler_options import SamplerOptions
+from test.utils import get_mocked_backend
+
+from ...ibm_test_case import IBMTestCase
 
 
 class TestSamplerOptionsToExecutorOptions(unittest.TestCase):
@@ -90,6 +98,114 @@ class TestSamplerOptionsToExecutorOptions(unittest.TestCase):
         options.experimental = {"execution": {"stretch_values": True, "scheduler_timing": True}}
         executor_options = options.to_executor_options()
 
-        # Check that experimental dict is carried over
+        # Check that experimental dict options map to executor options.
         self.assertEqual(executor_options.execution.stretch_values, True)
         self.assertEqual(executor_options.execution.scheduler_timing, True)
+
+
+class TestSamplerUsingOptions(IBMTestCase):
+    """Tests option setting on the ``Sampler`` class."""
+
+    def test_default_options(self):
+        """Test that default options are set when none are provided."""
+        sampler = SamplerV2(mode=get_mocked_backend())
+        self.assertIsInstance(sampler.options, SamplerOptions)
+        self.assertEqual(sampler.options, SamplerOptions())
+
+    def test_options_from_instance(self):
+        """Test constructing with an SamplerOptions instance."""
+        opts = SamplerOptions(execution=SamplerExecutionOptions(init_qubits=False))
+        sampler = SamplerV2(mode=get_mocked_backend(), options=opts)
+        self.assertIs(sampler.options, opts)
+        self.assertFalse(sampler.options.execution.init_qubits)
+
+    def test_options_from_dict(self):
+        """Test constructing with a nested dict."""
+        opts_dict = {
+            "execution": {"init_qubits": False, "rep_delay": 0.5},
+            "environment": {"log_level": "DEBUG", "job_tags": ["tag1"]},
+        }
+        sampler = SamplerV2(mode=get_mocked_backend(), options=opts_dict)
+        self.assertFalse(sampler.options.execution.init_qubits)
+        self.assertEqual(sampler.options.execution.rep_delay, 0.5)
+        self.assertEqual(sampler.options.environment.log_level, "DEBUG")
+        self.assertEqual(sampler.options.environment.job_tags, ["tag1"])
+
+    def test_options_from_partial_dict(self):
+        """Test constructing with a nested dict when only specifying some of the options."""
+        sampler = SamplerV2(
+            mode=get_mocked_backend(), options={"execution": {"init_qubits": False}}
+        )
+        self.assertFalse(sampler.options.execution.init_qubits)
+        self.assertIsNone(sampler.options.execution.rep_delay)
+        self.assertEqual(sampler.options.environment, SamplerEnvironmentOptions())
+
+    def test_options_constructor_invalid_type(self):
+        """Test that an invalid options type raises TypeError."""
+        with self.assertRaisesRegex(TypeError, "Expected SamplerOptions or dict"):
+            SamplerV2(mode=get_mocked_backend(), options="invalid")
+
+    def test_setter_with_instance(self):
+        """Test setting options via the setter with an SamplerOptions instance."""
+        sampler = SamplerV2(mode=get_mocked_backend())
+        new_opts = SamplerOptions(execution=SamplerExecutionOptions(init_qubits=False))
+        sampler.options = new_opts
+        self.assertIs(sampler.options, new_opts)
+
+    def test_setter_with_dict(self):
+        """Test setting options via the setter with a dict."""
+        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler.options = {"execution": {"init_qubits": False}}
+        self.assertIsInstance(sampler.options, SamplerOptions)
+        self.assertFalse(sampler.options.execution.init_qubits)
+
+    def test_setter_invalid_type(self):
+        """Test that setting options with an invalid type raises TypeError."""
+        sampler = SamplerV2(mode=get_mocked_backend())
+        with self.assertRaisesRegex(TypeError, "Expected SamplerOptions or dict"):
+            sampler.options = 42
+
+    def test_setter_replaces_options(self):
+        """Test that the setter replaces (not updates) the options."""
+        sampler = SamplerV2(
+            mode=get_mocked_backend(), options={"environment": {"log_level": "DEBUG"}}
+        )
+        sampler.options = {"execution": {"init_qubits": False}}
+        # environment should be back to defaults since we replaced, not updated
+        self.assertEqual(sampler.options.environment.log_level, "WARNING")
+        self.assertFalse(sampler.options.execution.init_qubits)
+
+    def test_experimental_options_default_empty(self):
+        """Test that experimental options default to empty dict."""
+        sampler = SamplerV2(mode=get_mocked_backend())
+        self.assertEqual(sampler.options.experimental, {})
+
+    def test_experimental_options_from_dict(self):
+        """Test constructing with experimental options in dict."""
+        opts_dict = {"experimental": {"foo": "bar", "baz": 123}}
+        sampler = SamplerV2(mode=get_mocked_backend(), options=opts_dict)
+        self.assertEqual(sampler.options.experimental, {"foo": "bar", "baz": 123})
+
+    def test_experimental_options_from_instance(self):
+        """Test constructing with an SamplerOptions instance with experimental options."""
+        opts = SamplerOptions(experimental={"custom_key": "custom_value"})
+        sampler = SamplerV2(mode=get_mocked_backend(), options=opts)
+        self.assertEqual(sampler.options.experimental, {"custom_key": "custom_value"})
+
+    def test_experimental_options_setter(self):
+        """Test setting experimental options via the setter."""
+        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler.options = {"experimental": {"test": "value"}}
+        self.assertEqual(sampler.options.experimental, {"test": "value"})
+
+    def test_validation_on_mutation(self):
+        """Test validation errors are raised on mutation, not just construction."""
+        options = SamplerExecutionOptions(init_qubits=False)
+        with self.assertRaises(ValidationError):
+            options.init_qubits = [0, 1]
+
+    def test_extra_variables_are_forbidden(self):
+        """Test that we can not set variables undefined by the model."""
+        options = SamplerExecutionOptions()
+        with self.assertRaises(ValidationError):
+            options.not_a_variable = 0


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Apply part of #2739 to `WrapperEstimator`, so it handles `options` in the same way as the rest of "new" programs (instead of a decorator, uses `__setattr__` for better auto-completing behavior and for more enforcing of validation when the attribute is set, not only as part of initializing during the constructor).

Tests have been copy-pasted (and adapted to use sampler / estimator option classes). In the process an inconsistency arose related to `experimental`, which defaults to a dict in `Executor` and allows `None` in `Estimator` and `Sampler`. I favored Executor-style handling of it, for consistency.

### Details and comments

Some tweaks of the docstrings in `option_models/` included.

Related to #2794 / #2681 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
