### PR TITLE
Allow measurement level "both"

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/quantum_program.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program.py
@@ -228,7 +228,7 @@ class QuantumProgram:
         shots: int,
         items: Iterable[QuantumProgramItem] | None = None,
         noise_maps: dict[str, PauliLindbladMap] | None = None,
-        meas_level: Literal["classified", "kerneled", "avg_kerneled"] = "classified",
+        meas_level: Literal["classified", "kerneled", "avg_kerneled", "both"] = "classified",
         passthrough_data: DataTree | None = None,
     ):
         self.shots = shots


### PR DESCRIPTION
### Summary

`QuantumProgram`'s attribute `meas_level` is now allowed to have value `both`, whose meaning is both `classified` and `kerneled` measurements in the same result.

### Details and comments

In draft until the server supports this new feature.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
