### PR TITLE
Add options to passthrough data and result metadata in wrapper estimator

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -76,7 +76,7 @@ def estimator_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveR
     circuits_metadata = post_processor_data.get("circuits_metadata", None)
 
     # Extract options if present
-    options_metadata = post_processor_data.get("options", None)
+    options_metadata = post_processor_data.get("options", {})
 
     # Check if measure_mitigation was used
     measure_mitigation = post_processor_data.get("measure_mitigation", None)
@@ -134,7 +134,7 @@ def estimator_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveR
         pub_result = EstimatorPubResult(data=data_bin, metadata=pub_metadata)
         pub_results.append(pub_result)
 
-    return PrimitiveResult(pub_results, metadata=options_metadata or {})
+    return PrimitiveResult(pub_results, metadata=options_metadata)
 
 
 def process_expectation_values(

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -75,6 +75,9 @@ def estimator_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveR
     # Extract circuit metadata if present
     circuits_metadata = post_processor_data.get("circuits_metadata", None)
 
+    # Extract options if present
+    options_metadata = post_processor_data.get("options", None)
+
     # Check if measure_mitigation was used
     measure_mitigation = post_processor_data.get("measure_mitigation", None)
     readout_noise_data = None
@@ -131,7 +134,7 @@ def estimator_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveR
         pub_result = EstimatorPubResult(data=data_bin, metadata=pub_metadata)
         pub_results.append(pub_result)
 
-    return PrimitiveResult(pub_results, metadata=result.metadata or {})
+    return PrimitiveResult(pub_results, metadata=options_metadata or {})
 
 
 def process_expectation_values(

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -172,6 +173,13 @@ class EstimatorV2(BaseEstimatorV2):
                 dd_options=self.options.dynamical_decoupling,
                 quantum_program=quantum_program,
             )
+
+        # Serialize options (assuming passthrough is correctly configured)
+        quantum_program.passthrough_data["post_processor"]["options"] = {  # type: ignore[index, call-overload]
+            "twirling": asdict(self.options.twirling),  # type: ignore[call-overload]
+            "dynamical_decoupling": asdict(self.options.dynamical_decoupling),  # type: ignore[call-overload]
+            "resilience": asdict(self.options.resilience),  # type: ignore[call-overload]
+        }
 
         executor_options = self.options.to_executor_options()
 

--- a/test/unit/decoders/executor_estimator/test_post_processor.py
+++ b/test/unit/decoders/executor_estimator/test_post_processor.py
@@ -303,6 +303,54 @@ class TestEstimatorV2PostProcessor(unittest.TestCase):
             primitive_result[0].data.ensemble_standard_error[0],
         )
 
+    def test_post_processor_with_options_metadata(self):
+        """Test that options metadata is properly transferred to primitive result."""
+        meas_data = np.array([[[[False, False]] * 10]])
+
+        # Create options metadata
+        options_metadata = {
+            "twirling": {
+                "enable_gates": True,
+                "enable_measure": False,
+                "num_randomizations": "auto",
+                "shots_per_randomization": "auto",
+                "strategy": "active-accum",
+            },
+            "dynamical_decoupling": {
+                "enable": True,
+                "sequence_type": "XY4",
+                "extra_slack_distribution": "middle",
+                "scheduling_method": "alap",
+            },
+            "resilience": {
+                "measure_mitigation": True,
+                "zne_mitigation": False,
+                "pec_mitigation": False,
+            },
+        }
+
+        result_data = [QuantumProgramItemResult({"_meas": meas_data})]
+        passthrough_data = {
+            "post_processor": {
+                "version": "v0.1",
+                "circuits_metadata": [None],
+                "observables": [[{"ZZ": 1.0}]],
+                "measure_bases": [["ZZ"]],
+                "param_basis_pairs": [[([], "ZZ")]],
+                "param_shapes": [[]],
+                "options": options_metadata,
+            },
+        }
+        result = QuantumProgramResult(
+            data=result_data, metadata=None, passthrough_data=passthrough_data
+        )
+        result._semantic_role = "estimator_v2"
+
+        primitive_result = estimator_v2_post_processor_v0_1(result)
+
+        # Verify primitive-level metadata contains options
+        self.assertEqual(primitive_result.metadata, options_metadata)
+
 
 @ddt
 class TestProcessExpectationValues(unittest.TestCase):

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -225,6 +225,39 @@ class TestEstimatorV2Run(unittest.TestCase):
         self.assertTrue(self.mock_executor_instance.options.execution.init_qubits)
         self.assertEqual(self.mock_executor_instance.options.execution.rep_delay, 0.001)
 
+    def test_run_adds_options_to_passthrough_data(self):
+        """Test that run adds options metadata to quantum program passthrough data."""
+        options = EstimatorOptions()
+        options.twirling.enable_gates = True
+        options.dynamical_decoupling.enable = True
+        options.resilience.measure_mitigation = True
+
+        estimator = EstimatorV2(mode=self.backend, options=options)
+
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+
+        estimator.run([(circuit, observable)], precision=0.03125)
+
+        # Verify executor.run was called
+        self.mock_executor_instance.run.assert_called_once()
+
+        # Get the quantum program passed to executor
+        call_args = self.mock_executor_instance.run.call_args
+        quantum_program = call_args[0][0]
+
+        # Verify passthrough data contains options
+        self.assertIsNotNone(quantum_program.passthrough_data)
+        self.assertIn("post_processor", quantum_program.passthrough_data)
+        self.assertIn("options", quantum_program.passthrough_data["post_processor"])
+
+        # Verify options content
+        options_metadata = quantum_program.passthrough_data["post_processor"]["options"]
+        self.assertEqual(options_metadata["twirling"]["enable_gates"], True)
+        self.assertEqual(options_metadata["dynamical_decoupling"]["enable"], True)
+        self.assertEqual(options_metadata["resilience"]["measure_mitigation"], True)
+
     def test_run_with_multiple_observables(self):
         """Test run with multiple observables in a single pub."""
         estimator = EstimatorV2(mode=self.backend)


### PR DESCRIPTION
### Summary
Related to #2825
This PR adds the estimator options to the pass through data, and eventually to the result metadata. This is meant to replicate the legacy estimator's behavior. This does not close the issue completely, as we are still missing some option fields, and option combinations.

### AI/LLM disclosure

- [X] I used the following tool to generate or modify code: IBM BOB
