### PR TITLE
Executor passthrough data does not passthrough arrays

### DIFF
--- a/qiskit_ibm_runtime/decoders/quantum_program/converters.py
+++ b/qiskit_ibm_runtime/decoders/quantum_program/converters.py
@@ -31,6 +31,8 @@ from ...results.quantum_program import (
 if TYPE_CHECKING:
     from ibm_quantum_schemas.executor.version_0_1 import QuantumProgramResultModel
 
+from ...quantum_program.converters.converters_0_2 import passthrough_data_from_0_2
+from ...quantum_program.converters.converters_1_0 import passthrough_data_from_1_0
 from ...quantum_program.converters.converters_1_1 import passthrough_data_from_1_1
 
 
@@ -86,7 +88,9 @@ def quantum_program_result_from_0_2(model: QuantumProgramResultModel) -> Quantum
         )
 
     return QuantumProgramResult(
-        data=data, metadata=metadata, passthrough_data=model.passthrough_data
+        data=data,
+        metadata=metadata,
+        passthrough_data=passthrough_data_from_0_2(model.passthrough_data),
     )
 
 
@@ -121,7 +125,9 @@ def quantum_program_result_from_1_0(model: QuantumProgramResultModel) -> Quantum
         )
 
     result = QuantumProgramResult(
-        data=data, metadata=metadata, passthrough_data=model.passthrough_data
+        data=data,
+        metadata=metadata,
+        passthrough_data=passthrough_data_from_1_0(model.passthrough_data),
     )
     result._semantic_role = model.semantic_role
     return result

--- a/qiskit_ibm_runtime/decoders/quantum_program/converters.py
+++ b/qiskit_ibm_runtime/decoders/quantum_program/converters.py
@@ -31,6 +31,8 @@ from ...results.quantum_program import (
 if TYPE_CHECKING:
     from ibm_quantum_schemas.executor.version_0_1 import QuantumProgramResultModel
 
+from ...quantum_program.converters.converters_1_1 import passthrough_data_from_1_1
+
 
 def quantum_program_result_from_0_1(model: QuantumProgramResultModel) -> QuantumProgramResult:
     """Convert a V0.1 model to a :class:`QuantumProgramResult`."""
@@ -156,7 +158,9 @@ def quantum_program_result_from_1_1(model: QuantumProgramResultModel) -> Quantum
         )
 
     result = QuantumProgramResult(
-        data=data, metadata=metadata, passthrough_data=model.passthrough_data
+        data=data,
+        metadata=metadata,
+        passthrough_data=passthrough_data_from_1_1(model.passthrough_data),
     )
     result._semantic_role = model.semantic_role
     return result

--- a/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ibm_quantum_schemas.common import (
@@ -35,6 +36,33 @@ from samplomatic.tensor_interface import PauliLindbladMapSpecification, TensorSp
 from ...options_models.executor_options import ExecutorOptions
 from ...utils.utils import get_qpy_version, get_ssv_version
 from ..quantum_program import CircuitItem, QuantumProgram, SamplexItem
+
+if TYPE_CHECKING:
+    from ibm_quantum_schemas.executor.version_0_2.models import DataTree as DataTreeModel
+
+    from ..datatree import DataTree
+
+
+def passthrough_data_to_0_2(passthrough_data: DataTree) -> DataTreeModel:
+    """Convert passthrough data to schema model."""
+    if isinstance(passthrough_data, dict):
+        return {k: passthrough_data_to_0_2(v) for k, v in passthrough_data.items()}
+    if isinstance(passthrough_data, (list, tuple)):
+        return [passthrough_data_to_0_2(v) for v in passthrough_data]
+    if isinstance(passthrough_data, np.ndarray):
+        return TensorModel.from_numpy(passthrough_data)
+    return passthrough_data
+
+
+def passthrough_data_from_0_2(passthrough_data: DataTree) -> DataTreeModel:
+    """Convert passthrough data to schema model."""
+    if isinstance(passthrough_data, TensorModel):
+        return passthrough_data.to_numpy()
+    if isinstance(passthrough_data, dict):
+        return {k: passthrough_data_from_0_2(v) for k, v in passthrough_data.items()}
+    if isinstance(passthrough_data, list):
+        return [passthrough_data_from_0_2(el) for el in passthrough_data]
+    return passthrough_data
 
 
 def quantum_program_from_0_2(model: ParamsModel) -> tuple[QuantumProgram, ExecutorOptions]:
@@ -84,7 +112,7 @@ def quantum_program_from_0_2(model: ParamsModel) -> tuple[QuantumProgram, Execut
         shots=program_model.shots,
         items=items,
         meas_level=program_model.meas_level,
-        passthrough_data=program_model.passthrough_data,
+        passthrough_data=passthrough_data_from_0_2(program_model.passthrough_data),
     )
 
     options = ExecutorOptions()
@@ -145,7 +173,7 @@ def quantum_program_to_0_2(program: QuantumProgram, options: ExecutorOptions) ->
             shots=program.shots,
             items=model_items,
             meas_level=program.meas_level,
-            passthrough_data=program.passthrough_data,
+            passthrough_data=passthrough_data_to_0_2(program.passthrough_data),
         ),
         options=options_dict,
     )

