### PR TITLE
Fix misleading constraint-validator names in NoiseLearnerOptions

### DIFF
--- a/qiskit_ibm_runtime/options/noise_learner_options.py
+++ b/qiskit_ibm_runtime/options/noise_learner_options.py
@@ -114,8 +114,8 @@ class NoiseLearnerOptions(OptionsV2):
     These options are subject to change without notification, and stability is not guaranteed.
     """
 
-    _gt0 = make_constraint_validator("max_layers_to_learn", ge=0)  # type: ignore[arg-type]
-    _ge0 = make_constraint_validator(
+    _ge0 = make_constraint_validator("max_layers_to_learn", ge=0)  # type: ignore[arg-type]
+    _ge1 = make_constraint_validator(
         "shots_per_randomization",
         "num_randomizations",
         ge=1,  # type: ignore[arg-type]


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Issue: https://github.com/Qiskit/qiskit-ibm-runtime/issues/2971
Fix misleading constraint-validator attribute names in `NoiseLearnerOptions`.

The two private constraint validators were named after the wrong constraint due to a copy-paste:

- `_gt0` enforced `ge=0` on `max_layers_to_learn`
- `_ge0` enforced `ge=1` on `shots_per_randomization` / `num_randomizations`

### Details and comments

Everywhere else in the `options` package the validator attribute name encodes its constraint (`_gt0` → `gt=0`, `_ge0` → `ge=0`, `_ge1` → `ge=1`), and the parallel `LayerNoiseLearningOptions` uses `_ge0` / `_ge1` for these exact same fields. This PR renames them to `_ge0` / `_ge1` to match.

This is a naming-only change; the enforced constraints (`ge=0` and `ge=1`) are unchanged, so no release note is needed. `test/unit/test_options.py` still passes and the constraints remain enforced (`max_layers_to_learn=0` accepted; `-1`, and `num_randomizations` / `shots_per_randomization` of `0` rejected).

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: Gemini
- [ ] I used the following tool to generate or modify code:
