### PR TITLE
fix noise model mapping in pec

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/pec_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec_utils.py
@@ -147,7 +147,7 @@ def prepare_pec(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
-        IBMInputValueError: If noise_model_mapping is missing a noise map for at least one of
+        IBMInputValueError: If ``noise_model_mapping`` is missing a noise map for at least one of
             the pubs layers.
     """
     num_randomizations, shots_per_randomization = calculate_pec_twirling_shots(
@@ -213,14 +213,15 @@ def prepare_pec(
         pub_noise_model = {}
         for spec in specs:
             ref = spec.name.split(".")[-1]
-            if ref not in noise_model_mapping.keys():
+            try:
+                pub_noise_model[ref] = noise_model_mapping[ref]
+            except KeyError:
                 raise IBMInputValueError(
                     f"noise_model_mapping is missing noise map for layer reference {ref}"
                 )
-            pub_noise_model[ref] = noise_model_mapping[ref]
-
-        for ref in pub_noise_model:
+            # noise_scales and pauli_lindblad_maps should have the same refs
             samplex_arguments[f"noise_scales.{ref}"] = noise_scale
+
         samplex_arguments["pauli_lindblad_maps"] = pub_noise_model
         scaled_gamma = calculate_gamma(boxed_circuit, pub_noise_model, noise_factor)
         pec_gamma_list.append(scaled_gamma)

--- a/qiskit_ibm_runtime/executor_estimator/pec_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec_utils.py
@@ -120,7 +120,7 @@ def prepare_pec(
     twirling_options: TwirlingOptions,
     shots: int,
     pec_options: PecOptions,
-    noise_model_mapping: Sequence[dict[str, PauliLindbladMap]],
+    noise_model_mapping: dict[str, PauliLindbladMap],
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
 ) -> QuantumProgram:
     """Convert estimator PUBs to a quantum program with PEC mitigation.
@@ -134,9 +134,9 @@ def prepare_pec(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         pec_options: The options for PEC mitigation.
-        noise_model_mapping: List of mapping between layer ref to a noise model to use for PEC
-            mitigation method. The list must contain a map for each pub. Assumes that the
-            unique layers used for noise learning were extracted using the ``get_layers`` method.
+        noise_model_mapping: Mapping between layer ref to a noise model to use for PEC mitigation
+            method. The dict contains layers from all pubs. Assumes that the unique layers
+            used for noise learning were extracted using the ``get_layers`` method.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,
@@ -147,20 +147,14 @@ def prepare_pec(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
-        IBMInputValueError: If the length of noise_model_mapping and the length of the pubs
-            mismatched.
+        IBMInputValueError: If noise_model_mapping is missing a noise map for at least one of
+            the pubs layers.
     """
     num_randomizations, shots_per_randomization = calculate_pec_twirling_shots(
         shots,
         twirling_options.num_randomizations,
         twirling_options.shots_per_randomization,
     )
-
-    # validate noise_model_mapping length
-    if noise_model_mapping is None or len(noise_model_mapping) != len(pubs):
-        raise IBMInputValueError(
-            "If PEC mitigation is used, the input must contain noise_model_mapping for each pub"
-        )
 
     # set max_overhead
     max_overhead = pec_options.max_overhead
@@ -195,7 +189,7 @@ def prepare_pec(
         # add samplex_arguments related to noise injection
         if pec_options.noise_gain == "auto":
             # calculate the gamma factor without scaling it by noise_factor
-            gamma = calculate_gamma(boxed_circuit, noise_model_mapping[i], 1)
+            gamma = calculate_gamma(boxed_circuit, noise_model_mapping, 1)
             # calculate the noise factor based on gamma and max_overhead
             noise_gain = 1 - np.log(max_overhead) / np.log(gamma**2)
             # Truncate noise_gain to [0, 1]
@@ -213,10 +207,22 @@ def prepare_pec(
         noise_scale = noise_gain - 1
         # The sampling scaling is proportional to 1 - noise_gain, as 0 is full PEC and 1 is no PEC
         noise_factor = 1 - noise_gain
-        for ref in noise_model_mapping[i]:
+
+        # Create a noise model map containing only the layers relevant for the current pub
+        specs = samplex.inputs().get_specs("pauli_lindblad_maps")
+        pub_noise_model = {}
+        for spec in specs:
+            ref = spec.name.split(".")[-1]
+            if ref not in noise_model_mapping.keys():
+                raise IBMInputValueError(
+                    f"noise_model_mapping is missing noise map for layer reference {ref}"
+                )
+            pub_noise_model[ref] = noise_model_mapping[ref]
+
+        for ref in pub_noise_model:
             samplex_arguments[f"noise_scales.{ref}"] = noise_scale
-        samplex_arguments["pauli_lindblad_maps"] = noise_model_mapping[i]
-        scaled_gamma = calculate_gamma(boxed_circuit, noise_model_mapping[i], noise_factor)
+        samplex_arguments["pauli_lindblad_maps"] = pub_noise_model
+        scaled_gamma = calculate_gamma(boxed_circuit, pub_noise_model, noise_factor)
         pec_gamma_list.append(scaled_gamma)
         # Scale the amount of randomizations by gamma**2
         sampling_overhead = scaled_gamma**2

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -22,9 +22,11 @@ from qiskit import QuantumCircuit
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import PauliLindbladMap, SparsePauliOp
 from samplomatic import InjectNoise
+from samplomatic.utils import get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.pec_utils import calculate_gamma, prepare_pec
+from qiskit_ibm_runtime.executor_estimator.prepare import get_layers
 from qiskit_ibm_runtime.options_models.measure_noise_learning_options import (
     MeasureNoiseLearningOptions,
 )
@@ -211,7 +213,14 @@ class TestPreparePecFunction(unittest.TestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("XX", [0, 1], 0.1), ("ZZ", [0, 1], 0.05)], num_qubits=2
         )
-        noise_model_mapping = [{"r2feB": noise_model}]
+        # find layers first to extract the layers ref
+        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        noise_layer_ref = ""
+        for layer in layers[0]:
+            if annot := get_annotation(layer.operation, InjectNoise):
+                noise_layer_ref = annot.ref
+
+        noise_model_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -230,16 +239,19 @@ class TestPreparePecFunction(unittest.TestCase):
         self.assertIsInstance(item, SamplexItem)
 
         # Check that samplex_arguments contains pauli_lindblad_maps
-        self.assertIn("pauli_lindblad_maps.r2feB", item.samplex_arguments)
+        self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
-            item.samplex_arguments["pauli_lindblad_maps.r2feB"], noise_model_mapping[0]["r2feB"]
+            item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
+            noise_model_mapping[noise_layer_ref],
         )
 
         # Check that samplex_arguments contains noise_scales for the layer
-        self.assertIn("noise_scales.r2feB", item.samplex_arguments)
+        self.assertIn(f"noise_scales.{noise_layer_ref}", item.samplex_arguments)
         # noise_gain = 0.5, so noise_factor = 0.5 - 1 = -0.5
         expected_noise_factor = pec_options.noise_gain - 1
-        self.assertEqual(item.samplex_arguments["noise_scales.r2feB"], expected_noise_factor)
+        self.assertEqual(
+            item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], expected_noise_factor
+        )
 
         # Check passthrough_data contains pec_gammas
         passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
@@ -274,10 +286,20 @@ class TestPreparePecFunction(unittest.TestCase):
         noise_model_1 = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
         noise_model_2a = PauliLindbladMap.from_sparse_list([("XY", [0, 1], 0.15)], num_qubits=2)
         noise_model_2b = PauliLindbladMap.from_sparse_list([("ZX", [1, 2], 0.2)], num_qubits=3)
-        noise_model_mapping = [
-            {"r2feB": noise_model_1},
-            {"rf55B": noise_model_2a, "rd2dB": noise_model_2b},
-        ]
+
+        # find layers first to extract the layers ref
+        layers = get_layers([pub1, pub2], TwirlingOptions(), inject_noise=True)
+        noise_layer_refs = []
+        for pub_layers in layers:
+            for layer in pub_layers:
+                if annot := get_annotation(layer.operation, InjectNoise):
+                    noise_layer_refs.append(annot.ref)
+
+        noise_model_mapping = {
+            noise_layer_refs[0]: noise_model_1,
+            noise_layer_refs[1]: noise_model_2a,
+            noise_layer_refs[2]: noise_model_2b,
+        }
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.3
@@ -291,24 +313,27 @@ class TestPreparePecFunction(unittest.TestCase):
 
         # Check first item
         item1 = cast("SamplexItem", quantum_program.items[0])
-        self.assertIn("pauli_lindblad_maps.r2feB", item1.samplex_arguments)
+        self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[0]}", item1.samplex_arguments)
         self.assertEqual(
-            item1.samplex_arguments["pauli_lindblad_maps.r2feB"], noise_model_mapping[0]["r2feB"]
+            item1.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[0]}"],
+            noise_model_mapping[noise_layer_refs[0]],
         )
-        self.assertIn("noise_scales.r2feB", item1.samplex_arguments)
+        self.assertIn(f"noise_scales.{noise_layer_refs[0]}", item1.samplex_arguments)
 
         # Check second item
         item2 = cast("SamplexItem", quantum_program.items[1])
-        self.assertIn("pauli_lindblad_maps.rf55B", item2.samplex_arguments)
-        self.assertIn("pauli_lindblad_maps.rd2dB", item2.samplex_arguments)
+        self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[1]}", item2.samplex_arguments)
+        self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[2]}", item2.samplex_arguments)
         self.assertEqual(
-            item2.samplex_arguments["pauli_lindblad_maps.rf55B"], noise_model_mapping[1]["rf55B"]
+            item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[1]}"],
+            noise_model_mapping[noise_layer_refs[1]],
         )
         self.assertEqual(
-            item2.samplex_arguments["pauli_lindblad_maps.rd2dB"], noise_model_mapping[1]["rd2dB"]
+            item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[2]}"],
+            noise_model_mapping[noise_layer_refs[2]],
         )
-        self.assertIn("noise_scales.rf55B", item2.samplex_arguments)
-        self.assertIn("noise_scales.rd2dB", item2.samplex_arguments)
+        self.assertIn(f"noise_scales.{noise_layer_refs[1]}", item2.samplex_arguments)
+        self.assertIn(f"noise_scales.{noise_layer_refs[2]}", item2.samplex_arguments)
 
         # Check passthrough_data contains pec_gammas for both pubs
         passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
@@ -327,7 +352,14 @@ class TestPreparePecFunction(unittest.TestCase):
         err_rate = 0.7
         max_overhead = 10
         noise_model = PauliLindbladMap.from_sparse_list([("IX", [0, 1], err_rate)], num_qubits=2)
-        noise_model_mapping = [{"r2feB": noise_model}]
+        # find layers first to extract the layers ref
+        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        noise_layer_ref = ""
+        for layer in layers[0]:
+            if annot := get_annotation(layer.operation, InjectNoise):
+                noise_layer_ref = annot.ref
+
+        noise_model_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = "auto"  # Should default to 0
@@ -341,10 +373,12 @@ class TestPreparePecFunction(unittest.TestCase):
         item = cast("SamplexItem", quantum_program.items[0])
 
         # With auto (defaulting to 0), noise_factor should be 0 - 1 = -1
-        self.assertIn("noise_scales.r2feB", item.samplex_arguments)
+        self.assertIn(f"noise_scales.{noise_layer_ref}", item.samplex_arguments)
         scaleless_gamma = float(np.exp(2 * err_rate))
         expected_noise_gain = -np.log(max_overhead) / np.log(scaleless_gamma**2)
-        self.assertEqual(item.samplex_arguments["noise_scales.r2feB"], expected_noise_gain)
+        self.assertEqual(
+            item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], expected_noise_gain
+        )
 
     def test_prepare_pec_raises_error_without_noise_model_mapping(self):
         """Test that prepare_pec raises error when noise_model_mapping is None."""
@@ -359,19 +393,19 @@ class TestPreparePecFunction(unittest.TestCase):
         pec_options.noise_gain = 0.5
 
         with self.assertRaises(IBMInputValueError) as context:
-            prepare_pec([pub], TwirlingOptions(), 1024, pec_options, None)
+            prepare_pec([pub], TwirlingOptions(), 1024, pec_options, {})
 
         self.assertIn("noise_model_mapping", str(context.exception))
 
-    def test_prepare_pec_raises_error_with_mismatched_noise_model_mapping_length(self):
-        """Test that prepare_pec raises error when noise_model_mapping length doesn't match pubs."""
+    def test_prepare_pec_raises_error_with_missing_noise_model_key(self):
+        """Test that prepare_pec raises error when noise_model_mapping is missing a noise model."""
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
         circuit1.cx(0, 1)
 
         circuit2 = QuantumCircuit(2)
         circuit2.h(0)
-        circuit2.cx(0, 1)
+        circuit2.cz(0, 1)
 
         observable = SparsePauliOp.from_list([("ZZ", 1)])
         pub1 = EstimatorPub.coerce((circuit1, observable))
@@ -379,7 +413,14 @@ class TestPreparePecFunction(unittest.TestCase):
 
         # Only provide noise model for one pub, but we have two pubs
         noise_model = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
-        noise_model_mapping = [{"r2feB": noise_model}]
+        # find layers first to extract the layers ref
+        layers = get_layers([pub1], TwirlingOptions(), inject_noise=True)
+        noise_layer_ref = ""
+        for layer in layers[0]:
+            if annot := get_annotation(layer.operation, InjectNoise):
+                noise_layer_ref = annot.ref
+
+        noise_model_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -399,7 +440,14 @@ class TestPreparePecFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable))
 
         noise_model = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
-        noise_model_mapping = [{"r2feB": noise_model}]
+        # find layers first to extract the layers ref
+        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        noise_layer_ref = ""
+        for layer in layers[0]:
+            if annot := get_annotation(layer.operation, InjectNoise):
+                noise_layer_ref = annot.ref
+
+        noise_model_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -416,13 +464,16 @@ class TestPreparePecFunction(unittest.TestCase):
 
         # Check first item has PEC arguments
         item = cast("SamplexItem", quantum_program.items[0])
-        self.assertIn("pauli_lindblad_maps.r2feB", item.samplex_arguments)
+        self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
-            item.samplex_arguments["pauli_lindblad_maps.r2feB"], noise_model_mapping[0]["r2feB"]
+            item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
+            noise_model_mapping[noise_layer_ref],
         )
