### PR TITLE
Update ruff config for more terse imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ source = ["qiskit_ibm_runtime"]
 line-length = 100
 target-version = "py310"
 
+[tool.ruff.lint.isort]
+split-on-trailing-comma = false
+
 [tool.ruff.lint]
 future-annotations = true
 select = [

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -214,16 +214,10 @@ from .exceptions import *
 from .utils.logging import setup_logger
 from .version import __version__
 
-from .estimator import (
-    EstimatorV2,
-    EstimatorV2 as Estimator,
-)
+from .estimator import EstimatorV2, EstimatorV2 as Estimator
 from .executor import Executor
 from .sampler import SamplerV2, SamplerV2 as Sampler
-from .noise_learner import (
-    NoiseLearner,
-    NoiseLearner as NoiseLearnerV2,
-)
+from .noise_learner import NoiseLearner, NoiseLearner as NoiseLearnerV2
 from .noise_learner_v3 import NoiseLearnerV3
 from .options import (
     EstimatorOptions,
@@ -232,10 +226,7 @@ from .options import (
     OptionsV2,
     OptionsV2 as Options,
 )
-from .options_models import (
-    ExecutorOptions,
-    NoiseLearnerV3Options,
-)
+from .options_models import ExecutorOptions, NoiseLearnerV3Options
 
 # Setup the logger for the IBM Quantum Provider package.
 logger = logging.getLogger(__name__)

--- a/qiskit_ibm_runtime/accounts/utils.py
+++ b/qiskit_ibm_runtime/accounts/utils.py
@@ -15,9 +15,7 @@
 from urllib.parse import urlparse
 
 import requests
-from ibm_cloud_sdk_core.authenticators import (
-    IAMAuthenticator,
-)
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from ibm_platform_services import ResourceControllerV2
 
 from ..utils.utils import is_crn

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -23,11 +23,7 @@ from qiskit.providers.backend import BackendV2
 
 from .options.options import BaseOptions, OptionsV2
 from .options.utils import merge_options_v2
-from .utils import (
-    validate_isa_circuits,
-    validate_no_dd_with_dynamic_circuits,
-    validate_rzz_pubs,
-)
+from .utils import validate_isa_circuits, validate_no_dd_with_dynamic_circuits, validate_rzz_pubs
 from .utils.default_session import get_cm_session
 from .utils.utils import is_simulator
 

--- a/qiskit_ibm_runtime/base_runtime_job.py
+++ b/qiskit_ibm_runtime/base_runtime_job.py
@@ -24,11 +24,7 @@ from typing import TYPE_CHECKING, Any
 from .api.exceptions import RequestsApiError
 from .decoders.defaults import DEFAULT_DECODERS
 from .decoders.result_decoder import ResultDecoder
-from .exceptions import (
-    IBMApiError,
-    IBMError,
-    IBMRuntimeError,
-)
+from .exceptions import IBMApiError, IBMError, IBMRuntimeError
 from .utils import utc_to_local, validate_job_tags
 
 if TYPE_CHECKING:

--- a/qiskit_ibm_runtime/decoders/noise_learner_v3/converters.py
+++ b/qiskit_ibm_runtime/decoders/noise_learner_v3/converters.py
@@ -18,15 +18,10 @@ from typing import TYPE_CHECKING
 
 from qiskit.quantum_info import QubitSparsePauliList
 
-from ...results.noise_learner_v3 import (
-    NoiseLearnerV3Result,
-    NoiseLearnerV3Results,
-)
+from ...results.noise_learner_v3 import NoiseLearnerV3Result, NoiseLearnerV3Results
 
 if TYPE_CHECKING:
-    from ibm_quantum_schemas.noise_learner_v3.version_0_2 import (
-        NoiseLearnerV3ResultsModel,
-    )
+    from ibm_quantum_schemas.noise_learner_v3.version_0_2 import NoiseLearnerV3ResultsModel
 
 
 def noise_learner_v3_result_from_0_1(

--- a/qiskit_ibm_runtime/decoders/quantum_program/decoder.py
+++ b/qiskit_ibm_runtime/decoders/quantum_program/decoder.py
@@ -30,12 +30,8 @@ from ibm_quantum_schemas.executor.version_1_1 import (
     QuantumProgramResultModel as QuantumProgramResultModel_1_1,
 )
 
-from ..executor_estimator.post_processor_v0_1 import (
-    estimator_v2_post_processor_v0_1,
-)
-from ..executor_sampler.post_processor_v0_1 import (
-    sampler_v2_post_processor_v0_1,
-)
+from ..executor_estimator.post_processor_v0_1 import estimator_v2_post_processor_v0_1
+from ..executor_sampler.post_processor_v0_1 import sampler_v2_post_processor_v0_1
 from ..result_decoder import ResultDecoder
 from .converters import (
     quantum_program_result_from_0_1,

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -24,14 +24,8 @@ from qiskit.providers import BackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.utils import optionals as _optionals
 
-from ..models import (
-    BackendConfiguration,
-    BackendProperties,
-    BackendStatus,
-)
-from ..models.exceptions import (
-    BackendPropertyError,
-)
+from ..models import BackendConfiguration, BackendProperties, BackendStatus
+from ..models.exceptions import BackendPropertyError
 from ..utils.backend_converter import convert_to_target
 from ..utils.backend_decoder import (
     configuration_from_server_data,
@@ -45,9 +39,7 @@ if TYPE_CHECKING:
     from qiskit.providers import Job, Options
     from qiskit.transpiler import Target
 
-    from ..models import (
-        QasmBackendConfiguration,
-    )
+    from ..models import QasmBackendConfiguration
     from ..qiskit_runtime_service import QiskitRuntimeService
 
 logger = logging.getLogger(__name__)
@@ -318,9 +310,7 @@ class FakeBackendV2(BackendV2):
             basic_device_gate_errors,
             basic_device_readout_errors,
         )
-        from qiskit_aer.noise.passes import (
-            RelaxationNoisePass,
-        )
+        from qiskit_aer.noise.passes import RelaxationNoisePass
 
         if self._props_dict is None:
             self._set_props_dict_from_json()

--- a/qiskit_ibm_runtime/fake_provider/local_service.py
+++ b/qiskit_ibm_runtime/fake_provider/local_service.py
@@ -21,10 +21,7 @@ import warnings
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Literal
 
-from qiskit.primitives import (
-    BackendEstimatorV2,
-    BackendSamplerV2,
-)
+from qiskit.primitives import BackendEstimatorV2, BackendSamplerV2
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
 

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -23,21 +23,11 @@ from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.providers.options import Options
 from qiskit.result import MeasLevel, MeasReturnType
 
-from .exceptions import (
-    IBMBackendApiProtocolError,
-    IBMBackendError,
-)
-from .models import (
-    BackendStatus,
-    GateConfig,
-    QasmBackendConfiguration,
-)
+from .exceptions import IBMBackendApiProtocolError, IBMBackendError
+from .models import BackendStatus, GateConfig, QasmBackendConfiguration
 from .utils import local_to_utc
 from .utils.backend_converter import convert_to_target
-from .utils.backend_decoder import (
-    configuration_from_server_data,
-    properties_from_server_data,
-)
+from .utils.backend_decoder import configuration_from_server_data, properties_from_server_data
 
 if TYPE_CHECKING:
     from qiskit import QuantumCircuit

--- a/qiskit_ibm_runtime/noise_learner_v3/validation.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/validation.py
@@ -17,12 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from qiskit.circuit import (
-    BoxOp,
-    ControlFlowOp,
-    ParameterExpression,
-    QuantumRegister,
-)
+from qiskit.circuit import BoxOp, ControlFlowOp, ParameterExpression, QuantumRegister
 from samplomatic.annotations import Twirl
 from samplomatic.utils import get_annotation
 
@@ -31,9 +26,7 @@ from ..options_models.post_selection_options import DEFAULT_X_PULSE_TYPE
 from .find_learning_protocol import find_learning_protocol
 
 if TYPE_CHECKING:
-    from qiskit.circuit import (
-        CircuitInstruction,
-    )
+    from qiskit.circuit import CircuitInstruction
     from qiskit.transpiler import Target
 
     from ..models.backend_configuration import BackendConfiguration

--- a/qiskit_ibm_runtime/options/estimator_options.py
+++ b/qiskit_ibm_runtime/options/estimator_options.py
@@ -19,13 +19,7 @@ from .execution_options import ExecutionOptionsV2
 from .options import OptionsV2
 from .resilience_options import ResilienceOptionsV2
 from .twirling_options import TwirlingOptions
-from .utils import (
-    Dict,
-    Unset,
-    UnsetType,
-    make_constraint_validator,
-    primitive_dataclass,
-)
+from .utils import Dict, Unset, UnsetType, make_constraint_validator, primitive_dataclass
 
 MAX_RESILIENCE_LEVEL: int = 2
 

--- a/qiskit_ibm_runtime/options/simulator_options.py
+++ b/qiskit_ibm_runtime/options/simulator_options.py
@@ -77,9 +77,7 @@ class SimulatorOptions:
                     "'noise_model' can only be a dictionary or qiskit_aer.noise.NoiseModel."
                 )
 
-            from qiskit_aer.noise import (
-                NoiseModel as AerNoiseModel,
-            )
+            from qiskit_aer.noise import NoiseModel as AerNoiseModel
 
             if not isinstance(model, AerNoiseModel):
                 raise ValueError(
@@ -103,9 +101,7 @@ class SimulatorOptions:
                 "qiskit-aer", "Aer provider", "pip install qiskit-aer"
             )
 
-        from qiskit_aer.noise import (
-            NoiseModel as AerNoiseModel,
-        )
+        from qiskit_aer.noise import NoiseModel as AerNoiseModel
 
         self.noise_model = AerNoiseModel.from_backend(backend)
 

--- a/qiskit_ibm_runtime/quantum_program/converters/__init__.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/__init__.py
@@ -12,19 +12,7 @@
 
 """Converters for executor."""
 
-from .converters_0_1 import (
-    quantum_program_from_0_1,
-    quantum_program_to_0_1,
-)
-from .converters_0_2 import (
-    quantum_program_from_0_2,
-    quantum_program_to_0_2,
-)
-from .converters_1_0 import (
-    quantum_program_from_1_0,
-    quantum_program_to_1_0,
-)
-from .converters_1_1 import (
-    quantum_program_from_1_1,
-    quantum_program_to_1_1,
-)
+from .converters_0_1 import quantum_program_from_0_1, quantum_program_to_0_1
+from .converters_0_2 import quantum_program_from_0_2, quantum_program_to_0_2
+from .converters_1_0 import quantum_program_from_1_0, quantum_program_to_1_0
+from .converters_1_1 import quantum_program_from_1_1, quantum_program_to_1_1

--- a/qiskit_ibm_runtime/transpiler/passes/basis/fold_rzz_angle.py
+++ b/qiskit_ibm_runtime/transpiler/passes/basis/fold_rzz_angle.py
@@ -37,9 +37,7 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit_ibm_runtime import EstimatorV2, SamplerV2
 
 if TYPE_CHECKING:
-    from qiskit.circuit import (
-        Qubit,
-    )
+    from qiskit.circuit import Qubit
     from qiskit.primitives.containers.estimator_pub import EstimatorPubLike
     from qiskit.primitives.containers.sampler_pub import SamplerPubLike
 

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py
@@ -16,14 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from qiskit.circuit import (
-    Clbit,
-    ControlFlowOp,
-    Gate,
-    IfElseOp,
-    Measure,
-    Qubit,
-)
+from qiskit.circuit import Clbit, ControlFlowOp, Gate, IfElseOp, Measure, Qubit
 from qiskit.circuit.controlflow import condition_resources
 from qiskit.circuit.delay import Delay
 from qiskit.circuit.library import Barrier
@@ -38,10 +31,7 @@ from .utils import block_order_op_nodes
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from qiskit.circuit import (
-        Bit,
-        Instruction,
-    )
+    from qiskit.circuit import Bit, Instruction
     from qiskit.dagcircuit import DAGNode
     from qiskit.transpiler import Target
 

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
@@ -22,15 +22,11 @@ from typing import TYPE_CHECKING, TypeAlias
 from qiskit.circuit import ControlFlowOp, Measure, Parameter, Reset
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode
 from qiskit.transpiler.exceptions import TranspilerError
-from qiskit.transpiler.instruction_durations import (
-    InstructionDurations,
-)
+from qiskit.transpiler.instruction_durations import InstructionDurations
 
 if TYPE_CHECKING:
     from qiskit.providers import Backend
-    from qiskit.transpiler.instruction_durations import (
-        InstructionDurationsType,
-    )
+    from qiskit.transpiler.instruction_durations import InstructionDurationsType
     from qiskit.transpiler.target import Target
 
 BlockOrderingCallableType = Callable[[DAGCircuit], Generator[DAGOpNode, None, None]]

--- a/qiskit_ibm_runtime/transpiler/plugin.py
+++ b/qiskit_ibm_runtime/transpiler/plugin.py
@@ -23,10 +23,7 @@ from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
 from qiskit.version import __version__ as _terra_version_string
 
-from qiskit_ibm_runtime.transpiler.passes.basis import (
-    ConvertIdToDelay,
-    FoldRzzAngle,
-)
+from qiskit_ibm_runtime.transpiler.passes.basis import ConvertIdToDelay, FoldRzzAngle
 
 if TYPE_CHECKING:
     from qiskit.transpiler.passmanager_config import PassManagerConfig

--- a/qiskit_ibm_runtime/utils/__init__.py
+++ b/qiskit_ibm_runtime/utils/__init__.py
@@ -12,14 +12,8 @@
 
 """Internal utilities."""
 
-from .converters import (
-    utc_to_local,
-    local_to_utc,
-)
-from .utils import (
-    is_crn,
-    are_circuits_dynamic,
-)
+from .converters import utc_to_local, local_to_utc
+from .utils import is_crn, are_circuits_dynamic
 from .validations import (
     validate_estimator_pubs,
     validate_classical_registers,

--- a/qiskit_ibm_runtime/utils/backend_decoder.py
+++ b/qiskit_ibm_runtime/utils/backend_decoder.py
@@ -18,10 +18,7 @@ import traceback
 import dateutil.parser
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 
-from ..models import (
-    BackendProperties,
-    QasmBackendConfiguration,
-)
+from ..models import BackendProperties, QasmBackendConfiguration
 from .converters import utc_to_local_all
 from .utils import is_fractional_gate
 

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -29,9 +29,7 @@ from typing import TYPE_CHECKING, Any, get_args
 import dateutil.parser
 import numpy as np
 
-from qiskit_ibm_runtime.quantum_program.params_converters import (
-    QUANTUM_PROGRAM_PARAMS_CONVERTERS,
-)
+from qiskit_ibm_runtime.quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
 
 try:
     from qiskit.quantum_info import PauliLindbladMap
@@ -40,12 +38,7 @@ try:
 except ImportError:
     HAS_PAULI_LINDBLAD_MAP = False
 
-from qiskit.circuit import (
-    Instruction,
-    Parameter,
-    QuantumCircuit,
-    QuantumRegister,
-)
+from qiskit.circuit import Instruction, Parameter, QuantumCircuit, QuantumRegister
 from qiskit.circuit.parametertable import ParameterView
 from qiskit.primitives.containers import (
     BitArray,
@@ -59,10 +52,7 @@ from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.primitives.containers.observables_array import ObservablesArray
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 from qiskit.qpy import QPY_VERSION as QISKIT_QPY_VERSION
-from qiskit.qpy import (
-    dump,
-    load,
-)
+from qiskit.qpy import dump, load
 from qiskit.qpy.binary_io.value import _read_parameter, _write_parameter
 from qiskit.result import Result
 from qiskit.transpiler import CouplingMap
@@ -75,9 +65,7 @@ from qiskit_ibm_runtime.execution_span import (
     TwirledSliceSpan,
     TwirledSliceSpanV2,
 )
-from qiskit_ibm_runtime.options.zne_options import (
-    ExtrapolatorType,
-)
+from qiskit_ibm_runtime.options.zne_options import ExtrapolatorType
 from qiskit_ibm_runtime.results.estimator_pub import EstimatorPubResult
 
 from ..results.noise_learner import NoiseLearnerResult

--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -20,11 +20,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from qiskit.circuit import ControlFlowOp, ParameterExpression
 from qiskit.circuit.delay import Delay
-from qiskit.circuit.library.standard_gates import (
-    PhaseGate,
-    RZGate,
-    U1Gate,
-)
+from qiskit.circuit.library.standard_gates import PhaseGate, RZGate, U1Gate
 from qiskit.qpy import QPY_VERSION
 from samplomatic.ssv import SSV
 

--- a/test/integration/test_account.py
+++ b/test/integration/test_account.py
@@ -20,10 +20,7 @@ from unittest.mock import patch
 import requests
 from ibm_cloud_sdk_core import ApiException
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
-from ibm_platform_services import (
-    GlobalSearchV2,
-    ResourceControllerV2,
-)
+from ibm_platform_services import GlobalSearchV2, ResourceControllerV2
 
 from qiskit_ibm_runtime import IBMInputValueError, QiskitRuntimeService
 from qiskit_ibm_runtime.accounts.utils import (

--- a/test/integration/test_ibm_job_attributes.py
+++ b/test/integration/test_ibm_job_attributes.py
@@ -26,9 +26,7 @@ from qiskit.compiler import transpile
 from qiskit_ibm_runtime import SamplerV2 as Sampler
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 
-from ..decorators import (
-    integration_test_setup,
-)
+from ..decorators import integration_test_setup
 from ..ibm_test_case import IBMTestCase
 from ..utils import bell
 
@@ -37,9 +35,7 @@ if TYPE_CHECKING:
 
     from qiskit_ibm_runtime import IBMBackend, RuntimeJobV2
 
-    from ..decorators import (
-        IntegrationTestDependencies,
-    )
+    from ..decorators import IntegrationTestDependencies
 
 
 class TestIBMJobAttributes(IBMTestCase):

--- a/test/smoke/test_primitives.py
+++ b/test/smoke/test_primitives.py
@@ -23,10 +23,7 @@ from qiskit_ibm_runtime import EstimatorV2, SamplerV2
 from qiskit_ibm_runtime.noise_learner import NoiseLearner
 from qiskit_ibm_runtime.noise_learner_v3 import NoiseLearnerV3
 from qiskit_ibm_runtime.options import NoiseLearnerOptions
-from qiskit_ibm_runtime.results import (
-    NoiseLearnerV3Result,
-    NoiseLearnerV3Results,
-)
+from qiskit_ibm_runtime.results import NoiseLearnerV3Result, NoiseLearnerV3Results
 from qiskit_ibm_runtime.results.noise_learner import NoiseLearnerResult
 
 from ..ibm_test_case import IBMIntegrationTestCase

--- a/test/unit/decoders/test_noise_learner_v3.py
+++ b/test/unit/decoders/test_noise_learner_v3.py
@@ -21,10 +21,7 @@ from qiskit_ibm_runtime.decoders.noise_learner_v3.decoder import NoiseLearnerV3R
 from qiskit_ibm_runtime.noise_learner_v3.converters.version_0_1 import (
     noise_learner_v3_result_to_0_1,
 )
-from qiskit_ibm_runtime.results.noise_learner_v3 import (
-    NoiseLearnerV3Result,
-    NoiseLearnerV3Results,
-)
+from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Result, NoiseLearnerV3Results
 
 from ...ibm_test_case import IBMTestCase
 

--- a/test/unit/decoders/test_quantum_program.py
+++ b/test/unit/decoders/test_quantum_program.py
@@ -29,10 +29,7 @@ from ibm_quantum_schemas.executor.version_0_1 import (
 from qiskit.primitives import PrimitiveResult
 
 from qiskit_ibm_runtime.decoders.quantum_program.decoder import QuantumProgramResultDecoder
-from qiskit_ibm_runtime.results.quantum_program import (
-    Metadata,
-    QuantumProgramResult,
-)
+from qiskit_ibm_runtime.results.quantum_program import Metadata, QuantumProgramResult
 
 from ...ibm_test_case import IBMTestCase
 

--- a/test/unit/executor/test_calculate_twirling_shots.py
+++ b/test/unit/executor/test_calculate_twirling_shots.py
@@ -16,9 +16,7 @@ import unittest
 
 from ddt import data, ddt, unpack
 
-from qiskit_ibm_runtime.executor.calculate_twirling_shots import (
-    calculate_twirling_shots,
-)
+from qiskit_ibm_runtime.executor.calculate_twirling_shots import calculate_twirling_shots
 
 
 @ddt

--- a/test/unit/executor_estimator/test_estimator_v2_trex_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_trex_utils.py
@@ -18,9 +18,7 @@ from qiskit import QuantumCircuit
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import SparsePauliOp
 
-from qiskit_ibm_runtime.executor_estimator.trex_utils import (
-    create_trex_calibration_circuit,
-)
+from qiskit_ibm_runtime.executor_estimator.trex_utils import create_trex_calibration_circuit
 from qiskit_ibm_runtime.options_models.measure_noise_learning_options import (
     MeasureNoiseLearningOptions,
 )

--- a/test/unit/executor_sampler/test_utils.py
+++ b/test/unit/executor_sampler/test_utils.py
@@ -19,10 +19,7 @@ from qiskit.circuit import BoxOp
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
-from qiskit_ibm_runtime.executor_sampler.utils import (
-    extract_shots_from_pubs,
-    validate_no_boxes,
-)
+from qiskit_ibm_runtime.executor_sampler.utils import extract_shots_from_pubs, validate_no_boxes
 
 
 class TestValidateNoBoxes(unittest.TestCase):

--- a/test/unit/noise_learner_v3/converters/test_converters_0_1.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_1.py
@@ -24,10 +24,7 @@ from qiskit_ibm_runtime.noise_learner_v3.converters.version_0_1 import (
     noise_learner_v3_result_to_0_1,
 )
 from qiskit_ibm_runtime.options_models import NoiseLearnerV3Options
-from qiskit_ibm_runtime.results.noise_learner_v3 import (
-    NoiseLearnerV3Result,
-    NoiseLearnerV3Results,
-)
+from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Result, NoiseLearnerV3Results
 
 from ....ibm_test_case import IBMTestCase
 

--- a/test/unit/noise_learner_v3/converters/test_converters_0_2.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_2.py
@@ -24,10 +24,7 @@ from qiskit_ibm_runtime.noise_learner_v3.converters.version_0_2 import (
     noise_learner_v3_result_to_0_2,
 )
 from qiskit_ibm_runtime.options_models import NoiseLearnerV3Options
-from qiskit_ibm_runtime.results.noise_learner_v3 import (
-    NoiseLearnerV3Result,
-    NoiseLearnerV3Results,
-)
+from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Result, NoiseLearnerV3Results
 
 from ....ibm_test_case import IBMTestCase
 

--- a/test/unit/noise_learner_v3/test_find_learning_protocol.py
+++ b/test/unit/noise_learner_v3/test_find_learning_protocol.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025-2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/unit/noise_learner_v3/test_find_learning_protocol.py
+++ b/test/unit/noise_learner_v3/test_find_learning_protocol.py
@@ -15,9 +15,7 @@
 from qiskit.circuit import QuantumCircuit
 from samplomatic import Twirl
 
-from qiskit_ibm_runtime.noise_learner_v3.find_learning_protocol import (
-    find_learning_protocol,
-)
+from qiskit_ibm_runtime.noise_learner_v3.find_learning_protocol import find_learning_protocol
 
 from ...ibm_test_case import IBMTestCase
 

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -17,10 +17,7 @@ from qiskit import QuantumCircuit
 from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauliList
 from samplomatic import InjectNoise, Twirl
 
-from qiskit_ibm_runtime.results.noise_learner_v3 import (
-    NoiseLearnerV3Result,
-    NoiseLearnerV3Results,
-)
+from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Result, NoiseLearnerV3Results
 
 from ...ibm_test_case import IBMTestCase
 

--- a/test/unit/test_backend.py
+++ b/test/unit/test_backend.py
@@ -22,17 +22,9 @@ from qiskit.transpiler import generate_preset_pass_manager
 
 from qiskit_ibm_runtime import SamplerV2
 from qiskit_ibm_runtime.circuit import MidCircuitMeasure
-from qiskit_ibm_runtime.fake_provider import (
-    FakeFractionalBackend,
-    FakeManilaV2,
-    FakeSherbrooke,
-)
+from qiskit_ibm_runtime.fake_provider import FakeFractionalBackend, FakeManilaV2, FakeSherbrooke
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
-from qiskit_ibm_runtime.models import (
-    BackendConfiguration,
-    BackendProperties,
-    BackendStatus,
-)
+from qiskit_ibm_runtime.models import BackendConfiguration, BackendProperties, BackendStatus
 from qiskit_ibm_runtime.utils.backend_converter import convert_to_target
 
 from ..ibm_test_case import IBMTestCase

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -65,11 +65,7 @@ from qiskit_ibm_runtime.utils import RuntimeDecoder, RuntimeEncoder
 
 from ..ibm_test_case import IBMTestCase
 from ..program import run_program
-from ..serialization import (
-    SerializableClass,
-    SerializableClassDecoder,
-    get_complex_types,
-)
+from ..serialization import SerializableClass, SerializableClassDecoder, get_complex_types
 from ..utils import bell, mock_wait_for_final_state
 from .mock.fake_runtime_client import CustomResultRuntimeJob
 from .mock.fake_runtime_service import FakeRuntimeService

--- a/test/unit/test_fake_backends.py
+++ b/test/unit/test_fake_backends.py
@@ -14,10 +14,7 @@
 
 from ddt import data, ddt
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit.library import (
-    CZGate,
-    ECRGate,
-)
+from qiskit.circuit.library import CZGate, ECRGate
 from qiskit.compiler import transpile
 
 from qiskit_ibm_runtime.fake_provider import (

--- a/test/unit/test_local_mode.py
+++ b/test/unit/test_local_mode.py
@@ -15,28 +15,16 @@
 import warnings
 
 from ddt import data, ddt
-from qiskit.primitives import (
-    PrimitiveResult,
-    PubResult,
-    SamplerPubResult,
-)
+from qiskit.primitives import PrimitiveResult, PubResult, SamplerPubResult
 from qiskit.primitives.containers.data_bin import DataBin
 from qiskit_aer import AerSimulator
 
-from qiskit_ibm_runtime import (
-    Batch,
-    EstimatorV2,
-    SamplerV2,
-    Session,
-)
+from qiskit_ibm_runtime import Batch, EstimatorV2, SamplerV2, Session
 from qiskit_ibm_runtime.fake_provider import FakeManilaV2
 from qiskit_ibm_runtime.fake_provider.local_runtime_job import LocalRuntimeJob
 
 from ..ibm_test_case import IBMTestCase
-from ..utils import (
-    combine,
-    get_primitive_inputs,
-)
+from ..utils import combine, get_primitive_inputs
 
 
 @ddt

--- a/test/unit/transpiler/passes/basis/test_convert_id_to_delay.py
+++ b/test/unit/transpiler/passes/basis/test_convert_id_to_delay.py
@@ -15,12 +15,8 @@
 from qiskit.circuit import QuantumCircuit
 from qiskit.transpiler.passmanager import PassManager
 
-from qiskit_ibm_runtime.transpiler.passes.basis.convert_id_to_delay import (
-    ConvertIdToDelay,
-)
-from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import (
-    DynamicCircuitInstructionDurations,
-)
+from qiskit_ibm_runtime.transpiler.passes.basis.convert_id_to_delay import ConvertIdToDelay
+from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import DynamicCircuitInstructionDurations
 
 from .....ibm_test_case import IBMTestCase
 

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -27,12 +27,8 @@ from qiskit.transpiler.passmanager import PassManager
 from qiskit_ibm_runtime.transpiler.passes.scheduling.dynamical_decoupling import (
     PadDynamicalDecoupling,
 )
-from qiskit_ibm_runtime.transpiler.passes.scheduling.scheduler import (
-    ASAPScheduleAnalysis,
-)
-from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import (
-    DynamicCircuitInstructionDurations,
-)
+from qiskit_ibm_runtime.transpiler.passes.scheduling.scheduler import ASAPScheduleAnalysis
+from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import DynamicCircuitInstructionDurations
 
 from .....ibm_test_case import IBMTestCase
 

--- a/test/unit/transpiler/passes/scheduling/test_scheduler.py
+++ b/test/unit/transpiler/passes/scheduling/test_scheduler.py
@@ -27,9 +27,7 @@ from qiskit_ibm_runtime.transpiler.passes.scheduling.scheduler import (
     ALAPScheduleAnalysis,
     ASAPScheduleAnalysis,
 )
-from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import (
-    DynamicCircuitInstructionDurations,
-)
+from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import DynamicCircuitInstructionDurations
 
 from .....ibm_test_case import IBMTestCase
 

--- a/test/unit/transpiler/passes/scheduling/test_utils.py
+++ b/test/unit/transpiler/passes/scheduling/test_utils.py
@@ -13,9 +13,7 @@
 """Tests for Qiskit scheduling utilities."""
 
 from qiskit_ibm_runtime.fake_provider import FakeKolkataV2
-from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import (
-    DynamicCircuitInstructionDurations,
-)
+from qiskit_ibm_runtime.transpiler.passes.scheduling.utils import DynamicCircuitInstructionDurations
 
 from .....ibm_test_case import IBMTestCase
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -29,21 +29,11 @@ from qiskit.compiler import transpile
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.quantum_info import Pauli, SparsePauliOp
 
-from qiskit_ibm_runtime import (
-    Batch,
-    EstimatorV2,
-    QiskitRuntimeService,
-    SamplerV2,
-    Session,
-)
+from qiskit_ibm_runtime import Batch, EstimatorV2, QiskitRuntimeService, SamplerV2, Session
 from qiskit_ibm_runtime.exceptions import RuntimeInvalidStateError
 from qiskit_ibm_runtime.fake_provider import FakeManilaV2
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
-from qiskit_ibm_runtime.models import (
-    BackendConfiguration,
-    BackendProperties,
-    BackendStatus,
-)
+from qiskit_ibm_runtime.models import BackendConfiguration, BackendProperties, BackendStatus
 from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
 
 if TYPE_CHECKING:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Disable the [`split-on-trailing-comma`](https://docs.astral.sh/ruff/settings/#lint_isort_split-on-trailing-comma) `isort` option, in order to automatically enforce keeping imports in one line (if they fit). 

This restricts a bit the flexibility (ie. developers cannot keep imports in multiple lines if they fit in one line), but it allows for more consistency and an easier time grepping over the codebase. Plus, arguably we don't exercise that flexibility (there are a good number of imports of just one item that are using multiple lines, likely due to copy-pasting).

### Details and comments

Fixes N/A

There is also https://docs.astral.sh/ruff/settings/#format_skip-magic-trailing-comma, which applies not only to `import` but to the other statement. It felt a bit aggressive to apply (dry-running it, it did caught some instances where being more compact made sense, but there seemed to be enough examples for extra lines included for providing more readability).

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