--- a/qiskit_ibm_runtime/quantum_program/converters/converters_1_0.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_1_0.py
@@ -38,7 +38,32 @@ from ...utils.utils import get_qpy_version, get_ssv_version
 from ..quantum_program import CircuitItem, QuantumProgram, SamplexItem
 
 if TYPE_CHECKING:
+    from ibm_quantum_schemas.executor.version_1_0.models import DataTree as DataTreeModel
     from qiskit.circuit import QuantumCircuit
+
+    from ..datatree import DataTree
+
+
+def passthrough_data_to_1_0(passthrough_data: DataTree) -> DataTreeModel:
+    """Convert passthrough data to schema model."""
+    if isinstance(passthrough_data, dict):
+        return {k: passthrough_data_to_1_0(v) for k, v in passthrough_data.items()}
+    if isinstance(passthrough_data, (list, tuple)):
+        return [passthrough_data_to_1_0(v) for v in passthrough_data]
+    if isinstance(passthrough_data, np.ndarray):
+        return TensorModel.from_numpy(passthrough_data)
+    return passthrough_data
+
+
+def passthrough_data_from_1_0(passthrough_data: DataTree) -> DataTreeModel:
+    """Convert passthrough data to schema model."""
+    if isinstance(passthrough_data, TensorModel):
+        return passthrough_data.to_numpy()
+    if isinstance(passthrough_data, dict):
+        return {k: passthrough_data_from_1_0(v) for k, v in passthrough_data.items()}
+    if isinstance(passthrough_data, list):
+        return [passthrough_data_from_1_0(el) for el in passthrough_data]
+    return passthrough_data
 
 
 def quantum_program_from_1_0(model: ParamsModel) -> tuple[QuantumProgram, ExecutorOptions]:
@@ -84,7 +109,7 @@ def quantum_program_from_1_0(model: ParamsModel) -> tuple[QuantumProgram, Execut
         shots=program_model.shots,
         items=items,
         meas_level=program_model.meas_level,
-        passthrough_data=program_model.passthrough_data,
+        passthrough_data=passthrough_data_from_1_0(program_model.passthrough_data),
     )
     quantum_program._semantic_role = program_model.semantic_role
 
@@ -144,7 +169,7 @@ def quantum_program_to_1_0(program: QuantumProgram, options: ExecutorOptions) ->
             circuits=QpyDataV13ToV17Model.from_python(circuits, qpy_version=get_qpy_version(17)),
             items=model_items,
             meas_level=program.meas_level,
-            passthrough_data=program.passthrough_data,
+            passthrough_data=passthrough_data_to_1_0(program.passthrough_data),
             semantic_role=program._semantic_role,
         ),
         options=options_dict,

--- a/qiskit_ibm_runtime/quantum_program/converters/converters_1_1.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_1_1.py
@@ -38,7 +38,32 @@ from ...utils.utils import get_qpy_version, get_ssv_version
 from ..quantum_program import CircuitItem, QuantumProgram, SamplexItem
 
 if TYPE_CHECKING:
+    from ibm_quantum_schemas.executor.version_1_0.models import DataTree as DataTreeModel
     from qiskit.circuit import QuantumCircuit
+
+    from ..datatree import DataTree
+
+
+def passthrough_data_to_1_1(passthrough_data: DataTree) -> DataTreeModel:
+    """Convert passthrough data to schema model."""
+    if isinstance(passthrough_data, dict):
+        return {k: passthrough_data_to_1_1(v) for k, v in passthrough_data.items()}
+    if isinstance(passthrough_data, (list, tuple)):
+        return [passthrough_data_to_1_1(v) for v in passthrough_data]
+    if isinstance(passthrough_data, np.ndarray):
+        return TensorModel.from_numpy(passthrough_data)
+    return passthrough_data
+
+
+def passthrough_data_from_1_1(passthrough_data: DataTree) -> DataTreeModel:
+    """Convert passthrough data to schema model."""
+    if isinstance(passthrough_data, TensorModel):
+        return passthrough_data.to_numpy()
+    if isinstance(passthrough_data, dict):
+        return {k: passthrough_data_from_1_1(v) for k, v in passthrough_data.items()}
+    if isinstance(passthrough_data, list):
+        return [passthrough_data_from_1_1(el) for el in passthrough_data]
+    return passthrough_data
 
 
 def quantum_program_from_1_1(model: ParamsModel) -> tuple[QuantumProgram, ExecutorOptions]:
