### PR TITLE
Users should know how to verify whether a backend is active or inactive

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -561,11 +561,13 @@ class QiskitRuntimeService:
                 For example::
 
                     QiskitRuntimeService.backends(
-                        filters=lambda b: b.max_shots > 50000
+                        filters=lambda backend: (
+                            (status := backend.status()).operational
+                            and status.status_msg == "active"
+                        )
                     )
-                    QiskitRuntimeService.backends(
-                        filters=lambda x: ("rz" in x.basis_gates )
-                    )
+
+                will only return backends that are operational and are active.
             use_fractional_gates: Set True to allow for the backends to include
                 fractional gates. Note that our backends now
                 support dynamic circuits and fractional gates simultaneously.

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -923,6 +923,20 @@ class QiskitRuntimeService:
     ) -> Backend:
         """Return a single backend matching the specified filtering.
 
+        Note that backend availability is only verified upon circuit submission. 
+        To check the backend status ahead of time, use the 
+        :meth:`~.IBMBackend.status` method on the backend object:
+
+        .. code-block:: python
+
+            from qiskit_ibm_runtime import QiskitRuntimeService
+
+            service = QiskitRuntimeService()
+            backend = service.backend()
+
+            status = backend.status()
+            assert status.operational and status.status_msg == "active"
+
         Args:
             name: Name of the backend.
             instance: Specify the IBM Cloud account CRN.

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -567,7 +567,7 @@ class QiskitRuntimeService:
                         )
                     )
 
-                will only return backends that are operational and are active.
+                will only return backends that are operational and active.
             use_fractional_gates: Set True to allow for the backends to include
                 fractional gates. Note that our backends now
                 support dynamic circuits and fractional gates simultaneously.

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -925,8 +925,8 @@ class QiskitRuntimeService:
     ) -> Backend:
         """Return a single backend matching the specified filtering.
 
-        Note that backend availability is only verified upon circuit submission. 
-        To check the backend status ahead of time, use the 
+        Note that backend availability is only verified upon circuit submission.
+        To check the backend status ahead of time, use the
         :meth:`~.IBMBackend.status` method on the backend object:
 
         .. code-block:: python


### PR DESCRIPTION
### Summary

Updating the runtime `.backend()` and `.backends()` docstrings to mention how users can check backend availability.

This PR closes #2923 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
