### PR TITLE
Add tests and improve docs for `box_circuit`

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -109,13 +109,7 @@ def prepare_pec(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        boxed_circuit = box_circuit(
-            circuit=pub.circuit,
-            enable_gates=pm_kwargs["enable_gates"],
-            measure_annotations=pm_kwargs["measure_annotations"],
-            twirling_strategy=pm_kwargs["twirling_strategy"],
-            inject_noise=True,
-        )
+        boxed_circuit = box_circuit(circuit=pub.circuit, inject_noise=True, **pm_kwargs)
 
         # Build the template and the samplex
         template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -101,14 +101,19 @@ def prepare_pec(
     param_shapes_list = []
     pec_gamma_list = []
 
+    pm_kwargs = options_to_boxing_pm_kwargs(
+        twirling_options,
+        measure_noise_learning,
+        inject_noise=True,
+    )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
-            **options_to_boxing_pm_kwargs(
-                twirling_options, measure_noise_learning, inject_noise=True
-            ),
+            enable_gates=pm_kwargs["enable_gates"],
+            measure_annotations=pm_kwargs["measure_annotations"],
+            twirling_strategy=pm_kwargs["twirling_strategy"],
             inject_noise=True,
         )
 

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -99,9 +99,13 @@ def prepare_pec(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
+        twirl_measurements = measure_noise_learning is not None
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
             enable_gates=True,
+            measure_annotations="all"
+            if twirling_options.enable_measure or twirl_measurements
+            else "change_basis",
             twirling_options=twirling_options,
             twirling_strategy=twirling_options.strategy.replace("-", "_"),
             twirl_measurements=measure_noise_learning is not None,

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -99,16 +99,13 @@ def prepare_pec(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        twirl_measurements = measure_noise_learning is not None
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
             enable_gates=True,
             measure_annotations="all"
-            if twirling_options.enable_measure or twirl_measurements
+            if twirling_options.enable_measure or (measure_noise_learning is not None)
             else "change_basis",
-            twirling_options=twirling_options,
             twirling_strategy=twirling_options.strategy.replace("-", "_"),
-            twirl_measurements=measure_noise_learning is not None,
             inject_noise=True,
         )
 

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -35,7 +35,12 @@ from ...exceptions import IBMInputValueError
 from ...quantum_program import QuantumProgram
 from ...quantum_program.quantum_program import SamplexItem
 from ..trex_utils import create_trex_calibration_circuit
-from ..utils import box_circuit, compute_samplex_arguments, make_samplex_arguments
+from ..utils import (
+    box_circuit,
+    compute_samplex_arguments,
+    make_samplex_arguments,
+    options_to_boxing_pm_kwargs,
+)
 from .utils import calculate_gamma, calculate_pec_twirling_shots
 
 logger = logging.getLogger(__name__)
@@ -101,11 +106,9 @@ def prepare_pec(
 
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
-            enable_gates=True,
-            measure_annotations="all"
-            if twirling_options.enable_measure or (measure_noise_learning is not None)
-            else "change_basis",
-            twirling_strategy=twirling_options.strategy.replace("-", "_"),
+            **options_to_boxing_pm_kwargs(
+                twirling_options, measure_noise_learning, inject_noise=True
+            ),
             inject_noise=True,
         )
 

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -103,6 +103,7 @@ def prepare_pec(
             circuit=pub.circuit,
             enable_gates=True,
             twirling_options=twirling_options,
+            twirling_strategy=twirling_options.strategy.replace("-", "_"),
             twirl_measurements=measure_noise_learning is not None,
             inject_noise=True,
         )

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -100,7 +100,11 @@ def prepare_pec(
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
         boxed_circuit = box_circuit(
-            pub.circuit, twirling_options, measure_noise_learning is not None, True
+            circuit=pub.circuit,
+            enable_gates=True,
+            twirling_options=twirling_options,
+            twirl_measurements=measure_noise_learning is not None,
+            inject_noise=True,
         )
 
         # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -91,8 +91,6 @@ def prepare(
             if twirling_options.enable_measure or twirl_measurements
             else "change_basis",
             twirling_strategy=twirling_options.strategy.replace("-", "_"),
-            twirling_options=twirling_options,
-            twirl_measurements=measure_noise_learning is not None,
         )
 
         # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -93,13 +93,7 @@ def prepare(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        boxed_circuit = box_circuit(
-            circuit=pub.circuit,
-            enable_gates=pm_kwargs["enable_gates"],
-            measure_annotations=pm_kwargs["measure_annotations"],
-            twirling_strategy=pm_kwargs["twirling_strategy"],
-            inject_noise=False,
-        )
+        boxed_circuit = box_circuit(circuit=pub.circuit, inject_noise=False, **pm_kwargs)
 
         # Build the template and the samplex
         template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -83,9 +83,13 @@ def prepare(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
+        twirl_measurements = measure_noise_learning is not None
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
             enable_gates=twirling_options.enable_gates,
+            measure_annotations="all"
+            if twirling_options.enable_measure or twirl_measurements
+            else "change_basis",
             twirling_strategy=twirling_options.strategy.replace("-", "_"),
             twirling_options=twirling_options,
             twirl_measurements=measure_noise_learning is not None,

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -86,6 +86,7 @@ def prepare(
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
             enable_gates=twirling_options.enable_gates,
+            twirling_strategy=twirling_options.strategy.replace("-", "_"),
             twirling_options=twirling_options,
             twirl_measurements=measure_noise_learning is not None,
         )

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -84,7 +84,10 @@ def prepare(
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
         boxed_circuit = box_circuit(
-            pub.circuit, twirling_options, measure_noise_learning is not None
+            circuit=pub.circuit,
+            enable_gates=twirling_options.enable_gates,
+            twirling_options=twirling_options,
+            twirl_measurements=measure_noise_learning is not None,
         )
 
         # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -32,7 +32,12 @@ from ..executor.calculate_twirling_shots import calculate_twirling_shots
 from ..quantum_program import QuantumProgram
 from ..quantum_program.quantum_program import SamplexItem
 from .trex_utils import create_trex_calibration_circuit
-from .utils import box_circuit, compute_samplex_arguments, make_samplex_arguments
+from .utils import (
+    box_circuit,
+    compute_samplex_arguments,
+    make_samplex_arguments,
+    options_to_boxing_pm_kwargs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,14 +88,11 @@ def prepare(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        twirl_measurements = measure_noise_learning is not None
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
-            enable_gates=twirling_options.enable_gates,
-            measure_annotations="all"
-            if twirling_options.enable_measure or twirl_measurements
-            else "change_basis",
-            twirling_strategy=twirling_options.strategy.replace("-", "_"),
+            **options_to_boxing_pm_kwargs(
+                twirling_options, measure_noise_learning, inject_noise=False
+            ),
         )
 
         # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -85,14 +85,20 @@ def prepare(
     param_basis_pairs_list = []
     param_shapes_list = []
 
+    pm_kwargs = options_to_boxing_pm_kwargs(
+        twirling_options,
+        measure_noise_learning,
+        inject_noise=False,
+    )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
-            **options_to_boxing_pm_kwargs(
-                twirling_options, measure_noise_learning, inject_noise=False
-            ),
+            enable_gates=pm_kwargs["enable_gates"],
+            measure_annotations=pm_kwargs["measure_annotations"],
+            twirling_strategy=pm_kwargs["twirling_strategy"],
+            inject_noise=False,
         )
 
         # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -100,16 +100,13 @@ def prepare_pea(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        twirl_measurements = measure_noise_learning is not None
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
             enable_gates=True,
             measure_annotations="all"
-            if twirling_options.enable_measure or twirl_measurements
+            if twirling_options.enable_measure or (measure_noise_learning is not None)
             else "change_basis",
             twirling_strategy=twirling_options.strategy.replace("-", "_"),
-            twirling_options=twirling_options,
-            twirl_measurements=measure_noise_learning is not None,
             inject_noise=True,
         )
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -100,9 +100,13 @@ def prepare_pea(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
+        twirl_measurements = measure_noise_learning is not None
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
             enable_gates=True,
+            measure_annotations="all"
+            if twirling_options.enable_measure or twirl_measurements
+            else "change_basis",
             twirling_strategy=twirling_options.strategy.replace("-", "_"),
             twirling_options=twirling_options,
             twirl_measurements=measure_noise_learning is not None,

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -102,14 +102,19 @@ def prepare_pea(
     param_basis_pairs_list = []
     param_shapes_list = []
 
+    pm_kwargs = options_to_boxing_pm_kwargs(
+        twirling_options,
+        measure_noise_learning,
+        inject_noise=True,
+    )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
-            **options_to_boxing_pm_kwargs(
-                twirling_options, measure_noise_learning, inject_noise=True
-            ),
+            enable_gates=pm_kwargs["enable_gates"],
+            measure_annotations=pm_kwargs["measure_annotations"],
+            twirling_strategy=pm_kwargs["twirling_strategy"],
             inject_noise=True,
         )
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -103,6 +103,7 @@ def prepare_pea(
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
             enable_gates=True,
+            twirling_strategy=twirling_options.strategy.replace("-", "_"),
             twirling_options=twirling_options,
             twirl_measurements=measure_noise_learning is not None,
             inject_noise=True,

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -36,7 +36,12 @@ from ..options_models.zne_options import PEA_DEFAULT_NOISE_FACTORS
 from ..quantum_program import QuantumProgram
 from ..quantum_program.quantum_program import SamplexItem
 from .trex_utils import create_trex_calibration_circuit
-from .utils import box_circuit, compute_samplex_arguments, make_samplex_arguments
+from .utils import (
+    box_circuit,
+    compute_samplex_arguments,
+    make_samplex_arguments,
+    options_to_boxing_pm_kwargs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,11 +107,9 @@ def prepare_pea(
 
         boxed_circuit = box_circuit(
             circuit=pub.circuit,
-            enable_gates=True,
-            measure_annotations="all"
-            if twirling_options.enable_measure or (measure_noise_learning is not None)
-            else "change_basis",
-            twirling_strategy=twirling_options.strategy.replace("-", "_"),
+            **options_to_boxing_pm_kwargs(
+                twirling_options, measure_noise_learning, inject_noise=True
+            ),
             inject_noise=True,
         )
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -101,7 +101,11 @@ def prepare_pea(
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
         boxed_circuit = box_circuit(
-            pub.circuit, twirling_options, measure_noise_learning is not None, True
+            circuit=pub.circuit,
+            enable_gates=True,
+            twirling_options=twirling_options,
+            twirl_measurements=measure_noise_learning is not None,
+            inject_noise=True,
         )
 
         # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -110,13 +110,7 @@ def prepare_pea(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        boxed_circuit = box_circuit(
-            circuit=pub.circuit,
-            enable_gates=pm_kwargs["enable_gates"],
-            measure_annotations=pm_kwargs["measure_annotations"],
-            twirling_strategy=pm_kwargs["twirling_strategy"],
-            inject_noise=True,
-        )
+        boxed_circuit = box_circuit(circuit=pub.circuit, inject_noise=True, **pm_kwargs)
 
         # Build the template and the samplex
         template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -163,6 +163,7 @@ def resolve_precision(
 def box_circuit(
     circuit: QuantumCircuit,
     enable_gates: bool,
+    measure_annotations: str,
     twirling_strategy: str,
     twirling_options: TwirlingOptions,
     twirl_measurements: bool = False,
@@ -179,6 +180,10 @@ def box_circuit(
         circuit: The quantum circuit to box.
         enable_gates: Whether to group gates into boxes. This value is passed directly to the
             ``enable_gates`` argument of
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+        measure_annotations: The annotations placed on the measurement boxes when
+            ``enable_measures`` is ``True``. This value is passed directly to the
+            ``measure_annotations`` argument of
             :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
         twirling_strategy: The strategy for whether and how twirling boxes are extended to
             include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
@@ -208,9 +213,7 @@ def box_circuit(
         enable_gates=enable_gates,
         enable_measures=True,
         twirling_strategy=twirling_strategy,
-        measure_annotations="all"
-        if twirling_options.enable_measure or twirl_measurements
-        else "change_basis",
+        measure_annotations=measure_annotations,
         inject_noise_site="after",
         inject_noise_targets="gates" if inject_noise else "none",
         inject_noise_strategy="uniform_modification" if inject_noise else "no_modification",
@@ -244,9 +247,9 @@ def get_layers(
             box_circuit(
                 circuit=pub.circuit,
                 enable_gates=twirling_options.enable_gates or inject_noise,
+                measure_annotations="all" if twirling_options.enable_measure else "change_basis",
                 twirling_strategy=twirling_options.strategy.replace("-", "_"),
                 twirling_options=twirling_options,
-                twirl_measurements=twirl_measurements,
                 inject_noise=inject_noise,
             ).data,
             normalize_annotations=None,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -162,6 +162,7 @@ def resolve_precision(
 
 def box_circuit(
     circuit: QuantumCircuit,
+    enable_gates: bool,
     twirling_options: TwirlingOptions,
     twirl_measurements: bool = False,
     inject_noise: bool = False,
@@ -174,14 +175,16 @@ def box_circuit(
     circuit into boxes.
 
     Args:
-        circuit: Quantum circuit to box.
+        circuit: The quantum circuit to box.
+        enable_gates: Whether to group gates into boxes. This value is passed directly to the
+            ``enable_gates`` argument of
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
         twirling_options: Twirling options.
         twirl_measurements: Whether to twirl measurements.
         inject_noise: Whether to inject noise.
 
     Returns:
         The boxed circuit.
-
     """
     # Remove any existing final measurements
     prepared_circuit = circuit.remove_final_measurements(inplace=False)
@@ -233,7 +236,13 @@ def get_layers(
     """
     return [
         find_unique_box_instructions(
-            box_circuit(pub.circuit, twirling_options, twirl_measurements, inject_noise).data,
+            box_circuit(
+                circuit=pub.circuit,
+                enable_gates=twirling_options.enable_gates,
+                twirling_options=twirling_options,
+                twirl_measurements=twirl_measurements,
+                inject_noise=inject_noise,
+            ).data,
             normalize_annotations=None,
             undress_boxes=True,
         )

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -236,7 +236,7 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
     Args:
         twirling_options: Twirling options.
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
-            Error eXtinction (TREX) mitigation method will be used.
+            Error eXtinction (TREX) mitigation method will be accounted for in boxing.
         inject_noise: Whether to inject noise.
 
     Returns:

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -189,7 +189,7 @@ def box_circuit(
             include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
             argument of
             :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
-            API docs for a full list of the supported values.
+            API docs for a full list of supported values.
         inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
             of gates. If ``True``, :meth:`~samplomatic.transpiler.generate_boxing_pass_manager` is
             called with arguments ``inject_noise_targets`` and ``inject_noise_strategy`` set to

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -279,13 +279,7 @@ def get_layers(
     )
     return [
         find_unique_box_instructions(
-            box_circuit(
-                circuit=pub.circuit,
-                enable_gates=pm_kwargs["enable_gates"],
-                measure_annotations=pm_kwargs["measure_annotations"],
-                twirling_strategy=pm_kwargs["twirling_strategy"],
-                inject_noise=inject_noise,
-            ),
+            box_circuit(circuit=pub.circuit, inject_noise=inject_noise, **pm_kwargs),
             normalize_annotations=None,
             undress_boxes=True,
         )

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -163,6 +163,7 @@ def resolve_precision(
 def box_circuit(
     circuit: QuantumCircuit,
     enable_gates: bool,
+    twirling_strategy: str,
     twirling_options: TwirlingOptions,
     twirl_measurements: bool = False,
     inject_noise: bool = False,
@@ -178,6 +179,10 @@ def box_circuit(
         circuit: The quantum circuit to box.
         enable_gates: Whether to group gates into boxes. This value is passed directly to the
             ``enable_gates`` argument of
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+        twirling_strategy: The strategy for whether and how twirling boxes are extended to
+            include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
+            argument of
             :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
         twirling_options: Twirling options.
         twirl_measurements: Whether to twirl measurements.
@@ -202,7 +207,7 @@ def box_circuit(
     boxing_pm = generate_boxing_pass_manager(
         enable_gates=enable_gates,
         enable_measures=True,
-        twirling_strategy=twirling_options.strategy.replace("-", "_"),
+        twirling_strategy=twirling_strategy,
         measure_annotations="all"
         if twirling_options.enable_measure or twirl_measurements
         else "change_basis",
@@ -239,6 +244,7 @@ def get_layers(
             box_circuit(
                 circuit=pub.circuit,
                 enable_gates=twirling_options.enable_gates or inject_noise,
+                twirling_strategy=twirling_options.strategy.replace("-", "_"),
                 twirling_options=twirling_options,
                 twirl_measurements=twirl_measurements,
                 inject_noise=inject_noise,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -180,15 +180,23 @@ def box_circuit(
         enable_gates: Whether to group gates into boxes. This value is passed directly to the
             ``enable_gates`` argument of
             :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
-        measure_annotations: The annotations placed on the measurement boxes when
-            ``enable_measures`` is ``True``. This value is passed directly to the
-            ``measure_annotations`` argument of
-            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+        measure_annotations: The annotations placed on the measurement boxes. The measurements
+            are grouped into boxes by default, and the value of ``measure_annotations`` passed
+            directly to the ``measure_annotations`` argument of
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
+            API docs for a full list of the supported values.
         twirling_strategy: The strategy for whether and how twirling boxes are extended to
             include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
             argument of
-            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
-        inject_noise: Whether to inject noise.
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
+            API docs for a full list of the supported values.
+        inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
+            of gates. If ``True``, :meth:`~samplomatic.transpiler.generate_boxing_pass_manager` is
+            called with arguments ``inject_noise_targets`` and ``inject_noise_strategy`` set to
+            ``"gates"`` and ``"uniform_modification"`` respectively; if ``False``, it is called with
+            ``inject_noise_targets`` and ``inject_noise_strategy`` set to ``"none"`` and
+            ``"no_modification"``. See the Samplomatic API docs for more details regarding these
+            values.
 
     Returns:
         The boxed circuit.
@@ -205,7 +213,6 @@ def box_circuit(
     prepared_circuit.barrier()
     prepared_circuit.measure(prepared_circuit.qubits, creg)
 
-    # Add boxes
     boxing_pm = generate_boxing_pass_manager(
         enable_gates=enable_gates,
         enable_measures=True,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -265,7 +265,7 @@ def get_layers(
         pubs: list of estimators pubs.
         twirling_options: Twirling options.
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
-            Error eXtinction (TREX) mitigation method will be used.
+            Error eXtinction (TREX) mitigation method will be accounted for in boxing.
         inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
             of gates.
 

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -272,13 +272,18 @@ def get_layers(
     Returns:
         Unique layers for each pub.
     """
+    pm_kwargs = options_to_boxing_pm_kwargs(
+        twirling_options,
+        measure_noise_learning,
+        inject_noise,
+    )
     return [
         find_unique_box_instructions(
             box_circuit(
                 circuit=pub.circuit,
-                **options_to_boxing_pm_kwargs(
-                    twirling_options, measure_noise_learning, inject_noise
-                ),
+                enable_gates=pm_kwargs["enable_gates"],
+                measure_annotations=pm_kwargs["measure_annotations"],
+                twirling_strategy=pm_kwargs["twirling_strategy"],
                 inject_noise=inject_noise,
             ),
             normalize_annotations=None,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -200,7 +200,7 @@ def box_circuit(
 
     # Add boxes
     boxing_pm = generate_boxing_pass_manager(
-        enable_gates=twirling_options.enable_gates or inject_noise,
+        enable_gates=enable_gates,
         enable_measures=True,
         twirling_strategy=twirling_options.strategy.replace("-", "_"),
         measure_annotations="all"
@@ -238,7 +238,7 @@ def get_layers(
         find_unique_box_instructions(
             box_circuit(
                 circuit=pub.circuit,
-                enable_gates=twirling_options.enable_gates,
+                enable_gates=twirling_options.enable_gates or inject_noise,
                 twirling_options=twirling_options,
                 twirl_measurements=twirl_measurements,
                 inject_noise=inject_noise,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from qiskit.primitives import EstimatorPub
     from samplomatic.samplex import Samplex
 
+    from ..options_models.measure_noise_learning_options import MeasureNoiseLearningOptions
     from ..options_models.twirling_options import TwirlingOptions
 
 from collections import defaultdict
@@ -165,8 +166,6 @@ def box_circuit(
     enable_gates: bool,
     measure_annotations: str,
     twirling_strategy: str,
-    twirling_options: TwirlingOptions,
-    twirl_measurements: bool = False,
     inject_noise: bool = False,
 ) -> QuantumCircuit:
     """Group the operations in the given ``circuit`` into boxes.
@@ -189,8 +188,6 @@ def box_circuit(
             include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
             argument of
             :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
-        twirling_options: Twirling options.
-        twirl_measurements: Whether to twirl measurements.
         inject_noise: Whether to inject noise.
 
     Returns:
@@ -225,7 +222,7 @@ def box_circuit(
 def get_layers(
     pubs: Sequence[EstimatorPub],
     twirling_options: TwirlingOptions,
-    twirl_measurements: bool = False,
+    measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     inject_noise: bool = False,
 ) -> list[list[CircuitInstruction]]:
     """Find unique layers of the circuit of each pub.
@@ -235,7 +232,8 @@ def get_layers(
     Args:
         pubs: list of estimators pubs.
         twirling_options: Twirling options.
-        twirl_measurements: Whether to twirl measurements.
+        measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
+            Error eXtinction (TREX) mitigation method will be used.
         inject_noise: Whether to inject noise.
 
     Returns:
@@ -247,11 +245,12 @@ def get_layers(
             box_circuit(
                 circuit=pub.circuit,
                 enable_gates=twirling_options.enable_gates or inject_noise,
-                measure_annotations="all" if twirling_options.enable_measure else "change_basis",
+                measure_annotations="all"
+                if twirling_options.enable_measure or (measure_noise_learning is not None)
+                else "change_basis",
                 twirling_strategy=twirling_options.strategy.replace("-", "_"),
-                twirling_options=twirling_options,
                 inject_noise=inject_noise,
-            ).data,
+            ),
             normalize_annotations=None,
             undress_boxes=True,
         )

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -184,7 +184,7 @@ def box_circuit(
             are grouped into boxes by default, and the value of ``measure_annotations`` passed
             directly to the ``measure_annotations`` argument of
             :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
-            API docs for a full list of the supported values.
+            API docs for a full list of supported values.
         twirling_strategy: The strategy for whether and how twirling boxes are extended to
             include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
             argument of

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -166,10 +166,12 @@ def box_circuit(
     twirl_measurements: bool = False,
     inject_noise: bool = False,
 ) -> QuantumCircuit:
-    """Box a circuit based on the given input options.
+    """Group the operations in the given ``circuit`` into boxes.
 
-    Removes the final measurement layer and adds a new measurement layer with dedicated
-    register name.
+    This function removes the final measurement layer from the given circuit and adds a new
+    measurement layer with a dedicated register name. Then, it uses the
+    :meth:`~samplomatic.transpiler.generate_boxing_pass_manager` to group the operations in a
+    circuit into boxes.
 
     Args:
         circuit: Quantum circuit to box.
@@ -178,7 +180,7 @@ def box_circuit(
         inject_noise: Whether to inject noise.
 
     Returns:
-        boxed circuit.
+        The boxed circuit.
 
     """
     # Remove any existing final measurements

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -226,6 +226,31 @@ def box_circuit(
     return boxed_circuit
 
 
+def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
+    twirling_options: TwirlingOptions,
+    measure_noise_learning: MeasureNoiseLearningOptions | None,
+    inject_noise: bool,
+):
+    """A helper to map options to kwargs for the boxing passmanager.
+
+    Args:
+        twirling_options: Twirling options.
+        measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
+            Error eXtinction (TREX) mitigation method will be used.
+        inject_noise: Whether to inject noise.
+
+    Returns:
+        Unique layers for each pub.
+    """
+    return {
+        "enable_gates": twirling_options.enable_gates or inject_noise,
+        "measure_annotations": "all"
+        if twirling_options.enable_measure or (measure_noise_learning is not None)
+        else "change_basis",
+        "twirling_strategy": twirling_options.strategy.replace("-", "_"),
+    }
+
+
 def get_layers(
     pubs: Sequence[EstimatorPub],
     twirling_options: TwirlingOptions,
@@ -241,21 +266,19 @@ def get_layers(
         twirling_options: Twirling options.
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
-        inject_noise: Whether to inject noise.
+        inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
+            of gates.
 
     Returns:
         Unique layers for each pub.
-
     """
     return [
         find_unique_box_instructions(
             box_circuit(
                 circuit=pub.circuit,
-                enable_gates=twirling_options.enable_gates or inject_noise,
-                measure_annotations="all"
-                if twirling_options.enable_measure or (measure_noise_learning is not None)
-                else "change_basis",
-                twirling_strategy=twirling_options.strategy.replace("-", "_"),
+                **options_to_boxing_pm_kwargs(
+                    twirling_options, measure_noise_learning, inject_noise
+                ),
                 inject_noise=inject_noise,
             ),
             normalize_annotations=None,

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -105,6 +105,11 @@ def prepare_zne(
     param_shapes_list = []
     item_id = []
 
+    pm_kwargs = options_to_boxing_pm_kwargs(
+        twirling_options,
+        measure_noise_learning,
+        inject_noise=False,
+    )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
@@ -131,9 +136,10 @@ def prepare_zne(
 
             boxed_circuit = box_circuit(
                 circuit=folded_circuit,
-                **options_to_boxing_pm_kwargs(
-                    twirling_options, measure_noise_learning, inject_noise=False
-                ),
+                enable_gates=pm_kwargs["enable_gates"],
+                measure_annotations=pm_kwargs["measure_annotations"],
+                twirling_strategy=pm_kwargs["twirling_strategy"],
+                inject_noise=False,
             )
 
             # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -134,13 +134,7 @@ def prepare_zne(
             folding_pm = PassManager([GateFolding(noise_factor, folding_method)])
             folded_circuit = folding_pm.run(pub.circuit)
 
-            boxed_circuit = box_circuit(
-                circuit=folded_circuit,
-                enable_gates=pm_kwargs["enable_gates"],
-                measure_annotations=pm_kwargs["measure_annotations"],
-                twirling_strategy=pm_kwargs["twirling_strategy"],
-                inject_noise=False,
-            )
+            boxed_circuit = box_circuit(circuit=folded_circuit, inject_noise=False, **pm_kwargs)
 
             # Build the template and the samplex
             template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -36,7 +36,12 @@ from ...options_models.zne_options import ZNE_DEFAULT_NOISE_FACTORS
 from ...quantum_program import QuantumProgram
 from ...quantum_program.quantum_program import SamplexItem
 from ..trex_utils import create_trex_calibration_circuit
-from ..utils import box_circuit, compute_samplex_arguments, make_samplex_arguments
+from ..utils import (
+    box_circuit,
+    compute_samplex_arguments,
+    make_samplex_arguments,
+    options_to_boxing_pm_kwargs,
+)
 from .gate_folding import GateFolding
 
 logger = logging.getLogger(__name__)
@@ -126,11 +131,9 @@ def prepare_zne(
 
             boxed_circuit = box_circuit(
                 circuit=folded_circuit,
-                enable_gates=twirling_options.enable_gates,
-                measure_annotations="all"
-                if twirling_options.enable_measure or (measure_noise_learning is not None)
-                else "change_basis",
-                twirling_strategy=twirling_options.strategy.replace("-", "_"),
+                **options_to_boxing_pm_kwargs(
+                    twirling_options, measure_noise_learning, inject_noise=False
+                ),
             )
 
             # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -127,6 +127,7 @@ def prepare_zne(
             boxed_circuit = box_circuit(
                 circuit=folded_circuit,
                 enable_gates=twirling_options.enable_gates,
+                twirling_strategy=twirling_options.strategy.replace("-", "_"),
                 twirling_options=twirling_options,
                 twirl_measurements=measure_noise_learning is not None,
             )

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -124,9 +124,13 @@ def prepare_zne(
             folding_pm = PassManager([GateFolding(noise_factor, folding_method)])
             folded_circuit = folding_pm.run(pub.circuit)
 
+            twirl_measurements = measure_noise_learning is not None
             boxed_circuit = box_circuit(
                 circuit=folded_circuit,
                 enable_gates=twirling_options.enable_gates,
+                measure_annotations="all"
+                if twirling_options.enable_measure or twirl_measurements
+                else "change_basis",
                 twirling_strategy=twirling_options.strategy.replace("-", "_"),
                 twirling_options=twirling_options,
                 twirl_measurements=measure_noise_learning is not None,

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -120,12 +120,15 @@ def prepare_zne(
                 case _:
                     # This should never happen due to prior validation
                     folding_method = "random"
-            folded_circuit = PassManager([GateFolding(noise_factor, folding_method)]).run(
-                pub.circuit
-            )
+
+            folding_pm = PassManager([GateFolding(noise_factor, folding_method)])
+            folded_circuit = folding_pm.run(pub.circuit)
 
             boxed_circuit = box_circuit(
-                folded_circuit, twirling_options, measure_noise_learning is not None
+                circuit=folded_circuit,
+                enable_gates=twirling_options.enable_gates,
+                twirling_options=twirling_options,
+                twirl_measurements=measure_noise_learning is not None,
             )
 
             # Build the template and the samplex

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -124,16 +124,13 @@ def prepare_zne(
             folding_pm = PassManager([GateFolding(noise_factor, folding_method)])
             folded_circuit = folding_pm.run(pub.circuit)
 
-            twirl_measurements = measure_noise_learning is not None
             boxed_circuit = box_circuit(
                 circuit=folded_circuit,
                 enable_gates=twirling_options.enable_gates,
                 measure_annotations="all"
-                if twirling_options.enable_measure or twirl_measurements
+                if twirling_options.enable_measure or (measure_noise_learning is not None)
                 else "change_basis",
                 twirling_strategy=twirling_options.strategy.replace("-", "_"),
-                twirling_options=twirling_options,
-                twirl_measurements=measure_noise_learning is not None,
             )
 
             # Build the template and the samplex

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -14,12 +14,15 @@
 
 import unittest
 
-from qiskit import QuantumCircuit
+from ddt import data, ddt
+from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import Pauli, SparsePauliOp
+from samplomatic.transpiler import generate_boxing_pass_manager
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.utils import (
+    box_circuit,
     get_pauli_basis,
     pauli_to_ints,
     resolve_precision,
@@ -143,3 +146,127 @@ class TestResolvePrecision(unittest.TestCase):
             resolve_precision([pub1, pub2, pub3])
 
         self.assertIn("same precision", str(context.exception))
+
+
+@ddt
+class TestBoxCircuit(unittest.TestCase):
+    """Tests for ``box_circuit``."""
+
+    @data(True, False)
+    def test_enable_gates(self, enable_gates):
+        """Tests for the ``enable_gates`` argument."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(1, 2)
+        circuit.measure_all()
+
+        circuit_out = box_circuit(
+            circuit,
+            enable_gates=enable_gates,
+            measure_annotations="all",
+            twirling_strategy="all",
+        )
+
+        pm = generate_boxing_pass_manager(
+            enable_gates=enable_gates,
+            measure_annotations="all",
+            twirling_strategy="all",
+        )
+
+        expected_circuit = circuit.remove_final_measurements(inplace=False)
+        expected_circuit.add_register(ClassicalRegister(expected_circuit.num_qubits, "_meas"))
+        expected_circuit.measure(range(3), range(3))
+        expected_circuit = pm.run(expected_circuit)
+
+        self.assertEqual(circuit_out, expected_circuit)
+
+    @data("change_basis", "all")
+    def test_measure_annotations(self, measure_annotations):
+        """Tests for the ``measure_annotations`` argument."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(1, 2)
+        circuit.measure_all()
+
+        circuit_out = box_circuit(
+            circuit,
+            enable_gates=True,
+            measure_annotations=measure_annotations,
+            twirling_strategy="all",
+        )
+
+        pm = generate_boxing_pass_manager(
+            enable_gates=True,
+            measure_annotations=measure_annotations,
+            twirling_strategy="all",
+        )
+
+        expected_circuit = circuit.remove_final_measurements(inplace=False)
+        expected_circuit.add_register(ClassicalRegister(expected_circuit.num_qubits, "_meas"))
+        expected_circuit.measure(range(3), range(3))
+        expected_circuit = pm.run(expected_circuit)
+
+        self.assertEqual(circuit_out, expected_circuit)
+
+    @data("active", "active_accum", "active_circuit", "all")
+    def test_twirling_strategy(self, twirling_strategy):
+        """Tests for the ``twirling_strategy`` argument."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(1, 2)
+        circuit.measure_all()
+
+        circuit_out = box_circuit(
+            circuit,
+            enable_gates=True,
+            measure_annotations="all",
+            twirling_strategy=twirling_strategy,
+        )
+
+        pm = generate_boxing_pass_manager(
+            enable_gates=True,
+            measure_annotations="all",
+            twirling_strategy=twirling_strategy,
+        )
+
+        expected_circuit = circuit.remove_final_measurements(inplace=False)
+        expected_circuit.add_register(ClassicalRegister(expected_circuit.num_qubits, "_meas"))
+        expected_circuit.measure(range(3), range(3))
+        expected_circuit = pm.run(expected_circuit)
+
+        self.assertEqual(circuit_out, expected_circuit)
+
+    @data(True, False)
+    def test_inject_noise(self, inject_noise):
+        """Tests for the ``inject_noise`` argument."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(1, 2)
+        circuit.measure_all()
+
+        circuit_out = box_circuit(
+            circuit,
+            enable_gates=True,
+            measure_annotations="all",
+            twirling_strategy="all",
+            inject_noise=inject_noise,
+        )
+
+        pm = generate_boxing_pass_manager(
+            enable_gates=True,
+            measure_annotations="all",
+            twirling_strategy="all",
+            inject_noise_targets="gates" if inject_noise else "none",
+            inject_noise_strategy="uniform_modification" if inject_noise else "no_modification",
+        )
+
+        expected_circuit = circuit.remove_final_measurements(inplace=False)
+        expected_circuit.add_register(ClassicalRegister(expected_circuit.num_qubits, "_meas"))
+        expected_circuit.measure(range(3), range(3))
+        expected_circuit = pm.run(expected_circuit)
+
+        self.assertEqual(circuit_out, expected_circuit)


### PR DESCRIPTION
### Summary
The function (central, used by multiple `prepare` functions) is currently untested.

This PR adds tests and improves the documentation, clarifying how it uses the samplomatic passmanager behind the scenes. In addition, it consolidates how it's used by the various `prepare` functions and by `get_layers`, ensuring that all of these functions consume the options in the same way.

Fixes #2966 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
