### PR TITLE
Bump executor schema version to 1.1

### DIFF
--- a/docs/apidocs/executor_1_1.rst
+++ b/docs/apidocs/executor_1_1.rst
@@ -1,0 +1,4 @@
+.. automodule:: ibm_quantum_schemas.executor.version_1_1
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/docs/apidocs/ibm_quantum_schemas.rst
+++ b/docs/apidocs/ibm_quantum_schemas.rst
@@ -16,6 +16,7 @@ Python.
    executor_0_1
    executor_0_2
    executor_1_0
+   executor_1_1
    noise_learner_v3_0_1
    noise_learner_v3_0_2
    schema_common

--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -78,7 +78,7 @@ class Executor:
     """
 
     _PROGRAM_ID = "executor"
-    _SCHEMA_VERSION = "v1.0"
+    _SCHEMA_VERSION = "v1.1"
 
     options: ExecutorOptions
     """The options of this executor."""

--- a/release-notes/unreleased/2911.upgrade.rst
+++ b/release-notes/unreleased/2911.upgrade.rst
@@ -1,0 +1,1 @@
+Switched default schema version for executor to `1.1`.

--- a/test/integration/test_executor.py
+++ b/test/integration/test_executor.py
@@ -68,6 +68,7 @@ class TestExecutor(IBMIntegrationTestCase):
         params = job.inputs
         assert params["options"] == executor.options
         assert isinstance(params["quantum_program"], QuantumProgram)
+        assert params["schema_version"] == Executor._SCHEMA_VERSION
 
         results = job.result()
         self.assertIsInstance(results, QuantumProgramResult)
@@ -115,6 +116,7 @@ class TestExecutor(IBMIntegrationTestCase):
         params = job.inputs
         assert params["options"] == executor.options
         assert isinstance(params["quantum_program"], QuantumProgram)
+        assert params["schema_version"] == Executor._SCHEMA_VERSION
 
         results = job.result()
         self.assertIsInstance(results, QuantumProgramResult)


### PR DESCRIPTION
Closes #2910 

I have triggered the integration tests locally and verified that it passes