### PR TITLE
Set default value of `inject_noise_site` to `"after"`

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/trex_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/trex_utils.py
@@ -55,6 +55,7 @@ def create_trex_calibration_circuit(
         enable_gates=False,
         enable_measures=True,
         measure_annotations="twirl",
+        inject_noise_site="after",
     )
     annotated_trex_circuit = boxing_pm.run(trex_circuit)
     template_trex_circuit, trex_samplex = build(annotated_trex_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -201,6 +201,7 @@ def box_circuit(
         measure_annotations="all"
         if twirling_options.enable_measure or twirl_measurements
         else "change_basis",
+        inject_noise_site="after",
         inject_noise_targets="gates" if inject_noise else "none",
         inject_noise_strategy="uniform_modification" if inject_noise else "no_modification",
     )

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -260,6 +260,7 @@ class SamplerV2(BaseSamplerV2):
                 enable_gates=bool(options.twirling.enable_gates),
                 enable_measures=bool(options.twirling.enable_measure),
                 twirling_strategy=options.twirling.strategy.replace("-", "_"),
+                inject_noise_site="after",
             )
 
             for i, pub in enumerate(pubs):

--- a/test/integration/test_executor.py
+++ b/test/integration/test_executor.py
@@ -99,6 +99,7 @@ class TestExecutor(IBMIntegrationTestCase):
         pm.post_scheduling = generate_boxing_pass_manager(
             enable_gates=True,
             enable_measures=True,
+            inject_noise_site="after",
         )
         boxed_isa_circuit = pm.run(circuit)
 

--- a/test/integration/test_noise_learner_v3.py
+++ b/test/integration/test_noise_learner_v3.py
@@ -35,6 +35,7 @@ class TestNoiseLearnerV3(IBMIntegrationTestCase):
         self.boxing_pm.post_scheduling = generate_boxing_pass_manager(
             enable_gates=True,
             enable_measures=True,
+            inject_noise_site="after",
         )
 
     def test_noise_learner_v3(self):

--- a/test/smoke/test_primitives.py
+++ b/test/smoke/test_primitives.py
@@ -37,7 +37,7 @@ class TestSmokePrimitives(IBMIntegrationTestCase):
         super().setUp()
         self._backend = self.service.backend(self.dependencies.qpu)
         self.pm = generate_preset_pass_manager(optimization_level=1, target=self._backend.target)
-        self.boxing_pm = generate_boxing_pass_manager()
+        self.boxing_pm = generate_boxing_pass_manager(inject_noise_site="after")
 
         # bell circuit
         bell = QuantumCircuit(2, name="Bell")

--- a/test/unit/noise_learner_v3/test_params_converters.py
+++ b/test/unit/noise_learner_v3/test_params_converters.py
@@ -45,6 +45,7 @@ class TestParamsConverters(IBMTestCase):
         boxing_pm.post_scheduling = generate_boxing_pass_manager(
             enable_gates=True,
             enable_measures=True,
+            inject_noise_site="after",
         )
         boxed_circuit = boxing_pm.run(circuit)
         instructions = find_unique_box_instructions(boxed_circuit)

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -843,6 +843,7 @@ class TestRuntimeDecoder(IBMTestCase):
         boxing_pm.post_scheduling = generate_boxing_pass_manager(
             enable_gates=True,
             enable_measures=True,
+            inject_noise_site="after",
         )
 
         circuit = QuantumCircuit(3, name="GHZ with params")


### PR DESCRIPTION
### Summary
In a recent change introduced in [this PR](https://github.com/Qiskit/samplomatic/pull/372) and release as part of version 0.20, Samplomatic has started to warn about a coming change in default value for `inject_noise_site` in the boxing pass manager, from `"before"` to `"after"`. This warning now appears to every call to the wrapper's `prepare` functions, as they use the boxing pass manager.

### Acceptance criteria
- [x] Set `inject_noise_site="after"` in every call to the boxing pass manager, to make sure that the warning does not appear.

Fixes #2951

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
