### PR TITLE
zne prepare function

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/zne/zne_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/zne_utils.py
@@ -1,0 +1,180 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Prepare function for Executor-based EstimatorV2 primitive."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from qiskit import QuantumCircuit
+    from qiskit.primitives.containers.estimator_pub import EstimatorPub
+
+    from ...options_models.measure_noise_learning_options import MeasureNoiseLearningOptions
+    from ...options_models.twirling_options import TwirlingOptions
+
+from qiskit.transpiler import PassManager
+from samplomatic import build
+
+from ...exceptions import IBMInputValueError
+from ...executor.calculate_twirling_shots import calculate_twirling_shots
+from ...executor.passthrough_utils import validate_and_extract_metadata
+from ...quantum_program import QuantumProgram
+from ...quantum_program.quantum_program import SamplexItem
+from ..prepare import box_circuit, compute_samplex_arguments, make_samplex_arguments
+from ..trex_utils import create_trex_calibration_circuit
+from .gate_folding import GateFolding
+
+logger = logging.getLogger(__name__)
+
+
+def fold_gates(
+    circuit: QuantumCircuit,
+    noise_factor: float,
+    method: Literal["random", "front", "back"] = "random",
+    **kwargs: Any,
+) -> QuantumCircuit:
+    """Test helper: run ``GateFolding`` via a one-pass PassManager."""
+    return PassManager([GateFolding(noise_factor, method, **kwargs)]).run(circuit)
+
+
+def prepare_zne(
+    pubs: Sequence[EstimatorPub],
+    twirling_options: TwirlingOptions,
+    shots: int,
+    noise_factors: Sequence[float],
+    folding_method: Literal["random", "front", "back"],
+    measure_noise_learning: MeasureNoiseLearningOptions | None = None,
+) -> QuantumProgram:
+    """Convert estimator PUBs to a quantum program.
+
+    Args:
+        pubs: List of estimator pubs to convert.
+        twirling_options: The twirling options.
+        shots: The number of shots to use. Will be overridden by
+            ``num_randomizations * shots_per_randomization`` when both are specified explicitly
+            and twirling is on.
+        noise_factors: The noise amplification factors.
+        folding_method: The method for folding the gates for noise amplification. Can be one of
+        `front`, `back` or `random`.
+        measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
+            Error eXtinction (TREX) mitigation method will be used.
+
+    Returns:
+        :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,
+        with ``passthrough data`` configured for
+        :class:`~qiskit_ibm_runtime.executor_estimator.estimator.EstimatorV2` post-processing.
+
+    Raises:
+        IBMInputValueError: If pubs have mismatched precision,
+            if a circuit contains mid-circuit measurements, or if a circuit already uses the
+            reserved classical register name ``_meas``.
+    """
+    if twirling_options.enable_gates or twirling_options.enable_measure:
+        num_randomizations, shots_per_randomization = calculate_twirling_shots(
+            shots,
+            twirling_options.num_randomizations,
+            twirling_options.shots_per_randomization,
+        )
+    else:
+        num_randomizations = 1
+        shots_per_randomization = shots
+
+    # Create items
+    items: list[SamplexItem] = []
+    observables_list = []
+    param_basis_pairs_list = []
+    param_shapes_list = []
+
+    for i, pub in enumerate(pubs):
+        logger.info("Processing pub %d/%d", i + 1, len(pubs))
+
+        # Prepare samplex_arguments that are common to all noise factors
+        flat_parameter_values, change_basis, param_basis_pairs = compute_samplex_arguments(pub)
+
+        for j, noise_factor in enumerate(noise_factors):
+            logger.info("Processing noise factor %d/%d", j + 1, len(noise_factors))
+
+            folded_circuit = fold_gates(pub.circuit, noise_factor, folding_method)
+
+            boxed_circuit = box_circuit(
+                folded_circuit, twirling_options, measure_noise_learning is not None
+            )
+
+            # Build the template and the samplex
+            template, samplex = build(boxed_circuit)
+
+            # Prepare samplex_arguments for the current noise factor
+            samplex_arguments = make_samplex_arguments(
+                samplex, boxed_circuit, flat_parameter_values, change_basis
+            )
+
+            # Create SamplexItem
+            # Each pub will have len(noise_factors) associated items
+            shape = (num_randomizations, change_basis.shape[0])
+            items.append(
+                SamplexItem(
+                    circuit=template,
+                    samplex=samplex,
+                    samplex_arguments=samplex_arguments,
+                    shape=shape,
+                )
+            )
+
+        # Store data for passthrough
+        observables_list.append(pub.observables.tolist())
+        param_basis_pairs_list.append(param_basis_pairs)
+        param_shapes_list.append(pub.parameter_values.shape)
+
+    # Collect and validate circuit metadata from each pub
+    circuits_metadata = validate_and_extract_metadata(pubs)
+
+    passthrough_data = {
+        "post_processor": {
+            "version": "v0.1",
+            "circuits_metadata": circuits_metadata,
+            "observables": observables_list,
+            "param_basis_pairs": param_basis_pairs_list,
+            "param_shapes": param_shapes_list,
+            "measure_mitigation": measure_noise_learning is not None,
+            "zne_noise_factors": noise_factors,
+        },
+    }
+
+    # Create QuantumProgram
+    quantum_program = QuantumProgram(
+        shots=shots_per_randomization,
+        items=items,
+        passthrough_data=passthrough_data,
+    )
+
+    # Add TREX calibration circuit
+    if measure_noise_learning is not None:
+        if (
+            isinstance(measure_noise_learning.shots_per_randomization, int)
+            and measure_noise_learning.shots_per_randomization != shots_per_randomization
+        ):
+            raise IBMInputValueError(
+                "shots_per_randomization must be the same for twirling and measure_noise_learning"
+            )
+        trex_item = create_trex_calibration_circuit(pubs, measure_noise_learning)
+        quantum_program.items.append(trex_item)
+        passthrough_data["post_processor"]["measure_mitigation"] = "True"
+
+    # Set semantic role for post-processing dispatch
+    quantum_program._semantic_role = "estimator_v2"
+
+    return quantum_program

