### PR TITLE
Bump `Samplomatic` to 0.17.0 and `Qiskit` to 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,9 +164,9 @@ dependencies = [
     "ibm-platform-services>=0.61.1",
     "ibm-quantum-schemas>=0.8.20260605,<1",
     "pydantic>=2.11.0",
-    "qiskit>=2.2.0",
+    "qiskit>=2.3.0",
     "pybase64>=1.4.0",
-    "samplomatic>=0.13.0"
+    "samplomatic>=0.17.0"
 ]
 
 [project.entry-points."qiskit.transpiler.translation"]


### PR DESCRIPTION
### Summary
Closes #2924 

### Details and comments
The tests added in #2897 hard code the references of `Samplex`'s `InjectNoise` nodes. Prior to `Samplomatic` version 0.17.0, these refs were not stable across python processes (`Samplomatic` ~~issue 337~~ PR [323](https://github.com/Qiskit/samplomatic/pull/323)). We can fix the tests to build the `Samplex` and query the refs, and it should be identical to the ones created in the `prepare` function (as the two builds run in the same process). However, this will mean that users will be unable to box in a different process than the one they use to run the wrapper Estimator. In the context of noise learning, such restriction is not acceptable. Therefore, we are forced to bump `Samplomatic` to 0.17.0, and `Qiskit` to 2.3.0 because `Samplomatic` depends on it.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
