### PR TITLE
Fix typos in docstrings

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -250,7 +250,7 @@ def compute_samplex_arguments(
            be measured for each subset, applying broadcasting rules to params and observables.
         2. It replaces the observables in that map with the minimal set of Pauli basis that
            can be used to measure all such observables.
-        3. It flattens the map into two 1D arrays of equal lenght, containing the subsets of
+        3. It flattens the map into two 1D arrays of equal length, containing the subsets of
            parameters and basis changing gates respectively. When a subset of parameter maps
            to more than one basis changing gate, the flattened array contains multiple copies
            of it.

--- a/qiskit_ibm_runtime/models/backend_configuration.py
+++ b/qiskit_ibm_runtime/models/backend_configuration.py
@@ -43,7 +43,7 @@ class GateConfig:
         qasm_def: definition of this gate in terms of OpenQASM 2 primitives U and CX.
         coupling_map: An optional coupling map for the gate. In the form of a list of lists of
             integers representing the qubit groupings which are coupled by this gate.
-        latency_map: An optional map of latency for the gate. In the the form of a list of
+        latency_map: An optional map of latency for the gate. In the form of a list of
             lists of integers of either 0 or 1 representing an array of dimension
             len(coupling_map) X n_registers that specifies the register latency
             (1: fast, 0: slow) conditional operations on the gate.

--- a/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py
@@ -326,7 +326,7 @@ class DynamicCircuitInstructionDurations(InstructionDurations):
     def _get_odd_cycle_correction(self) -> int:
         """Determine the amount of the odd cycle correction to apply.
 
-        For devices with short gates with odd lenghts we add an extra 16dt to the measurement.
+        For devices with short gates with odd lengths we add an extra 16dt to the measurement.
 
         TODO: Eliminate the need for this correction
         """


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Issue: https://github.com/Qiskit/qiskit-ibm-runtime/issues/2972
Fix three small typos in docstrings (text-only, no behavior change):

- `transpiler/passes/scheduling/utils.py`: "odd lenghts" → "odd lengths"
- `models/backend_configuration.py`: "In the the form of" → "In the form of"
- `executor_estimator/utils.py`: "equal lenght" → "equal length"

### Details and comments

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