--- a/qiskit_ibm_runtime/executor_estimator/zne/zne_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/zne_utils.py
@@ -26,12 +26,14 @@ if TYPE_CHECKING:
     from ...options_models.twirling_options import TwirlingOptions
     from ...options_models.zne_options import ZneOptions
 
+import numpy as np
 from qiskit.transpiler import PassManager
 from samplomatic import build
 
 from ...exceptions import IBMInputValueError
 from ...executor.calculate_twirling_shots import calculate_twirling_shots
 from ...executor.passthrough_utils import validate_and_extract_metadata
+from ...options_models.zne_options import ZNE_DEFAULT_NOISE_FACTORS
 from ...quantum_program import QuantumProgram
 from ...quantum_program.quantum_program import SamplexItem
 from ..prepare import box_circuit, compute_samplex_arguments, make_samplex_arguments
@@ -78,9 +80,9 @@ def prepare_zne(
         )
 
     if zne_options.noise_factors == "auto":
-        noise_factors = [1.0, 3.0, 5.0]
+        noise_factors = np.array(ZNE_DEFAULT_NOISE_FACTORS)
     else:
-        noise_factors = list(zne_options.noise_factors)
+        noise_factors = np.array(zne_options.noise_factors)
 
     if twirling_options.enable_gates or twirling_options.enable_measure:
         num_randomizations, shots_per_randomization = calculate_twirling_shots(
@@ -97,7 +99,7 @@ def prepare_zne(
     observables_list = []
     param_basis_pairs_list = []
     param_shapes_list = []
-    item_to_pub_and_noise_factor_map = []
+    item_id = []
 
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
@@ -148,7 +150,7 @@ def prepare_zne(
             )
 
             # each index is the item index, and it maps to (pub_number, noise_factor)
-            item_to_pub_and_noise_factor_map.append((i, noise_factor))
+            item_id.append((i, noise_factor))
 
         # Store data for passthrough
         observables_list.append(pub.observables.tolist())
@@ -167,7 +169,7 @@ def prepare_zne(
             "param_shapes": param_shapes_list,
             "measure_mitigation": measure_noise_learning is not None,
             "zne_noise_factors": noise_factors,
-            "item_to_pub_and_noise_factor_map": item_to_pub_and_noise_factor_map,
+            "item_id": item_id,
         },
     }
 

--- a/qiskit_ibm_runtime/executor_estimator/zne/zne_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/zne_utils.py
@@ -15,16 +15,16 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from qiskit import QuantumCircuit
     from qiskit.primitives.containers.estimator_pub import EstimatorPub
 
     from ...options_models.measure_noise_learning_options import MeasureNoiseLearningOptions
     from ...options_models.twirling_options import TwirlingOptions
+    from ...options_models.zne_options import ZneOptions
 
 from qiskit.transpiler import PassManager
 from samplomatic import build
@@ -41,22 +41,11 @@ from .gate_folding import GateFolding
 logger = logging.getLogger(__name__)
 
 
-def fold_gates(
-    circuit: QuantumCircuit,
-    noise_factor: float,
-    method: Literal["random", "front", "back"] = "random",
-    **kwargs: Any,
-) -> QuantumCircuit:
-    """Test helper: run ``GateFolding`` via a one-pass PassManager."""
-    return PassManager([GateFolding(noise_factor, method, **kwargs)]).run(circuit)
-
-
 def prepare_zne(
     pubs: Sequence[EstimatorPub],
     twirling_options: TwirlingOptions,
     shots: int,
-    noise_factors: Sequence[float],
-    folding_method: Literal["random", "front", "back"],
+    zne_options: ZneOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
 ) -> QuantumProgram:
     """Convert estimator PUBs to a quantum program.
@@ -67,9 +56,7 @@ def prepare_zne(
         shots: The number of shots to use. Will be overridden by
             ``num_randomizations * shots_per_randomization`` when both are specified explicitly
             and twirling is on.
-        noise_factors: The noise amplification factors.
-        folding_method: The method for folding the gates for noise amplification. Can be one of
-        `front`, `back` or `random`.
+        zne_options: The options for ZNE mitigation.
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
 
@@ -82,7 +69,19 @@ def prepare_zne(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
+        IBMInputValueError: If the amplifier in the ZneOptions is not one of ``gate_folding``,
+        ``gate_folding_front`` or ``gate_folding_back``.
     """
+    if zne_options.amplifier not in ["gate_folding", "gate_folding_front", "gate_folding_back"]:
+        raise IBMInputValueError(
+            "ZNE mitigation must be used with a gate folding noise amplification."
+        )
+
+    if zne_options.noise_factors == "auto":
+        noise_factors = [1.0, 3.0, 5.0]
+    else:
+        noise_factors = list(zne_options.noise_factors)
+
     if twirling_options.enable_gates or twirling_options.enable_measure:
         num_randomizations, shots_per_randomization = calculate_twirling_shots(
             shots,
@@ -98,6 +97,7 @@ def prepare_zne(
     observables_list = []
     param_basis_pairs_list = []
     param_shapes_list = []
+    item_to_pub_and_noise_factor_map = []
 
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
@@ -108,7 +108,20 @@ def prepare_zne(
         for j, noise_factor in enumerate(noise_factors):
             logger.info("Processing noise factor %d/%d", j + 1, len(noise_factors))
 
-            folded_circuit = fold_gates(pub.circuit, noise_factor, folding_method)
+            folding_method: Literal["random", "front", "back"]
+            match zne_options.amplifier:
+                case "gate_folding":
+                    folding_method = "random"
+                case "gate_folding_front":
+                    folding_method = "front"
+                case "gate_folding_back":
+                    folding_method = "back"
+                case _:
+                    # This should never happen due to prior validation
+                    folding_method = "random"
+            folded_circuit = PassManager([GateFolding(noise_factor, folding_method)]).run(
+                pub.circuit
+            )
 
             boxed_circuit = box_circuit(
                 folded_circuit, twirling_options, measure_noise_learning is not None
@@ -134,6 +147,9 @@ def prepare_zne(
                 )
             )
 
+            # each index is the item index, and it maps to (pub_number, noise_factor)
+            item_to_pub_and_noise_factor_map.append((i, noise_factor))
+
         # Store data for passthrough
         observables_list.append(pub.observables.tolist())
         param_basis_pairs_list.append(param_basis_pairs)
@@ -151,6 +167,7 @@ def prepare_zne(
             "param_shapes": param_shapes_list,
             "measure_mitigation": measure_noise_learning is not None,
             "zne_noise_factors": noise_factors,
+            "item_to_pub_and_noise_factor_map": item_to_pub_and_noise_factor_map,
         },
     }
 

--- a/qiskit_ibm_runtime/options_models/zne_options.py
+++ b/qiskit_ibm_runtime/options_models/zne_options.py
@@ -36,8 +36,11 @@ ExtrapolatorType = Literal[
     "fallback",
 ]
 
-FloatLargerThanOne = Annotated[float, Field(ge=1)]
-NonNegativeFloat = Annotated[float, Field(ge=0)]
+PEA_DEFAULT_NOISE_FACTORS = (1, 1.5, 2, 2.5, 3)
+"""The values of ``noise_factors`` used by default when PEA is selected."""
+
+ZNE_DEFAULT_NOISE_FACTORS = (1, 3, 5)
+"""The values of ``noise_factors`` used by default when gate folding is selected."""
 
 
 @dataclass(config=PRIMITIVES_CONFIG)
@@ -55,7 +58,7 @@ class ZneOptions:
         ``shape=np.broadcast_shapes(obs_shape, par_shape)``. Then the corresponding pub result will
         additionally contain:
 
-        1. `pub_result.data.evs_extrapolated` and `pub_result.data.stds_extrapolated`,
+        1. ``pub_result.data.evs_extrapolated`` and ``pub_result.data.stds_extrapolated``,
             both with shape ``(*shape, num_extrapolators, num_evaluation_points)``, where
             ``num_extrapolators`` is the length of the list of
             ``options.resilience.zne.extrapolators``, and ``num_evaluation_points`` is the length of
@@ -112,11 +115,12 @@ class ZneOptions:
             proportional to the corresponding learned noise model.
     """
 
-    noise_factors: Sequence[FloatLargerThanOne] | Literal["auto"] = "auto"
+    noise_factors: Sequence[Annotated[float, Field(ge=1)]] | Literal["auto"] = "auto"
     """ noise_factors: Noise factors to use for noise amplification.
 
-    The default depends on the amplifier method - the default for pea is (1, 1.5, 2, 2.5, 3)
-    and the default for the other methods is (1, 3, 5).
+    The default depends on the amplifier method - the default for pea is
+    :class:.~PEA_DEFAULT_NOISE_FACTORS` and the default for the other methods
+    is :class:.~ZNE_DEFAULT_NOISE_FACTORS`.
     """
 
     extrapolator: ExtrapolatorType | Sequence[ExtrapolatorType] = ("exponential", "linear")
@@ -140,7 +144,7 @@ class ZneOptions:
     successful extrapolator, where an extrapolator success is determined heuristically.
     """
 
-    extrapolated_noise_factors: Sequence[NonNegativeFloat] | Literal["auto"] = "auto"
+    extrapolated_noise_factors: Sequence[Annotated[float, Field(ge=0)]] | Literal["auto"] = "auto"
     r"""Noise factors to evaluate the fit extrapolation models at.
 
     If auto, the expectation values will be evaluated at ``[0, *noise_factors]``. This

--- a/qiskit_ibm_runtime/options_models/zne_options.py
+++ b/qiskit_ibm_runtime/options_models/zne_options.py
@@ -1,0 +1,150 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024-2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Zero noise extrapolation mitigation options.."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence  # noqa: TC003
+from typing import Annotated, Literal
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+from .utils import PRIMITIVES_CONFIG
+
+ExtrapolatorType = Literal[
+    "linear",
+    "exponential",
+    "double_exponential",
+    "polynomial_degree_1",
+    "polynomial_degree_2",
+    "polynomial_degree_3",
+    "polynomial_degree_4",
+    "polynomial_degree_5",
+    "polynomial_degree_6",
+    "polynomial_degree_7",
+    "fallback",
+]
+
+FloatLargerThanOne = Annotated[float, Field(ge=1)]
+NonNegativeFloat = Annotated[float, Field(ge=0)]
+
+
+@dataclass(config=PRIMITIVES_CONFIG)
+class ZneOptions:
+    """Zero noise extrapolation mitigation options. This is only used by the V2 Estimator.
+
+    .. note::
+
+        Any V2 estimator is guaranteed to return data fields called ``evs`` and ``stds`` that
+        report the desired expectation value estimates and errors, respectively.
+        When ZNE options are enabled in the runtime estimator, additional data is returned.
+
+        In particular, suppose an input pub has observable array shape ``obs_shape`` and parameter
+        values shape ``par_shape``, with corresponding pub shape
+        ``shape=np.broadcast_shapes(obs_shape, par_shape)``. Then the corresponding pub result will
+        additionally contain:
+
+        1. `pub_result.data.evs_extrapolated` and `pub_result.data.stds_extrapolated`,
+            both with shape ``(*shape, num_extrapolators, num_evaluation_points)``, where
+            ``num_extrapolators`` is the length of the list of
+            ``options.resilience.zne.extrapolators``, and ``num_evaluation_points`` is the length of
+            the list ``options.resilience.extrapolated_noise_factors``. These values provide
+            evaluations of every extrapolator at every specified noise extrapolation value.
+        2. ``pub_result.data.evs_noise_factors``, ``pub_result.data.stds_noise_factors``, and
+           ``ensemble_stds_noise_factors`` all have shape ``(*shape, num_noise_factors)`` where
+           ``num_noise_factors`` is the length of ``options.resilience.zne.noise_factors``. These
+           values provide raw expectation values, averaged over twirling if applicable,
+           at each of the noise amplifications; you can base your own fitting routines off of these
+           values. In the case of no twirling, both ``*stds*`` arrays will be equal, otherwise,
+           ``stds_noise_factors`` is derived from the spread over twirling samples, whereas
+           ``ensemble_stds_noise_factors`` assumes only shot noise and no drift.
+
+        Technical note: for single observables with multiple basis terms it might turn out that
+        multiple extrapolation methods are used in *the same* expectation value, for example, ``XX``
+        gets linearly extrapolated but ``XY`` gets exponentially extrapolated in the observable
+        ``{"XX": 0.5, "XY": 0.5}``. Let's call this a *heterogeneous fit*. The data from (2) is
+        evaluated from heterogeneous fits by selecting the best fit for every individual distinct
+        term, whereas data from (1) is evaluated from forced homogenous fits, one for each provided
+        extrapolator. If your work requires a nuanced distinction in this regard, we presently
+        recommend that you use single-term observables in addition to your multi-term observables.
+
+    References:
+        1. Z. Cai, *Multi-exponential error extrapolation and combining error mitigation techniques
+           for NISQ applications*,
+           `npj Quantum Inf 7, 80 (2021) <https://www.nature.com/articles/s41534-021-00404-3>`_
+    """
+
+    amplifier: Literal["gate_folding", "gate_folding_front", "gate_folding_back", "pea"] = (
+        "gate_folding"
+    )
+    """Which technique to use for amplifying noise.
+
+    One of:
+
+        * `"gate_folding"` (default) uses 2-qubit gate folding to amplify noise. If the noise
+            factor requires amplifying only a subset of the gates, then these gates are chosen
+            randomly.
+        * `"gate_folding_front"` uses 2-qubit gate folding to amplify noise. If the noise
+            factor requires amplifying only a subset of the gates, then these gates are selected
+            from the front of the topologically ordered DAG circuit.
+        * `"gate_folding_back"` uses 2-qubit gate folding to amplify noise. If the noise
+            factor requires amplifying only a subset of the gates, then these gates are selected
+            from the back of the topologically ordered DAG circuit.
+        * `"pea"` uses a technique called Probabilistic Error Amplification
+            (`PEA <https://www.nature.com/articles/s41586-023-06096-3>`_) to amplify noise. When
+            this option is selected, gate twirling will always be used whether or not it has
+            been enabled in the options. In this technique, the twirled noise model of each each
+            unique layer of entangling gates in your ISA circuits is learned beforehand, see
+            :class:`~.LayerNoiseLearningOptions` for relevant learning options. Once complete,
+            your circuits are executed at each noise factor, where every entangling layer of
+            your circuits is amplified by probabilistically injecting single-qubit noise
+            proportional to the corresponding learned noise model.
+    """
+
+    noise_factors: Sequence[FloatLargerThanOne] | Literal["auto"] = "auto"
+    """ noise_factors: Noise factors to use for noise amplification.
+
+    The default depends on the amplifier method - the default for pea is (1, 1.5, 2, 2.5, 3)
+    and the default for the other methods is (1, 3, 5).
+    """
+
+    extrapolator: ExtrapolatorType | Sequence[ExtrapolatorType] = ("exponential", "linear")
+    r"""Extrapolator(s) to try (in order) for extrapolating to zero noise.
+
+    The available options are:
+
+        * ``"exponential"``, which fits the data using an exponential decaying function
+            defined as :math:`f(x; A, \tau) = A e^{-x/\tau}`, where :math:`A = f(0; A, \tau)`
+            is the value at zero noise (:math:`x=0`) and :math:`\tau>0` is a positive rate.
+        * ``"double_exponential"``, which uses a sum of two exponential as in Ref. 1.
+        * ``"polynomial_degree_(1 <= k <= 7)"``, which uses a polynomial function defined as
+            :math:`f(x; c_0, c_1, \ldots, c_k) = \sum_{i=0, k} c_i x^i`.
+        * ``"linear"``, which is equivalent to ``"polynomial_degree_1"``.
+        * ``"fallback"``, which simply returns the raw data corresponding to the lowest noise
+            factor (typically ``1``) without performing any sort of extrapolation.
+
+    The extrapolated values (``evs_extrapolated`` and ``stds_extrapolated``) are sorted
+    according to the order of the provided extrapolators. If more than one extrapolator is
+    specified, the ``evs`` and ``stds`` reported in the result's data refer to the first
+    successful extrapolator, where an extrapolator success is determined heuristically.
+    """
+
+    extrapolated_noise_factors: Sequence[NonNegativeFloat] | Literal["auto"] = "auto"
+    r"""Noise factors to evaluate the fit extrapolation models at.
+
+    If auto, the expectation values will be evaluated at ``[0, *noise_factors]``. This
+    option does not affect execution or model fitting in any way, it only determines the
+    points at which the ``extrapolator``\s are evaluated to be returned in the data
+    fields called ``evs_extrapolated`` and ``stds_extrapolated``.
+    """

--- a/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
@@ -64,12 +64,15 @@ class TestPrepareZneFunction(unittest.TestCase):
         # Check passthrough_data contains zne_noise_factors
         passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
         self.assertIn("zne_noise_factors", passthrough["post_processor"])
-        self.assertEqual(passthrough["post_processor"]["zne_noise_factors"], noise_factors)
-        self.assertIn("item_to_pub_and_noise_factor_map", passthrough["post_processor"])
-        expected_map = [(0, 1.0), (0, 2.0), (0, 3.0)]
-        self.assertEqual(
-            passthrough["post_processor"]["item_to_pub_and_noise_factor_map"], expected_map
+        self.assertTrue(
+            np.array_equal(
+                np.array(passthrough["post_processor"]["zne_noise_factors"]),
+                np.array(noise_factors),
+            )
         )
+        self.assertIn("item_id", passthrough["post_processor"])
+        expected_map = [(0, 1.0), (0, 2.0), (0, 3.0)]
+        self.assertEqual(passthrough["post_processor"]["item_id"], expected_map)
 
     def test_prepare_zne_multiple_pubs(self):
         """Test prepare_zne with multiple pubs."""
@@ -114,12 +117,15 @@ class TestPrepareZneFunction(unittest.TestCase):
         self.assertEqual(len(passthrough["post_processor"]["observables"]), 2)
         self.assertEqual(len(passthrough["post_processor"]["observables"][0]), 3)
         self.assertEqual(len(passthrough["post_processor"]["observables"][1]), 1)
-        self.assertEqual(passthrough["post_processor"]["zne_noise_factors"], noise_factors)
-        self.assertIn("item_to_pub_and_noise_factor_map", passthrough["post_processor"])
-        expected_map = [(0, 1.0), (0, 2.0), (1, 1.0), (1, 2.0)]
-        self.assertEqual(
-            passthrough["post_processor"]["item_to_pub_and_noise_factor_map"], expected_map
+        self.assertTrue(
+            np.array_equal(
+                np.array(passthrough["post_processor"]["zne_noise_factors"]),
+                np.array(noise_factors),
+            )
         )
+        self.assertIn("item_id", passthrough["post_processor"])
+        expected_map = [(0, 1.0), (0, 2.0), (1, 1.0), (1, 2.0)]
+        self.assertEqual(passthrough["post_processor"]["item_id"], expected_map)
 
     def test_prepare_zne_with_single_noise_factor(self):
         """Test prepare_zne with a single noise factor."""

--- a/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
@@ -22,57 +22,14 @@ from qiskit.circuit import Parameter
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import SparsePauliOp
 
-from qiskit_ibm_runtime.executor_estimator.zne.zne_utils import fold_gates, prepare_zne
+from qiskit_ibm_runtime.executor_estimator.zne.zne_utils import prepare_zne
 from qiskit_ibm_runtime.options_models.measure_noise_learning_options import (
     MeasureNoiseLearningOptions,
 )
 from qiskit_ibm_runtime.options_models.twirling_options import TwirlingOptions
+from qiskit_ibm_runtime.options_models.zne_options import ZneOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
-
-
-@ddt
-class TestFoldGates(unittest.TestCase):
-    """Tests for fold_gates helper function."""
-
-    def test_fold_gates_with_noise_factor_one(self):
-        """Test that noise_factor=1 returns circuit unchanged."""
-        circuit = QuantumCircuit(2)
-        circuit.h(0)
-        circuit.cx(0, 1)
-        circuit.x(1)
-
-        folded = fold_gates(circuit, noise_factor=1.0)
-
-        # With noise_factor=1, circuit should be unchanged
-        self.assertEqual(folded.num_qubits, circuit.num_qubits)
-        self.assertEqual(folded.depth(), circuit.depth())
-
-    def test_fold_gates_with_noise_factor_greater_than_one(self):
-        """Test that noise_factor>1 increases circuit depth."""
-        circuit = QuantumCircuit(2)
-        circuit.h(0)
-        circuit.cx(0, 1)
-
-        original_depth = circuit.depth()
-        folded = fold_gates(circuit, noise_factor=3.0)
-
-        # With noise_factor=3, circuit depth should increase
-        self.assertGreater(folded.depth(), original_depth)
-
-    @data("random", "front", "back")
-    def test_fold_gates_with_different_methods(self, method):
-        """Test fold_gates with different folding methods."""
-        circuit = QuantumCircuit(2)
-        circuit.h(0)
-        circuit.cx(0, 1)
-        circuit.x(1)
-
-        folded = fold_gates(circuit, noise_factor=2.0, method=method)
-
-        # Should return a valid circuit
-        self.assertIsInstance(folded, QuantumCircuit)
-        self.assertEqual(folded.num_qubits, circuit.num_qubits)
 
 
 @ddt
@@ -89,10 +46,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable))
 
         noise_factors = [1.0, 2.0, 3.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding"
+        zne_options.noise_factors = noise_factors
         shots = 1024
-        quantum_program = prepare_zne(
-            [pub], TwirlingOptions(), shots, noise_factors, folding_method="random"
-        )
+        quantum_program = prepare_zne([pub], TwirlingOptions(), shots, zne_options)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, shots)
@@ -107,6 +65,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
         self.assertIn("zne_noise_factors", passthrough["post_processor"])
         self.assertEqual(passthrough["post_processor"]["zne_noise_factors"], noise_factors)
+        self.assertIn("item_to_pub_and_noise_factor_map", passthrough["post_processor"])
+        expected_map = [(0, 1.0), (0, 2.0), (0, 3.0)]
+        self.assertEqual(
+            passthrough["post_processor"]["item_to_pub_and_noise_factor_map"], expected_map
+        )
 
     def test_prepare_zne_multiple_pubs(self):
         """Test prepare_zne with multiple pubs."""
@@ -126,10 +89,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub2 = EstimatorPub.coerce((circuit2, observable2))
 
         noise_factors = [1.0, 2.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding_front"
+        zne_options.noise_factors = noise_factors
         shots = 2048
-        quantum_program = prepare_zne(
-            [pub1, pub2], TwirlingOptions(), shots, noise_factors, folding_method="front"
-        )
+        quantum_program = prepare_zne([pub1, pub2], TwirlingOptions(), shots, zne_options)
 
         # Should have len(pubs) * len(noise_factors) items
         expected_items = 2 * len(noise_factors)
@@ -151,6 +115,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         self.assertEqual(len(passthrough["post_processor"]["observables"][0]), 3)
         self.assertEqual(len(passthrough["post_processor"]["observables"][1]), 1)
         self.assertEqual(passthrough["post_processor"]["zne_noise_factors"], noise_factors)
+        self.assertIn("item_to_pub_and_noise_factor_map", passthrough["post_processor"])
+        expected_map = [(0, 1.0), (0, 2.0), (1, 1.0), (1, 2.0)]
+        self.assertEqual(
+            passthrough["post_processor"]["item_to_pub_and_noise_factor_map"], expected_map
+        )
 
     def test_prepare_zne_with_single_noise_factor(self):
         """Test prepare_zne with a single noise factor."""
@@ -162,10 +131,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable))
 
         noise_factors = [1.5]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding_back"
+        zne_options.noise_factors = noise_factors
         shots = 1024
-        quantum_program = prepare_zne(
-            [pub], TwirlingOptions(), shots, noise_factors, folding_method="back"
-        )
+        quantum_program = prepare_zne([pub], TwirlingOptions(), shots, zne_options)
 
         # Should have 1 item for single pub and single noise factor
         self.assertEqual(len(quantum_program.items), 1)
@@ -183,15 +153,16 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable))
 
         noise_factors = []
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding"
+        zne_options.noise_factors = noise_factors
         shots = 1024
-        quantum_program = prepare_zne(
-            [pub], TwirlingOptions(), shots, noise_factors, folding_method="random"
-        )
+        quantum_program = prepare_zne([pub], TwirlingOptions(), shots, zne_options)
 
         # Should have 0 items for empty noise_factors
         self.assertEqual(len(quantum_program.items), 0)
 
-    @data("random", "front", "back")
+    @data("gate_folding", "gate_folding_front", "gate_folding_back")
     def test_prepare_zne_with_different_folding_methods(self, folding_method):
         """Test prepare_zne with different folding methods."""
         circuit = QuantumCircuit(2)
@@ -202,10 +173,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable))
 
         noise_factors = [1.0, 2.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = folding_method
+        zne_options.noise_factors = noise_factors
         shots = 1024
-        quantum_program = prepare_zne(
-            [pub], TwirlingOptions(), shots, noise_factors, folding_method=folding_method
-        )
+        quantum_program = prepare_zne([pub], TwirlingOptions(), shots, zne_options)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(len(quantum_program.items), len(noise_factors))
@@ -224,10 +196,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable, parameter_values))
 
         noise_factors = [1.0, 2.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding"
+        zne_options.noise_factors = noise_factors
         shots = 1024
-        quantum_program = prepare_zne(
-            [pub], TwirlingOptions(), shots, noise_factors, folding_method="random"
-        )
+        quantum_program = prepare_zne([pub], TwirlingOptions(), shots, zne_options)
 
         # Should have len(noise_factors) items
         self.assertEqual(len(quantum_program.items), len(noise_factors))
@@ -256,10 +229,11 @@ class TestPrepareZneFunction(unittest.TestCase):
         twirling_options.num_randomizations = 8
 
         noise_factors = [1.0, 2.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding"
+        zne_options.noise_factors = noise_factors
         shots = 1024
-        quantum_program = prepare_zne(
-            [pub], twirling_options, shots, noise_factors, folding_method="random"
-        )
+        quantum_program = prepare_zne([pub], twirling_options, shots, zne_options)
 
         # Should have len(noise_factors) items
         self.assertEqual(len(quantum_program.items), len(noise_factors))
@@ -279,6 +253,9 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable))
 
         noise_factors = [1.0, 2.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding"
+        zne_options.noise_factors = noise_factors
         measure_noise_learning = MeasureNoiseLearningOptions()
         measure_noise_learning.num_randomizations = 16
 
@@ -286,8 +263,7 @@ class TestPrepareZneFunction(unittest.TestCase):
             [pub],
             TwirlingOptions(),
             1024,
-            noise_factors,
-            folding_method="random",
+            zne_options,
             measure_noise_learning=measure_noise_learning,
         )
 
@@ -316,6 +292,9 @@ class TestPrepareZneFunction(unittest.TestCase):
         pub2 = EstimatorPub.coerce((circuit2, observable2))
 
         noise_factors = [1.0, 2.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding"
+        zne_options.noise_factors = noise_factors
         measure_noise_learning = MeasureNoiseLearningOptions()
         measure_noise_learning.num_randomizations = 32
 
@@ -323,8 +302,7 @@ class TestPrepareZneFunction(unittest.TestCase):
             [pub1, pub2],
             TwirlingOptions(),
             1024,
-            noise_factors,
-            folding_method="random",
+            zne_options,
             measure_noise_learning=measure_noise_learning,
         )
 

--- a/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
@@ -1,0 +1,337 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for EstimatorV2 ZNE helper functions."""
+
+import unittest
+from typing import Any, cast
+
+import numpy as np
+from ddt import data, ddt
+from qiskit import QuantumCircuit
+from qiskit.circuit import Parameter
+from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_ibm_runtime.executor_estimator.zne.zne_utils import fold_gates, prepare_zne
+from qiskit_ibm_runtime.options_models.measure_noise_learning_options import (
+    MeasureNoiseLearningOptions,
+)
+from qiskit_ibm_runtime.options_models.twirling_options import TwirlingOptions
+from qiskit_ibm_runtime.quantum_program import QuantumProgram
+from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
+
+
+@ddt
+class TestFoldGates(unittest.TestCase):
+    """Tests for fold_gates helper function."""
+
+    def test_fold_gates_with_noise_factor_one(self):
+        """Test that noise_factor=1 returns circuit unchanged."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.x(1)
+
+        folded = fold_gates(circuit, noise_factor=1.0)
+
+        # With noise_factor=1, circuit should be unchanged
+        self.assertEqual(folded.num_qubits, circuit.num_qubits)
+        self.assertEqual(folded.depth(), circuit.depth())
+
+    def test_fold_gates_with_noise_factor_greater_than_one(self):
+        """Test that noise_factor>1 increases circuit depth."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        original_depth = circuit.depth()
+        folded = fold_gates(circuit, noise_factor=3.0)
+
+        # With noise_factor=3, circuit depth should increase
+        self.assertGreater(folded.depth(), original_depth)
+
+    @data("random", "front", "back")
+    def test_fold_gates_with_different_methods(self, method):
+        """Test fold_gates with different folding methods."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.x(1)
+
+        folded = fold_gates(circuit, noise_factor=2.0, method=method)
+
+        # Should return a valid circuit
+        self.assertIsInstance(folded, QuantumCircuit)
+        self.assertEqual(folded.num_qubits, circuit.num_qubits)
+
+
+@ddt
+class TestPrepareZneFunction(unittest.TestCase):
+    """Tests for the prepare_zne function."""
+
+    def test_prepare_zne_basic(self):
+        """Test prepare_zne with basic ZNE options."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+        pub = EstimatorPub.coerce((circuit, observable))
+
+        noise_factors = [1.0, 2.0, 3.0]
+        shots = 1024
+        quantum_program = prepare_zne(
+            [pub], TwirlingOptions(), shots, noise_factors, folding_method="random"
+        )
+
+        self.assertIsInstance(quantum_program, QuantumProgram)
+        self.assertEqual(quantum_program.shots, shots)
+        self.assertEqual(quantum_program._semantic_role, "estimator_v2")
+        # Should have len(noise_factors) items for the single pub
+        self.assertEqual(len(quantum_program.items), len(noise_factors))
+
+        for item in quantum_program.items:
+            self.assertIsInstance(item, SamplexItem)
+
+        # Check passthrough_data contains zne_noise_factors
+        passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
+        self.assertIn("zne_noise_factors", passthrough["post_processor"])
+        self.assertEqual(passthrough["post_processor"]["zne_noise_factors"], noise_factors)
+
+    def test_prepare_zne_multiple_pubs(self):
+        """Test prepare_zne with multiple pubs."""
+        circuit1 = QuantumCircuit(2)
+        circuit1.h(0)
+        circuit1.cx(0, 1)
+
+        circuit2 = QuantumCircuit(3)
+        circuit2.h(0)
+        circuit2.cx(0, 1)
+        circuit2.cx(1, 2)
+
+        observable1 = SparsePauliOp.from_list([("ZZ", 1), ("XX", 1), ("YY", 1)])
+        observable2 = SparsePauliOp.from_list([("ZZZ", 1)])
+
+        pub1 = EstimatorPub.coerce((circuit1, observable1))
+        pub2 = EstimatorPub.coerce((circuit2, observable2))
+
+        noise_factors = [1.0, 2.0]
+        shots = 2048
+        quantum_program = prepare_zne(
+            [pub1, pub2], TwirlingOptions(), shots, noise_factors, folding_method="front"
+        )
+
+        # Should have len(pubs) * len(noise_factors) items
+        expected_items = 2 * len(noise_factors)
+        self.assertEqual(len(quantum_program.items), expected_items)
+        # Check items shape
+        auto_num_rand = 1  # no twirling - single randomization
+        pub1_items = len(noise_factors)
+        for i, item in enumerate(quantum_program.items):
+            if i < pub1_items:
+                num_observables = len(observable1)  # 3
+            else:
+                num_observables = len(observable2)
+            expected_shape = (auto_num_rand, num_observables)
+            self.assertEqual(item.shape, expected_shape)
+
+        # Check passthrough_data
+        passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
+        self.assertEqual(len(passthrough["post_processor"]["observables"]), 2)
+        self.assertEqual(len(passthrough["post_processor"]["observables"][0]), 3)
+        self.assertEqual(len(passthrough["post_processor"]["observables"][1]), 1)
+        self.assertEqual(passthrough["post_processor"]["zne_noise_factors"], noise_factors)
+
+    def test_prepare_zne_with_single_noise_factor(self):
+        """Test prepare_zne with a single noise factor."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+        pub = EstimatorPub.coerce((circuit, observable))
+
+        noise_factors = [1.5]
+        shots = 1024
+        quantum_program = prepare_zne(
+            [pub], TwirlingOptions(), shots, noise_factors, folding_method="back"
+        )
+
+        # Should have 1 item for single pub and single noise factor
+        self.assertEqual(len(quantum_program.items), 1)
+
+        item = cast("SamplexItem", quantum_program.items[0])
+        self.assertIsInstance(item, SamplexItem)
+
+    def test_prepare_zne_with_empty_noise_factors_list(self):
+        """Test prepare_zne behavior with empty noise_factors list."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+        pub = EstimatorPub.coerce((circuit, observable))
+
+        noise_factors = []
+        shots = 1024
+        quantum_program = prepare_zne(
+            [pub], TwirlingOptions(), shots, noise_factors, folding_method="random"
+        )
+
+        # Should have 0 items for empty noise_factors
+        self.assertEqual(len(quantum_program.items), 0)
+
+    @data("random", "front", "back")
+    def test_prepare_zne_with_different_folding_methods(self, folding_method):
+        """Test prepare_zne with different folding methods."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+        pub = EstimatorPub.coerce((circuit, observable))
+
+        noise_factors = [1.0, 2.0]
+        shots = 1024
+        quantum_program = prepare_zne(
+            [pub], TwirlingOptions(), shots, noise_factors, folding_method=folding_method
+        )
+
+        self.assertIsInstance(quantum_program, QuantumProgram)
+        self.assertEqual(len(quantum_program.items), len(noise_factors))
+
+    def test_prepare_zne_with_parameterized_circuit(self):
+        """Test prepare_zne with parameterized circuit."""
+        circuit = QuantumCircuit(2)
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        circuit.rx(theta, 0)
+        circuit.ry(phi, 1)
+        circuit.cx(0, 1)
+
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+        parameter_values = np.array([[0.1, 0.2], [0.3, 0.4]])
+        pub = EstimatorPub.coerce((circuit, observable, parameter_values))
+
+        noise_factors = [1.0, 2.0]
+        shots = 1024
+        quantum_program = prepare_zne(
+            [pub], TwirlingOptions(), shots, noise_factors, folding_method="random"
+        )
+
+        # Should have len(noise_factors) items
+        self.assertEqual(len(quantum_program.items), len(noise_factors))
+
+        # Check that parameter values are in samplex_arguments and check item shape
+        auto_num_rand = 1  # no twirling - single randomization
+        num_param_sets = parameter_values.shape[0]  # 2
+        num_observables = 1  # Single observable
+        expected_shape = (auto_num_rand, num_param_sets * num_observables)
+        for item in quantum_program.items:
+            item_cast = cast("SamplexItem", item)
+            self.assertIn("parameter_values", item_cast.samplex_arguments)
+            self.assertEqual(item.shape, expected_shape)
+
+    def test_prepare_zne_with_twirling(self):
+        """Test that items have correct shapes based on twirling and observables."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        observables = SparsePauliOp.from_list([("ZZ", 1), ("XX", 1)])
+        pub = EstimatorPub.coerce((circuit, observables))
+
+        twirling_options = TwirlingOptions()
+        twirling_options.enable_gates = True
+        twirling_options.num_randomizations = 8
+
+        noise_factors = [1.0, 2.0]
+        shots = 1024
+        quantum_program = prepare_zne(
+            [pub], twirling_options, shots, noise_factors, folding_method="random"
+        )
+
+        # Should have len(noise_factors) items
+        self.assertEqual(len(quantum_program.items), len(noise_factors))
+        # Each item should have shape (num_randomizations, num_basis_changes)
+        # With 2 observables (ZZ, XX), we need 2 basis changes (Z and X basis)
+        for item in quantum_program.items:
+            item_cast = cast("SamplexItem", item)
+            self.assertEqual(item_cast.shape, (8, 2))
+
+    def test_prepare_zne_single_pub_with_measure_noise_learning(self):
+        """Test prepare_zne with measure noise learning (TREX)."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+        pub = EstimatorPub.coerce((circuit, observable))
+
+        noise_factors = [1.0, 2.0]
+        measure_noise_learning = MeasureNoiseLearningOptions()
+        measure_noise_learning.num_randomizations = 16
+
+        quantum_program = prepare_zne(
+            [pub],
+            TwirlingOptions(),
+            1024,
+            noise_factors,
+            folding_method="random",
+            measure_noise_learning=measure_noise_learning,
+        )
+
+        # Should have len(noise_factors) items + 1 TREX calibration
+        self.assertEqual(len(quantum_program.items), len(noise_factors) + 1)
+
+        # Check passthrough data
+        passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
+        self.assertEqual(passthrough["post_processor"]["measure_mitigation"], "True")
+
+    def test_prepare_zne_multiple_pubs_with_measure_noise_learning(self):
+        """Test prepare_zne with multiple pubs and TREX."""
+        circuit1 = QuantumCircuit(2)
+        circuit1.h(0)
+        circuit1.cx(0, 1)
+
+        circuit2 = QuantumCircuit(3)
+        circuit2.h(0)
+        circuit2.cx(0, 1)
+        circuit2.cx(1, 2)
+
+        observable1 = SparsePauliOp.from_list([("ZZ", 1)])
+        observable2 = SparsePauliOp.from_list([("ZZZ", 1)])
+
+        pub1 = EstimatorPub.coerce((circuit1, observable1))
+        pub2 = EstimatorPub.coerce((circuit2, observable2))
+
+        noise_factors = [1.0, 2.0]
+        measure_noise_learning = MeasureNoiseLearningOptions()
+        measure_noise_learning.num_randomizations = 32
+
+        quantum_program = prepare_zne(
+            [pub1, pub2],
+            TwirlingOptions(),
+            1024,
+            noise_factors,
+            folding_method="random",
+            measure_noise_learning=measure_noise_learning,
+        )
+
+        # Should have 2 pubs * 2 noise_factors + 1 TREX calibration = 5 items
+        self.assertEqual(len(quantum_program.items), 5)
+
+        # Last item should be TREX calibration
+        trex_item = quantum_program.items[-1]
+        self.assertIsInstance(trex_item, SamplexItem)
+        self.assertEqual(trex_item.shape, (32,))


### PR DESCRIPTION
### Summary
Add support for the preparing quantum program for zne with gate folding mitigation method.
Create a new prepare_zne function - add folded gates to the circuit. Add new item to the quantum program for each noise scale factor for each pub, and pass the scale factors using the passthourgh_data.

### Details and comments

Fixes #2849 
