### PR TITLE
Add precision validation for estimator pubs to prevent non-positive v…

### DIFF
--- a/qiskit_ibm_runtime/utils/validations.py
+++ b/qiskit_ibm_runtime/utils/validations.py
@@ -82,6 +82,7 @@ def validate_estimator_pubs(pubs: list[EstimatorPub]) -> None:
 
     Raises:
         IBMInputValueError: If any observable array is of size 0
+        IBMInputValueError: If any precision value is not greater than 0
     """
     for pub in pubs:
         if pub.precision is not None and pub.precision <= 0:

--- a/qiskit_ibm_runtime/utils/validations.py
+++ b/qiskit_ibm_runtime/utils/validations.py
@@ -84,6 +84,9 @@ def validate_estimator_pubs(pubs: list[EstimatorPub]) -> None:
         IBMInputValueError: If any observable array is of size 0
     """
     for pub in pubs:
+        if pub.precision is not None and pub.precision <= 0:
+            raise IBMInputValueError("The precision value must be strictly greater than 0.")
+
         if pub.observables.shape == (0,):
             raise IBMInputValueError("Empty observables array is not allowed")
 

--- a/test/unit/test_estimator.py
+++ b/test/unit/test_estimator.py
@@ -94,6 +94,22 @@ class TestEstimatorV2(IBMTestCase):
             estimator.run(**get_primitive_inputs(estimator), precision=0)
         self.assertIn("The precision value must be strictly greater than 0", str(exc.exception))
 
+    def test_invalid_estimator_pub_precision(self):
+        """Test exception when a pub specifies a precision that is not strictly greater than 0."""
+        backend = get_mocked_backend()
+        backend.configuration().simulator = True
+
+        estimator = EstimatorV2(mode=backend)
+        # Precision supplied at the pub level (4th element) must also be guarded client-side,
+        # not just the run() kwarg -- otherwise a pub-level precision=0 reaches the server and
+        # raises a bare ZeroDivisionError when it converts precision to shots.
+        pub = get_primitive_inputs(estimator)["pubs"][0]
+        pub_with_zero_precision = (*pub, 0)
+        with self.assertRaisesRegex(
+            ValueError, "The precision value must be strictly greater than 0"
+        ):
+            estimator.run([pub_with_zero_precision])
+
     def test_pec_simulator(self):
         """Test error is raised when using pec on simulator without coupling map."""
         backend = get_mocked_backend()


### PR DESCRIPTION
### Summary

Specifying 0 as you precision in the pub level input on the legacy EstimatorV2 will cause the following server error: `RuntimeJobFailureError: "Unable to retrieve job result. Error code 1500;`

A guard clause should be added before server submission to throw `IBMInputValueError: 'The precision value must be strictly greater than 0.'` instead.

This is consistent to specifying 0 as your precision in the run kwarg level or default options level. 

```
qc = QuantumCircuit(2)
qc.h(0)
qc.cx(0, 1)

pm = generate_preset_pass_manager(optimization_level=1, backend=backend)
isa_circuit = pm.run(qc)
isa_obs = SparsePauliOp("ZZ").apply_layout(isa_circuit.layout)

estimator = EstimatorV2(mode=backend)

# precision = 0 on the pub -> accepted by the client, then ZeroDivisionError server-side
job = estimator.run([(isa_circuit, isa_obs, None, 0.0)])
print(job.result())  # job fails: (error 1500)
```


### AI/LLM disclosure

- [x] I used the following tool to generate or modify code: Claude Code
