### PR TITLE
Move json module from utils to top-level

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -38,7 +38,7 @@ An object is *publicly documented* if and only if it appears in [the hosted API 
 The presence of a docstring in the Python source (or a `__doc__` attribute) is not sufficient to make an object publicly documented; this documentation must also be rendered in the public API documentation.
 
 As well as the objects themselves needing to be publicly documented, the only public-API *import locations* for a given object is the location it is documented at in [the public API documentation](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime), and parent modules or packages that re-export the object (if any).
-For example, while it is possible to import `RuntimeEncoder` from `qiskit_ibm_runtime.utils.json`, this is not a supported part of the public API because the[`RuntimeEncoder` object is documented as being in `qiskit_ibm_runtime`](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-encoder).
+For example, while it is possible to import `RuntimeEncoder` from `qiskit_ibm_runtime.json`, this is not a supported part of the public API because the[`RuntimeEncoder` object is documented as being in `qiskit_ibm_runtime`](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-encoder).
 
 As a rule of thumb, if you are using `qiskit-ibm-runtime`, you should import objects from the highest-level package that exports that object.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,10 +114,6 @@ ignore = [
     "I",      # isort -- requires specific import order and tweaks
 ]
 
-"qiskit_ibm_runtime/utils/__init__.py" = [
-    "I",      # isort -- requires specific import order and tweaks
-]
-
 "qiskit_ibm_runtime/options/*options.py" = [
     "TC",     # flake8-type-checking -- ruff moves Unset and Dict to TYPE_CHECKING block
 ]

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -204,7 +204,7 @@ from .qiskit_runtime_service import QiskitRuntimeService
 from .ibm_backend import IBMBackend
 from .runtime_job_v2 import RuntimeJobV2
 from .runtime_options import RuntimeOptions
-from .utils.json import RuntimeEncoder, RuntimeDecoder
+from .json import RuntimeEncoder, RuntimeDecoder
 from .session import Session
 from .batch import Batch
 

--- a/qiskit_ibm_runtime/api/rest/program_job.py
+++ b/qiskit_ibm_runtime/api/rest/program_job.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-from ...utils.json import RuntimeDecoder
+from ...json import RuntimeDecoder
 from .base import RestAdapterBase
 
 if TYPE_CHECKING:

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime.api.rest.base import RestAdapterBase
 from qiskit_ibm_runtime.api.rest.program_job import ProgramJob
 from qiskit_ibm_runtime.utils import local_to_utc
 
-from ...utils import RuntimeEncoder
+from ...json import RuntimeEncoder
 from .cloud_backend import CloudBackend
 from .runtime_session import RuntimeSession
 

--- a/qiskit_ibm_runtime/decoders/result_decoder.py
+++ b/qiskit_ibm_runtime/decoders/result_decoder.py
@@ -15,7 +15,7 @@
 import json
 from typing import Any
 
-from qiskit_ibm_runtime.utils import RuntimeDecoder
+from qiskit_ibm_runtime.json import RuntimeDecoder
 
 
 class ResultDecoder:

--- a/qiskit_ibm_runtime/json.py
+++ b/qiskit_ibm_runtime/json.py
@@ -80,7 +80,7 @@ from qiskit_ibm_runtime.options.zne_options import (
 )
 from qiskit_ibm_runtime.results.estimator_pub import EstimatorPubResult
 
-from ..results.noise_learner import NoiseLearnerResult
+from .results.noise_learner import NoiseLearnerResult
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/qiskit_ibm_runtime/utils/__init__.py
+++ b/qiskit_ibm_runtime/utils/__init__.py
@@ -12,13 +12,13 @@
 
 """Internal utilities."""
 
-from .converters import utc_to_local, local_to_utc
-from .utils import is_crn, are_circuits_dynamic
+from .converters import local_to_utc, utc_to_local
+from .utils import are_circuits_dynamic, is_crn
 from .validations import (
-    validate_estimator_pubs,
     validate_classical_registers,
-    validate_no_dd_with_dynamic_circuits,
+    validate_estimator_pubs,
     validate_isa_circuits,
     validate_job_tags,
+    validate_no_dd_with_dynamic_circuits,
     validate_rzz_pubs,
 )

--- a/qiskit_ibm_runtime/utils/__init__.py
+++ b/qiskit_ibm_runtime/utils/__init__.py
@@ -28,5 +28,3 @@ from .validations import (
     validate_job_tags,
     validate_rzz_pubs,
 )
-
-from .json import RuntimeEncoder, RuntimeDecoder, to_base64_string

--- a/test/unit/mock/fake_runtime_client.py
+++ b/test/unit/mock/fake_runtime_client.py
@@ -22,7 +22,7 @@ from typing import Any
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 from qiskit_ibm_runtime.api.exceptions import RequestsApiError
-from qiskit_ibm_runtime.utils import RuntimeEncoder
+from qiskit_ibm_runtime.json import RuntimeEncoder
 
 from .fake_api_backend import FakeApiBackend, FakeApiBackendSpecs
 

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -51,6 +51,7 @@ from qiskit_ibm_runtime.execution_span import (
     TwirledSliceSpanV2,
 )
 from qiskit_ibm_runtime.fake_provider import FakeNairobiV2
+from qiskit_ibm_runtime.json import RuntimeDecoder, RuntimeEncoder
 from qiskit_ibm_runtime.noise_learner_v3.params_converters import NOISE_LEARNER_V3_PARAMS_CONVERTERS
 from qiskit_ibm_runtime.options_models import ExecutorOptions, NoiseLearnerV3Options
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
@@ -61,7 +62,6 @@ from qiskit_ibm_runtime.results.noise_learner import (
     NoiseLearnerResult,
     PauliLindbladError,
 )
-from qiskit_ibm_runtime.json import RuntimeDecoder, RuntimeEncoder
 
 from ..ibm_test_case import IBMTestCase
 from ..program import run_program

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -61,7 +61,7 @@ from qiskit_ibm_runtime.results.noise_learner import (
     NoiseLearnerResult,
     PauliLindbladError,
 )
-from qiskit_ibm_runtime.utils import RuntimeDecoder, RuntimeEncoder
+from qiskit_ibm_runtime.json import RuntimeDecoder, RuntimeEncoder
 
 from ..ibm_test_case import IBMTestCase
 from ..program import run_program


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Move `qiskit_ibm_runtime.utils.json` to `qiskit_ibm_runtime.json`. `RuntimeEncoder` and `RuntimeDecoder` are a bit central - and having them in `utils` forced every other item using `utils` for other purposes go through it. Moving the package up reflects better his significativeness, and allows to keep `utils` lighter.

Top-level import remains unchanged.

### Details and comments

Related to #2749 (and a bit to #2894, continuing it)

As a small byproduct, we no longer need to exclude `utils/__init__.py` from `isort` rules.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