@@ -84,7 +109,7 @@ def quantum_program_from_1_1(model: ParamsModel) -> tuple[QuantumProgram, Execut
         shots=program_model.shots,
         items=items,
         meas_level=program_model.meas_level,
-        passthrough_data=program_model.passthrough_data,
+        passthrough_data=passthrough_data_from_1_1(program_model.passthrough_data),
     )
     quantum_program._semantic_role = program_model.semantic_role
 
@@ -144,7 +169,7 @@ def quantum_program_to_1_1(program: QuantumProgram, options: ExecutorOptions) ->
             circuits=QpyDataV13ToV17Model.from_python(circuits, qpy_version=get_qpy_version(17)),
             items=model_items,
             meas_level=program.meas_level,
-            passthrough_data=program.passthrough_data,
+            passthrough_data=passthrough_data_to_1_1(program.passthrough_data),
             semantic_role=program._semantic_role,
         ),
         options=options_dict,

--- a/qiskit_ibm_runtime/quantum_program/converters/converters_1_1.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_1_1.py
@@ -38,7 +38,7 @@ from ...utils.utils import get_qpy_version, get_ssv_version
 from ..quantum_program import CircuitItem, QuantumProgram, SamplexItem
 
 if TYPE_CHECKING:
-    from ibm_quantum_schemas.executor.version_1_0.models import DataTree as DataTreeModel
+    from ibm_quantum_schemas.executor.version_1_1.models import DataTree as DataTreeModel
     from qiskit.circuit import QuantumCircuit
 
     from ..datatree import DataTree

--- a/test/integration/test_executor.py
+++ b/test/integration/test_executor.py
@@ -58,7 +58,16 @@ class TestExecutor(IBMIntegrationTestCase):
         pm = generate_preset_pass_manager(backend=self.backend, optimization_level=0)
         isa_circuit = pm.run(circuit)
 
-        passthrough_data = {"key": "value"}
+        passthrough_data = {
+            "str": "ciao",
+            "float": 1.2,
+            "int": 1,
+            "bool": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "array": np.array([1.0, 2.0]),
+            "nested": {"array2": np.array([3.0, 4.0])},
+        }
         program = QuantumProgram(shots := 123, passthrough_data=passthrough_data)
         program.append_circuit_item(isa_circuit, circuit_arguments=circuit_arguments)
 
@@ -73,13 +82,18 @@ class TestExecutor(IBMIntegrationTestCase):
         results = job.result()
         self.assertIsInstance(results, QuantumProgramResult)
         self.assertEqual(len(results), 1)
-        self.assertEqual(results.passthrough_data, passthrough_data)
 
         result = results[0]
         self.assertIsInstance(result, QuantumProgramItemResult)
         self.assertEqual(list(result.keys()), ["meas"])
         self.assertIsInstance(result["meas"], np.ndarray)
         self.assertEqual(result["meas"].shape, shape + (shots, circuit.num_qubits))
+
+        self.assertEqual(passthrough_data.keys(), results.passthrough_data.keys())
+        for key in ["str", "float", "int", "bool", "none", "list"]:
+            self.assertEqual(passthrough_data[key], results.passthrough_data[key])
+        self.assertIsInstance(results.passthrough_data["array"], np.ndarray)
+        np.testing.assert_array_equal(passthrough_data["array"], results.passthrough_data["array"])
 
     def test_executor_with_samplex_item(self):
         """Test sampler with a single samplex item."""

--- a/test/unit/quantum_program/converters/test_converters_0_2.py
+++ b/test/unit/quantum_program/converters/test_converters_0_2.py
@@ -240,6 +240,18 @@ class TestQuantumProgramConverters(IBMTestCase):
             samplex=samplex,
         )
 
+        passthrough_data = {
+            "str": "ciao",
+            "float": 1.2,
+            "int": 1,
+            "bool": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "array": np.array([1.0, 2.0]),
+            "nested": {"array2": np.array([3.0, 4.0])},
+        }
+        quantum_program.passthrough_data = passthrough_data
+
         options = ExecutorOptions()
         options.execution.init_qubits = False
         options.experimental = {"key": "value"}
@@ -255,3 +267,11 @@ class TestQuantumProgramConverters(IBMTestCase):
         self.assertEqual(items[0].circuit, quantum_program.items[0].circuit)
         self.assertIsInstance(items[1], SamplexItem)
         self.assertEqual(items[1].circuit, quantum_program.items[1].circuit)
+
+        self.assertEqual(passthrough_data.keys(), quantum_program_out.passthrough_data.keys())
+        for key in ["str", "float", "int", "bool", "none", "list"]:
+            self.assertEqual(passthrough_data[key], quantum_program_out.passthrough_data[key])
+        self.assertIsInstance(quantum_program_out.passthrough_data["array"], np.ndarray)
+        np.testing.assert_array_equal(
+            passthrough_data["array"], quantum_program_out.passthrough_data["array"]
+        )

