### PR TITLE
Homogenize on unittest-style asserts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ select = [
     "G",      # flake8-logging-format
     "I",      # isort
     "RUF013", # implicit-optional
-    "S101",   # flake8-bandit assert (enforced in test/ only)
+    "S101",   # flake8-bandit assert
     "T10",    # flake8-debugger
     "TC",     # flake8-type-checking
     "UP",     # pyupgrade
@@ -117,10 +117,6 @@ ignore = [
 
 "qiskit_ibm_runtime/options/*options.py" = [
     "TC",     # flake8-type-checking -- ruff moves Unset and Dict to TYPE_CHECKING block
-]
-
-"!test/**.py" = [
-    "S101",   # flake8-bandit assert -- enforce using unittest-style assertion in tests
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ select = [
     "G",      # flake8-logging-format
     "I",      # isort
     "RUF013", # implicit-optional
-    "S101",   # flake8-bandit assert (enforcef in test/ only)
+    "S101",   # flake8-bandit assert (enforced in test/ only)
     "T10",    # flake8-debugger
     "TC",     # flake8-type-checking
     "UP",     # pyupgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ select = [
     "G",      # flake8-logging-format
     "I",      # isort
     "RUF013", # implicit-optional
+    "S101",   # flake8-bandit assert (enforcef in test/ only)
     "T10",    # flake8-debugger
     "TC",     # flake8-type-checking
     "UP",     # pyupgrade
@@ -118,6 +119,9 @@ ignore = [
     "TC",     # flake8-type-checking -- ruff moves Unset and Dict to TYPE_CHECKING block
 ]
 
+"!test/**.py" = [
+    "S101",   # flake8-bandit assert -- enforce using unittest-style assertion in tests
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/test/integration/test_executor.py
+++ b/test/integration/test_executor.py
@@ -66,9 +66,9 @@ class TestExecutor(IBMIntegrationTestCase):
         job = executor.run(program)
 
         params = job.inputs
-        assert params["options"] == executor.options
-        assert isinstance(params["quantum_program"], QuantumProgram)
-        assert params["schema_version"] == Executor._SCHEMA_VERSION
+        self.assertEqual(params["options"], executor.options)
+        self.assertIsInstance(params["quantum_program"], QuantumProgram)
+        self.assertEqual(params["schema_version"], Executor._SCHEMA_VERSION)
 
         results = job.result()
         self.assertIsInstance(results, QuantumProgramResult)
@@ -114,9 +114,9 @@ class TestExecutor(IBMIntegrationTestCase):
         job = executor.run(program)
 
         params = job.inputs
-        assert params["options"] == executor.options
-        assert isinstance(params["quantum_program"], QuantumProgram)
-        assert params["schema_version"] == Executor._SCHEMA_VERSION
+        self.assertEqual(params["options"], executor.options)
+        self.assertIsInstance(params["quantum_program"], QuantumProgram)
+        self.assertEqual(params["schema_version"], Executor._SCHEMA_VERSION)
 
         results = job.result()
         self.assertIsInstance(results, QuantumProgramResult)

--- a/test/integration/test_noise_learner_v3.py
+++ b/test/integration/test_noise_learner_v3.py
@@ -50,7 +50,7 @@ class TestNoiseLearnerV3(IBMIntegrationTestCase):
 
         boxed_circuit = self.boxing_pm.run(circuit)
         instructions = find_unique_box_instructions(boxed_circuit)
-        assert len(instructions) == 3  # 2 with gates, 1 with measurements
+        self.assertEqual(len(instructions), 3)  # 2 with gates, 1 with measurements
 
         learner = NoiseLearnerV3(self.backend)
         learner.options.layer_pair_depths = [0, 2, 4]
@@ -63,19 +63,19 @@ class TestNoiseLearnerV3(IBMIntegrationTestCase):
         # default option of experimental is Unset, and is then converted to {}
         params["options"].experimental = {}
 
-        assert params["instructions"] == instructions
-        assert params["options"] == learner.options
+        self.assertEqual(params["instructions"], instructions)
+        self.assertEqual(params["options"], learner.options)
 
         result = job.result()
-        assert isinstance(result, NoiseLearnerV3Results)
-        assert all(isinstance(datum, NoiseLearnerV3Result) for datum in result)
+        self.assertIsInstance(result, NoiseLearnerV3Results)
+        self.assertTrue(all(isinstance(datum, NoiseLearnerV3Result) for datum in result))
 
-        assert result[0].metadata["learning_protocol"] == "lindblad"
-        assert result[0].to_pauli_lindblad_map().num_qubits == len(instructions[0].qubits)
+        self.assertEqual(result[0].metadata["learning_protocol"], "lindblad")
+        self.assertEqual(result[0].to_pauli_lindblad_map().num_qubits, len(instructions[0].qubits))
 
-        assert result[1].metadata["learning_protocol"] == "lindblad"
-        assert result[1].to_pauli_lindblad_map().num_qubits == len(instructions[1].qubits)
+        self.assertEqual(result[1].metadata["learning_protocol"], "lindblad")
+        self.assertEqual(result[1].to_pauli_lindblad_map().num_qubits, len(instructions[1].qubits))
 
-        assert result[2].metadata["learning_protocol"] == "trex"
-        assert result[2].to_pauli_lindblad_map().num_qubits == len(instructions[2].qubits)
-        assert result[2].to_pauli_lindblad_map().num_terms == len(instructions[2].qubits)
+        self.assertEqual(result[2].metadata["learning_protocol"], "trex")
+        self.assertEqual(result[2].to_pauli_lindblad_map().num_qubits, len(instructions[2].qubits))
+        self.assertEqual(result[2].to_pauli_lindblad_map().num_terms, len(instructions[2].qubits))

--- a/test/unit/decoders/test_noise_learner_v3.py
+++ b/test/unit/decoders/test_noise_learner_v3.py
@@ -59,10 +59,10 @@ class TestDecoder(IBMTestCase):
         """Tests the decoder."""
         decoded = NoiseLearnerV3ResultDecoder.decode(self.encoded)
         for datum_in, datum_out in zip(self.results.data, decoded.data):
-            assert datum_in._generators == datum_out._generators
-            assert np.allclose(datum_in._rates, datum_out._rates)
-            assert np.allclose(datum_in._rates_std, datum_out._rates_std)
-            assert datum_in.metadata == datum_out.metadata
+            self.assertEqual(datum_in._generators, datum_out._generators)
+            self.assertTrue(np.allclose(datum_in._rates, datum_out._rates))
+            self.assertTrue(np.allclose(datum_in._rates_std, datum_out._rates_std))
+            self.assertEqual(datum_in.metadata, datum_out.metadata)
 
     def test_no_schema_version(self):
         """Verify an error is raised if the encoded string does not specify any schema version."""

--- a/test/unit/fake_provider/test_local_service.py
+++ b/test/unit/fake_provider/test_local_service.py
@@ -29,24 +29,24 @@ class QiskitRuntimeLocalServiceTest(IBMTestCase):
     def test_backend(self):
         """Tests the ``backend`` method."""
         service = QiskitRuntimeLocalService()
-        assert isinstance(service.backend(), FakeBackendV2)
-        assert isinstance(service.backend("fake_algiers"), FakeAlgiers)
-        assert isinstance(service.backend("fake_torino"), FakeTorino)
+        self.assertIsInstance(service.backend(), FakeBackendV2)
+        self.assertIsInstance(service.backend("fake_algiers"), FakeAlgiers)
+        self.assertIsInstance(service.backend("fake_torino"), FakeTorino)
 
     def test_backends(self):
         """Tests the ``backends`` method."""
         all_backends = QiskitRuntimeLocalService().backends()
         expected = FakeProviderForBackendV2().backends()
-        assert len(all_backends) == len(expected)
+        self.assertEqual(len(all_backends), len(expected))
 
         for b1, b2 in zip(all_backends, expected):
-            assert isinstance(b1, b2.__class__)
+            self.assertIsInstance(b1, b2.__class__)
 
     def test_backends_name_filter(self):
         """Tests the ``name`` filter of the ``backends`` method."""
         backends = QiskitRuntimeLocalService().backends("fake_torino")
-        assert len(backends) == 1
-        assert isinstance(backends[0], FakeTorino)
+        self.assertEqual(len(backends), 1)
+        self.assertIsInstance(backends[0], FakeTorino)
 
     def test_backends_min_num_qubits_filter(self):
         """Tests the ``min_num_qubits`` filter of the ``backends`` method.
@@ -55,25 +55,25 @@ class QiskitRuntimeLocalServiceTest(IBMTestCase):
         the target, making the test slightly slow.
         """
         for b in QiskitRuntimeLocalService().backends(min_num_qubits=27):
-            assert b.num_qubits >= 27
+            self.assertGreaterEqual(b.num_qubits, 27)
 
     @data(False, True)
     def test_backends_dynamic_circuits_filter(self, supports):
         """Tests the ``dynamic_circuits`` filter of the ``backends`` method."""
         for b in QiskitRuntimeLocalService().backends(dynamic_circuits=supports):
-            assert b._supports_dynamic_circuits() == supports
+            self.assertEqual(b._supports_dynamic_circuits(), supports)
 
     def test_backends_filters(self):
         """Tests the ``filters`` argument of the ``backends`` method."""
         for b in QiskitRuntimeLocalService().backends(
             filters=lambda b: (b.online_date.year == 2021)
         ):
-            assert b.online_date.year == 2021
+            self.assertEqual(b.online_date.year, 2021)
 
         for b in QiskitRuntimeLocalService().backends(
             filters=lambda b: (b.dtm is not None and b.dtm < 5e-10)
         ):
-            assert b.dtm < 5e-10
+            self.assertLess(b.dtm, 5e-10)
 
     def test_backends_filters_combined(self):
         """Tests the ``backends`` method with more than one filter."""
@@ -82,9 +82,9 @@ class QiskitRuntimeLocalServiceTest(IBMTestCase):
         backends1 = service.backends(
             name="fake_torino", min_num_qubits=27, filters=lambda b: (b.online_date.year == 2023)
         )
-        assert len(backends1) == 1
-        assert isinstance(backends1[0], FakeTorino)
-        assert backends1[0].online_date.year == 2023
+        self.assertEqual(len(backends1), 1)
+        self.assertIsInstance(backends1[0], FakeTorino)
+        self.assertEqual(backends1[0].online_date.year, 2023)
 
     def test_backends_errors(self):
         """Tests the errors raised by the ``backends`` method."""
@@ -97,4 +97,4 @@ class QiskitRuntimeLocalServiceTest(IBMTestCase):
 
     def test_least_busy(self):
         """Tests the ``least_busy`` method."""
-        assert isinstance(QiskitRuntimeLocalService().least_busy(), FakeBackendV2)
+        self.assertIsInstance(QiskitRuntimeLocalService().least_busy(), FakeBackendV2)

--- a/test/unit/noise_learner_v3/converters/test_converters_0_1.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_1.py
@@ -60,7 +60,7 @@ class TestConverters(IBMTestCase):
         options.execution.init_qubits = True
         options.execution.rep_delay = None
 
-        assert decoded == (instructions, options)
+        self.assertEqual(decoded, (instructions, options))
 
     def test_converting_results(self):
         """Tests converting results."""
@@ -87,10 +87,10 @@ class TestConverters(IBMTestCase):
         encoded = noise_learner_v3_result_to_0_1(results)
         decoded = noise_learner_v3_result_from_0_1(encoded)
         for datum_in, datum_out in zip(results.data, decoded.data):
-            assert datum_in._generators == datum_out._generators
-            assert np.allclose(datum_in._rates, datum_out._rates)
-            assert np.allclose(datum_in._rates_std, datum_out._rates_std)
-            assert datum_in.metadata == datum_out.metadata
+            self.assertEqual(datum_in._generators, datum_out._generators)
+            self.assertTrue(np.allclose(datum_in._rates, datum_out._rates))
+            self.assertTrue(np.allclose(datum_in._rates_std, datum_out._rates_std))
+            self.assertEqual(datum_in.metadata, datum_out.metadata)
 
     def test_converting_invalid_results(self):
         """Test that converting results raises when results are invalid."""

--- a/test/unit/noise_learner_v3/converters/test_converters_0_2.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_2.py
@@ -55,7 +55,7 @@ class TestConverters(IBMTestCase):
         encoded = noise_learner_v3_inputs_to_0_2(instructions, options)
         decoded = noise_learner_v3_inputs_from_0_2(encoded)
 
-        assert decoded == (instructions, options)
+        self.assertEqual(decoded, (instructions, options))
 
     def test_converting_results(self):
         """Tests converting results."""
@@ -85,10 +85,10 @@ class TestConverters(IBMTestCase):
         encoded = noise_learner_v3_result_to_0_2(results)
         decoded = noise_learner_v3_result_from_0_2(encoded)
         for datum_in, datum_out in zip(results.data, decoded.data):
-            assert datum_in._generators == datum_out._generators
-            assert np.allclose(datum_in._rates, datum_out._rates)
-            assert np.allclose(datum_in._rates_std, datum_out._rates_std)
-            assert datum_in.metadata == datum_out.metadata
+            self.assertEqual(datum_in._generators, datum_out._generators)
+            self.assertTrue(np.allclose(datum_in._rates, datum_out._rates))
+            self.assertTrue(np.allclose(datum_in._rates_std, datum_out._rates_std))
+            self.assertEqual(datum_in.metadata, datum_out.metadata)
 
     def test_converting_invalid_results(self):
         """Test that converting results raises when results are invalid."""

--- a/test/unit/noise_learner_v3/converters/test_converters_0_3.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_3.py
@@ -55,7 +55,7 @@ class TestConverters(IBMTestCase):
         encoded = noise_learner_v3_inputs_to_0_3(instructions, options)
         decoded = noise_learner_v3_inputs_from_0_3(encoded)
 
-        assert decoded == (instructions, options)
+        self.assertEqual(decoded, (instructions, options))
 
     def test_converting_results(self):
         """Tests converting results."""
@@ -85,10 +85,10 @@ class TestConverters(IBMTestCase):
         encoded = noise_learner_v3_result_to_0_3(results)
         decoded = noise_learner_v3_result_from_0_3(encoded)
         for datum_in, datum_out in zip(results.data, decoded.data):
-            assert datum_in._generators == datum_out._generators
-            assert np.allclose(datum_in._rates, datum_out._rates)
-            assert np.allclose(datum_in._rates_std, datum_out._rates_std)
-            assert datum_in.metadata == datum_out.metadata
+            self.assertEqual(datum_in._generators, datum_out._generators)
+            self.assertTrue(np.allclose(datum_in._rates, datum_out._rates))
+            self.assertTrue(np.allclose(datum_in._rates_std, datum_out._rates_std))
+            self.assertEqual(datum_in.metadata, datum_out.metadata)
 
     def test_converting_invalid_results(self):
         """Test that converting results raises when results are invalid."""

--- a/test/unit/noise_learner_v3/test_params_converters.py
+++ b/test/unit/noise_learner_v3/test_params_converters.py
@@ -56,5 +56,5 @@ class TestParamsConverters(IBMTestCase):
         encoded = converters.encoder(instructions, options).model_dump()
         decoded = converters.decoder(converters.model(**encoded))
 
-        assert decoded[0] == instructions
-        assert decoded[1] == options
+        self.assertEqual(decoded[0], instructions)
+        self.assertEqual(decoded[1], options)

--- a/test/unit/quantum_program/converters/test_converters_0_1.py
+++ b/test/unit/quantum_program/converters/test_converters_0_1.py
@@ -220,11 +220,11 @@ class TestQuantumProgramConverters(IBMTestCase):
         params_model = quantum_program_to_0_1(quantum_program, options)
         quantum_program_out, options_out = quantum_program_from_0_1(params_model)
 
-        assert options_out == options
+        self.assertEqual(options_out, options)
 
         items = quantum_program_out.items
-        assert len(items) == 2
-        assert isinstance(items[0], CircuitItem)
-        assert items[0].circuit == quantum_program.items[0].circuit
-        assert isinstance(items[1], SamplexItem)
-        assert items[1].circuit == quantum_program.items[1].circuit
+        self.assertEqual(len(items), 2)
+        self.assertIsInstance(items[0], CircuitItem)
+        self.assertEqual(items[0].circuit, quantum_program.items[0].circuit)
+        self.assertIsInstance(items[1], SamplexItem)
+        self.assertEqual(items[1].circuit, quantum_program.items[1].circuit)

--- a/test/unit/quantum_program/converters/test_converters_0_2.py
+++ b/test/unit/quantum_program/converters/test_converters_0_2.py
@@ -247,11 +247,11 @@ class TestQuantumProgramConverters(IBMTestCase):
         params_model = quantum_program_to_0_2(quantum_program, options)
         quantum_program_out, options_out = quantum_program_from_0_2(params_model)
 
-        assert options_out == options
+        self.assertEqual(options_out, options)
 
         items = quantum_program_out.items
-        assert len(items) == 2
-        assert isinstance(items[0], CircuitItem)
-        assert items[0].circuit == quantum_program.items[0].circuit
-        assert isinstance(items[1], SamplexItem)
-        assert items[1].circuit == quantum_program.items[1].circuit
+        self.assertEqual(len(items), 2)
+        self.assertIsInstance(items[0], CircuitItem)
+        self.assertEqual(items[0].circuit, quantum_program.items[0].circuit)
+        self.assertIsInstance(items[1], SamplexItem)
+        self.assertEqual(items[1].circuit, quantum_program.items[1].circuit)

--- a/test/unit/quantum_program/converters/test_converters_1_0.py
+++ b/test/unit/quantum_program/converters/test_converters_1_0.py
@@ -252,11 +252,11 @@ class TestQuantumProgramConverters(IBMTestCase):
         params_model = quantum_program_to_1_0(quantum_program, options)
         quantum_program_out, options_out = quantum_program_from_1_0(params_model)
 
-        assert options_out == options
+        self.assertEqual(options_out, options)
 
         items = quantum_program_out.items
-        assert len(items) == 2
-        assert isinstance(items[0], CircuitItem)
-        assert items[0].circuit == quantum_program.items[0].circuit
-        assert isinstance(items[1], SamplexItem)
-        assert items[1].circuit == quantum_program.items[1].circuit
+        self.assertEqual(len(items), 2)
+        self.assertIsInstance(items[0], CircuitItem)
+        self.assertEqual(items[0].circuit, quantum_program.items[0].circuit)
+        self.assertIsInstance(items[1], SamplexItem)
+        self.assertEqual(items[1].circuit, quantum_program.items[1].circuit)

--- a/test/unit/quantum_program/converters/test_converters_1_1.py
+++ b/test/unit/quantum_program/converters/test_converters_1_1.py
@@ -252,11 +252,11 @@ class TestQuantumProgramConverters(IBMTestCase):
         params_model = quantum_program_to_1_1(quantum_program, options)
         quantum_program_out, options_out = quantum_program_from_1_1(params_model)
 
-        assert options_out == options
+        self.assertEqual(options_out, options)
 
         items = quantum_program_out.items
-        assert len(items) == 2
-        assert isinstance(items[0], CircuitItem)
-        assert items[0].circuit == quantum_program.items[0].circuit
-        assert isinstance(items[1], SamplexItem)
-        assert items[1].circuit == quantum_program.items[1].circuit
+        self.assertEqual(len(items), 2)
+        self.assertIsInstance(items[0], CircuitItem)
+        self.assertEqual(items[0].circuit, quantum_program.items[0].circuit)
+        self.assertIsInstance(items[1], SamplexItem)
+        self.assertEqual(items[1].circuit, quantum_program.items[1].circuit)

--- a/test/unit/quantum_program/test_params_converters.py
+++ b/test/unit/quantum_program/test_params_converters.py
@@ -38,5 +38,5 @@ class TestParamsConverters(IBMTestCase):
         encoded = converters.encoder(program, options).model_dump()
         decoded = converters.decoder(converters.model(**encoded))
 
-        assert isinstance(decoded[0], QuantumProgram)
-        assert decoded[1] == options
+        self.assertIsInstance(decoded[0], QuantumProgram)
+        self.assertEqual(decoded[1], options)

--- a/test/unit/test_backend.py
+++ b/test/unit/test_backend.py
@@ -259,9 +259,9 @@ class TestBackend(IBMTestCase):
         """Test handling of non-unitary ISA operations."""
         target = convert_to_target(FakeSherbrooke().configuration())
 
-        assert isinstance(target.get("reset"), dict)
-        assert isinstance(target.get("measure"), dict)
-        assert target.get("measure_2") is None
+        self.assertIsInstance(target.get("reset"), dict)
+        self.assertIsInstance(target.get("measure"), dict)
+        self.assertIsNone(target.get("measure_2"))
 
     def test_convert_to_target_with_filter(self):
         """Test converting legacy data structure to V2 target model with faulty qubits.

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -804,8 +804,8 @@ class TestRuntimeDecoder(IBMTestCase):
         encoded = json.dumps(params, cls=RuntimeEncoder)
         decoded = json.loads(encoded, cls=RuntimeDecoder)
 
-        assert isinstance(decoded["params"]["quantum_program"], QuantumProgram)
-        assert decoded["params"]["options"] == ExecutorOptions()
+        self.assertIsInstance(decoded["params"]["quantum_program"], QuantumProgram)
+        self.assertEqual(decoded["params"]["options"], ExecutorOptions())
 
     @data(*list(QUANTUM_PROGRAM_PARAMS_CONVERTERS))
     def test_decoding_incorrect_executor_params_warns(self, schema_version):
@@ -828,8 +828,8 @@ class TestRuntimeDecoder(IBMTestCase):
         with self.assertWarnsRegex(Warning, "Unable to convert"):
             decoded = json.loads(encoded, cls=RuntimeDecoder)
 
-        assert decoded["params"]["quantum_program"] == "foo"
-        assert decoded["params"]["options"] == "bar"
+        self.assertEqual(decoded["params"]["quantum_program"], "foo")
+        self.assertEqual(decoded["params"]["options"], "bar")
 
     @data(*list(NOISE_LEARNER_V3_PARAMS_CONVERTERS))
     def test_decoding_noise_learner_v3_params(self, schema_version):
@@ -871,8 +871,8 @@ class TestRuntimeDecoder(IBMTestCase):
         encoded = json.dumps(params, cls=RuntimeEncoder)
         decoded = json.loads(encoded, cls=RuntimeDecoder)
 
-        assert decoded["params"]["instructions"] == instructions
-        assert decoded["params"]["options"] == options
+        self.assertEqual(decoded["params"]["instructions"], instructions)
+        self.assertEqual(decoded["params"]["options"], options)
 
     @data(*list(NOISE_LEARNER_V3_PARAMS_CONVERTERS))
     def test_decoding_incorrect_noise_learner_v3_params_warns(self, schema_version):
@@ -892,5 +892,5 @@ class TestRuntimeDecoder(IBMTestCase):
         with self.assertWarnsRegex(Warning, "Unable to convert"):
             decoded = json.loads(encoded, cls=RuntimeDecoder)
 
-        assert decoded["params"]["instructions"] == "foo"
-        assert decoded["params"]["options"] == "bar"
+        self.assertEqual(decoded["params"]["instructions"], "foo")
+        self.assertEqual(decoded["params"]["options"], "bar")

--- a/test/utils.py
+++ b/test/utils.py
@@ -117,9 +117,10 @@ def cancel_job_safe(job: RuntimeJobV2, logger: logging.Logger) -> bool:
     try:
         job.cancel()
         status = job.status()
-        assert status == "CANCELLED", (
-            f"cancel() was successful for job {job.job_id()} but its status is {status}."
-        )
+        if status != "CANCELLED":
+            raise AssertionError(
+                f"cancel() was successful for job {job.job_id()} but its status is {status}."
+            )
         return True
     except RuntimeInvalidStateError:
         if job.status() in ["DONE", "CANCELLED", "ERROR"]:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

During #2934, noticed that we are mixing bare `asserts` with unitttest-style asserts (`self.assertFoo`) in the tests. While they are both acceptable and roughly equivalent in most scenarios, this PR homogenizes them in direction of unittest, with the main argument being consistency, and adds a `ruff` rule to enforce not using asserts.

### Details and comments

Other minor arguments for going with unittest are continuing to strive for a runner-agnostic suite based on `unittest`, which can provide more informative details when the asserts are not met. Minor argument for bare `assert` is readability and conciseness. 

Fixes N/A

### AI/LLM disclosure

- [x] I used the following tool to generate or modify code: claude opus 4.8 for easier replacing.
