### PR TITLE
Add `AdvancedSession` class

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -219,6 +219,7 @@ class RuntimeClient(BaseBackendClient):
         instance: str | None = None,
         max_time: int | None = None,
         mode: str | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         """Create a session.
 
@@ -227,8 +228,11 @@ class RuntimeClient(BaseBackendClient):
             instance: The service instance to use.
             max_time: Maximum duration of the session.
             mode: Execution mode.
+            kwargs: Keyword arguments to add to the payload.
         """
-        return self._api.runtime_session(session_id=None).create(backend, instance, max_time, mode)
+        return self._api.runtime_session(session_id=None).create(
+            backend, instance, max_time, mode, **kwargs
+        )
 
     def cancel_session(self, session_id: str) -> None:
         """Close all jobs in the runtime session.

--- a/qiskit_ibm_runtime/api/rest/runtime_session.py
+++ b/qiskit_ibm_runtime/api/rest/runtime_session.py
@@ -50,6 +50,7 @@ class RuntimeSession(RestAdapterBase):
         instance: str | None = None,
         max_time: int | None = None,
         mode: str | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         """Create a session."""
         url = self.get_url("self")
@@ -62,6 +63,7 @@ class RuntimeSession(RestAdapterBase):
             payload["instance"] = instance
         if max_time:
             payload["max_ttl"] = max_time
+        payload.update(kwargs)
         return self.session.post(url, json=payload, headers=self._HEADER_JSON_CONTENT).json()
 
     def cancel(self) -> None:

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -466,17 +466,3 @@ class AdvancedSession(Session):
             )
             return session.get("id")
         return None
-
-    @classmethod
-    def from_id(
-        cls,
-        session_id: str,
-        service: QiskitRuntimeService,
-        use_fractional_gates: bool = False,
-        calibration_id: str | None = None,
-        **kwargs: Any,
-    ) -> AdvancedSession:
-        """Construct an AdvancedSession object with a given ``session_id``."""
-        raise NotImplementedError(
-            "The ``from_id`` method is not yet supported for ``AdvancedSession`` objects."
-        )

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -431,3 +431,61 @@ class Session:
     ) -> None:
         set_cm_session(None)
         self.close()
+
+
+class AdvancedSession(Session):
+    """A class representing an advanced session.
+
+    This class extends :pyclass:`~.Session` by allowing additional request fields to be included
+    in the session creation payload.
+
+    This class is intended for internal use. Its behaviour is subject to change without notice.
+    Third party clients should not use or depend on this class.
+    """
+
+    def __init__(
+        self,
+        backend: BackendV2,
+        max_time: int | str | None = None,
+        *,
+        create_new: bool | None = True,
+        **kwargs: Any,
+    ):
+        self._service: QiskitRuntimeService | QiskitRuntimeLocalService | None = None
+        self._backend: BackendV2 | None = None
+        self._instance = None
+        self._active = True
+        self._session_id = None
+
+        if isinstance(backend, IBMBackend):
+            self._service = backend.service
+            self._backend = backend
+        elif isinstance(backend, (BackendV2)):
+            self._service = QiskitRuntimeLocalService()
+            self._backend = backend
+        else:
+            raise ValueError(f"Invalid backend type {type(backend)}")
+
+        self._max_time = (
+            max_time
+            if max_time is None or isinstance(max_time, int)
+            else hms_to_seconds(max_time, "Invalid max_time value: ")
+        )
+
+        if isinstance(self._backend, IBMBackend):
+            self._instance = self._backend._instance
+            if not self._backend.configuration().simulator:
+                self._session_id = self._create_session(create_new=create_new, **kwargs)
+
+    def _create_session(self, *, create_new: bool | None = True, **kwargs: Any) -> str | None:
+        """Create a session."""
+        if isinstance(self._service, QiskitRuntimeService) and create_new:
+            session = self._service._get_api_client(self._instance).create_session(
+                self.backend(),
+                self._instance,
+                self._max_time,
+                "dedicated",
+                **kwargs,
+            )
+            return session.get("id")
+        return None

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -451,41 +451,14 @@ class AdvancedSession(Session):
         create_new: bool | None = True,
         **kwargs: Any,
     ):
-        self._service: QiskitRuntimeService | QiskitRuntimeLocalService | None = None
-        self._backend: BackendV2 | None = None
-        self._instance = None
-        self._active = True
-        self._session_id = None
+        self._kwargs = kwargs
+        super().__init__(backend=backend, max_time=max_time, create_new=create_new)
 
-        if isinstance(backend, IBMBackend):
-            self._service = backend.service
-            self._backend = backend
-        elif isinstance(backend, (BackendV2)):
-            self._service = QiskitRuntimeLocalService()
-            self._backend = backend
-        else:
-            raise ValueError(f"Invalid backend type {type(backend)}")
-
-        self._max_time = (
-            max_time
-            if max_time is None or isinstance(max_time, int)
-            else hms_to_seconds(max_time, "Invalid max_time value: ")
-        )
-
-        if isinstance(self._backend, IBMBackend):
-            self._instance = self._backend._instance
-            if not self._backend.configuration().simulator:
-                self._session_id = self._create_session(create_new=create_new, **kwargs)
-
-    def _create_session(self, *, create_new: bool | None = True, **kwargs: Any) -> str | None:
+    def _create_session(self, *, create_new: bool | None = True) -> str | None:
         """Create a session."""
         if isinstance(self._service, QiskitRuntimeService) and create_new:
             session = self._service._get_api_client(self._instance).create_session(
-                self.backend(),
-                self._instance,
-                self._max_time,
-                "dedicated",
-                **kwargs,
+                self.backend(), self._instance, self._max_time, "dedicated", **self._kwargs
             )
             return session.get("id")
         return None

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -436,7 +436,7 @@ class Session:
 class AdvancedSession(Session):
     """A class representing an advanced session.
 
-    This class extends :pyclass:`~.Session` by allowing additional request fields to be included
+    This class extends :class:`~.Session` by allowing additional request fields to be included
     in the session creation payload.
 
     This class is intended for internal use. Its behaviour is subject to change without notice.

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -462,3 +462,17 @@ class AdvancedSession(Session):
             )
             return session.get("id")
         return None
+
+    @classmethod
+    def from_id(
+        cls,
+        session_id: str,
+        service: QiskitRuntimeService,
+        use_fractional_gates: bool = False,
+        calibration_id: str | None = None,
+        **kwargs: Any,
+    ) -> AdvancedSession:
+        """Construct an AdvancedSession object with a given ``session_id``."""
+        raise NotImplementedError(
+            "The ``from_id`` method is not yet supported for ``AdvancedSession`` objects."
+        )

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -455,7 +455,11 @@ class AdvancedSession(Session):
         super().__init__(backend=backend, max_time=max_time, create_new=create_new)
 
     def _create_session(self, *, create_new: bool | None = True) -> str | None:
-        """Create a session."""
+        """Create a session.
+
+        Differs from ``Session._create_session`` in that it includes ``self._kwargs`` in
+        the session creation payload.
+        """
         if isinstance(self._service, QiskitRuntimeService) and create_new:
             session = self._service._get_api_client(self._instance).create_session(
                 self.backend(), self._instance, self._max_time, "dedicated", **self._kwargs


### PR DESCRIPTION
### Summary

This PR introduces the `AdvancedSession` class, which extends ``Session`` by allowing additional request fields to be included in the session creation payload.

This class is intended for internal use. Its behaviour is subject to change without notice. Third party clients should not use or depend on this class. 

Closes #2950 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