--- a/test/unit/quantum_program/converters/test_converters_1_0.py
+++ b/test/unit/quantum_program/converters/test_converters_1_0.py
@@ -245,6 +245,18 @@ class TestQuantumProgramConverters(IBMTestCase):
             samplex=samplex,
         )
 
+        passthrough_data = {
+            "str": "ciao",
+            "float": 1.2,
+            "int": 1,
+            "bool": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "array": np.array([1.0, 2.0]),
+            "nested": {"array2": np.array([3.0, 4.0])},
+        }
+        quantum_program.passthrough_data = passthrough_data
+
         options = ExecutorOptions()
         options.execution.init_qubits = False
         options.experimental = {"key": "value"}
@@ -260,3 +272,11 @@ class TestQuantumProgramConverters(IBMTestCase):
         self.assertEqual(items[0].circuit, quantum_program.items[0].circuit)
         self.assertIsInstance(items[1], SamplexItem)
         self.assertEqual(items[1].circuit, quantum_program.items[1].circuit)
+
+        self.assertEqual(passthrough_data.keys(), quantum_program_out.passthrough_data.keys())
+        for key in ["str", "float", "int", "bool", "none", "list"]:
+            self.assertEqual(passthrough_data[key], quantum_program_out.passthrough_data[key])
+        self.assertIsInstance(quantum_program_out.passthrough_data["array"], np.ndarray)
+        np.testing.assert_array_equal(
+            passthrough_data["array"], quantum_program_out.passthrough_data["array"]
+        )

--- a/test/unit/quantum_program/converters/test_converters_1_1.py
+++ b/test/unit/quantum_program/converters/test_converters_1_1.py
@@ -233,18 +233,6 @@ class TestQuantumProgramConverters(IBMTestCase):
         circuit1 = QuantumCircuit(1)
         quantum_program.append_circuit_item(circuit1)
 
-        passthrough_data = {
-            "str": "ciao",
-            "float": 1.2,
-            "int": 1,
-            "bool": True,
-            "none": None,
-            "list": [1, 2, 3],
-            "array": np.array([1.0, 2.0]),
-            "nested": {"array2": np.array([3.0, 4.0])},
-        }
-        quantum_program.passthrough_data = passthrough_data
-
         circuit2 = QuantumCircuit(2)
         with circuit2.box(annotations=[Twirl()]):
             circuit2.cx(0, 1)
@@ -256,6 +244,18 @@ class TestQuantumProgramConverters(IBMTestCase):
             template_circuit,
             samplex=samplex,
         )
+
+        passthrough_data = {
+            "str": "ciao",
+            "float": 1.2,
+            "int": 1,
+            "bool": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "array": np.array([1.0, 2.0]),
+            "nested": {"array2": np.array([3.0, 4.0])},
+        }
+        quantum_program.passthrough_data = passthrough_data
 
         options = ExecutorOptions()
         options.execution.init_qubits = False

--- a/test/unit/quantum_program/converters/test_converters_1_1.py
+++ b/test/unit/quantum_program/converters/test_converters_1_1.py
@@ -233,6 +233,18 @@ class TestQuantumProgramConverters(IBMTestCase):
         circuit1 = QuantumCircuit(1)
         quantum_program.append_circuit_item(circuit1)
 
+        passthrough_data = {
+            "str": "ciao",
+            "float": 1.2,
+            "int": 1,
+            "bool": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "array": np.array([1.0, 2.0]),
+            "nested": {"array2": np.array([3.0, 4.0])},
+        }
+        quantum_program.passthrough_data = passthrough_data
+
         circuit2 = QuantumCircuit(2)
         with circuit2.box(annotations=[Twirl()]):
             circuit2.cx(0, 1)
@@ -260,3 +272,11 @@ class TestQuantumProgramConverters(IBMTestCase):
         self.assertEqual(items[0].circuit, quantum_program.items[0].circuit)
         self.assertIsInstance(items[1], SamplexItem)
         self.assertEqual(items[1].circuit, quantum_program.items[1].circuit)
+
+        self.assertEqual(passthrough_data.keys(), quantum_program_out.passthrough_data.keys())
+        for key in ["str", "float", "int", "bool", "none", "list"]:
+            self.assertEqual(passthrough_data[key], quantum_program_out.passthrough_data[key])
+        self.assertIsInstance(quantum_program_out.passthrough_data["array"], np.ndarray)
+        np.testing.assert_array_equal(
+            passthrough_data["array"], quantum_program_out.passthrough_data["array"]
+        )


### PR DESCRIPTION
### Summary
This PR fixes a bug where `np.array`s inside passthrough data are incorrectly converted into `list`s upon serialization.
The full issue is reported in issue #2954 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