-        self.assertIn("noise_scales.r2feB", item.samplex_arguments)
+        self.assertIn(f"noise_scales.{noise_layer_ref}", item.samplex_arguments)
         expected_noise_factor = pec_options.noise_gain - 1
-        self.assertEqual(item.samplex_arguments["noise_scales.r2feB"], expected_noise_factor)
+        self.assertEqual(
+            item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], expected_noise_factor
+        )
 
         # Check passthrough data
         passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -380,8 +380,8 @@ class TestPreparePecFunction(unittest.TestCase):
             item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], expected_noise_gain
         )
 
-    def test_prepare_pec_raises_error_without_noise_model_mapping(self):
-        """Test that prepare_pec raises error when noise_model_mapping is None."""
+    def test_prepare_pec_raises_error_with_empty_noise_model_mapping(self):
+        """Test that prepare_pec raises error when noise_model_mapping is empty."""
         circuit = QuantumCircuit(2)
         circuit.h(0)
         circuit.cx(0, 1)


### PR DESCRIPTION
### Summary
Change `noise_model_mapping` in `prepare_pec` from a list of dicts to a single dict containing the mapping for all pubs.

In addition, remove the hardcoded noise model refs from the tests, and instead use `get_layers` and take the refs from the layers. 

### Details and comments

related to comments raised in #2918 
