### PR TITLE
Add optional `persist` argument to `FakeBackendV2.refresh()` method

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
@@ -83,6 +83,11 @@ class FakeNighthawk(fake_backend.FakeBackendV2):
 
         super().__init__(*args, **kwargs)
 
-    def refresh(self, service: QiskitRuntimeService, use_fractional_gates: bool = False) -> None:
+    def refresh(
+        self,
+        service: QiskitRuntimeService,
+        use_fractional_gates: bool = False,
+        use_temp_dir: bool = False,
+    ) -> None:
         """Retrieve the newest backend configuration and refresh the current backend target."""
         raise NotImplementedError("fake_nighthawk does not have calibration data to pull.")

--- a/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
@@ -87,7 +87,7 @@ class FakeNighthawk(fake_backend.FakeBackendV2):
         self,
         service: QiskitRuntimeService,
         use_fractional_gates: bool = False,
-        use_temp_dir: bool = False,
+        persist: bool = True,
     ) -> None:
         """Retrieve the newest backend configuration and refresh the current backend target."""
         raise NotImplementedError("fake_nighthawk does not have calibration data to pull.")

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 import warnings
 from typing import TYPE_CHECKING, Any
 
@@ -43,11 +44,6 @@ if TYPE_CHECKING:
     from ..qiskit_runtime_service import QiskitRuntimeService
 
 logger = logging.getLogger(__name__)
-
-# User-writable directory where refreshed fake backend data is cached. Updates are
-# stored here instead of inside the package installation (e.g. ``site-packages``),
-# which is often read-only and should not be modified at runtime.
-_LOCAL_DATA_DIR = os.path.join(os.path.expanduser("~"), ".qiskit", "fake_provider")
 
 
 class FakeBackendV2(BackendV2):
@@ -121,23 +117,8 @@ class FakeBackendV2(BackendV2):
         supported_features = self._conf_dict.get("supported_features") or []
         return "qasm3" in supported_features
 
-    def _local_data_dir(self) -> str:
-        """Return the user-writable directory where refreshed data for this backend is cached."""
-        return os.path.join(_LOCAL_DATA_DIR, self.backend_name)  # type: ignore[arg-type]
-
-    def _resolve_data_path(self, filename: str) -> str:
-        """Return the path to a data file.
-
-        A locally cached copy (written by :meth:`refresh`) in the user's home directory takes
-        precedence over the copy bundled with the package.
-        """
-        local_path = os.path.join(self._local_data_dir(), filename)
-        if os.path.exists(local_path):
-            return local_path
-        return os.path.join(self.dirname, filename)  # type: ignore[arg-type]
-
     def _load_json(self, filename: str) -> dict:
-        with open(self._resolve_data_path(filename)) as f_json:
+        with open(os.path.join(self.dirname, filename)) as f_json:  # type: ignore[arg-type]
             the_json = json.load(f_json)
         return the_json
 
@@ -389,25 +370,40 @@ class FakeBackendV2(BackendV2):
 
         return noise_model
 
-    def refresh(self, service: QiskitRuntimeService, use_fractional_gates: bool = False) -> None:
+    def refresh(
+        self,
+        service: QiskitRuntimeService,
+        use_fractional_gates: bool = False,
+        use_temp_dir: bool = False,
+    ) -> None:
         """Update the data files from its real counterpart.
 
-        This method pulls the latest backend data from its real counterpart and writes it to a
-        user-writable cache directory:
+        This method pulls the latest backend data files from their real counterpart and,
+        by default (``use_temp_dir=False``), overwrites the corresponding files in the local
+        installation:
 
-        *  ``~/.qiskit/fake_provider/{backend_name}/conf_{backend_name}.json``
-        *  ``~/.qiskit/fake_provider/{backend_name}/props_{backend_name}.json``
+        *  ``../fake_provider/backends/{backend_name}/conf_{backend_name}.json``
+        *  ``../fake_provider/backends/{backend_name}/props_{backend_name}.json``
 
-        The cached files take precedence over the copies bundled with the package and persist
-        through sessions, so the backend stays updated until the cache is manually removed.
-        Writing to ``~/.qiskit`` rather than the package installation means refreshing works even
-        when ``qiskit-ibm-runtime`` is installed in a read-only location (e.g. ``site-packages``)
-        and avoids modifying the installed package itself.
+        The new data files will persist through sessions so the files will stay updated unless they
+        are manually reverted locally or when ``qiskit-ibm-runtime`` is upgraded or reinstalled.
+
+        Overwriting the installed data files fails, however, when the package is installed in a
+        read-only location (e.g. a system-wide ``site-packages`` directory). In that case, or
+        whenever modifying the installed package is undesirable, pass ``use_temp_dir=True`` to write
+        the refreshed data to a temporary directory instead. The backend is still updated for the
+        current session, but the changes are not persisted to disk and are lost once the backend is
+        garbage collected or the process exits.
 
         Args:
             service: A :class:`QiskitRuntimeService` instance
             use_fractional_gates: Set True to allow for the backends to include
                 fractional gates.
+            use_temp_dir: If ``False`` (default), the refreshed data files overwrite the copies
+                bundled with the installed package so the update persists across sessions. If
+                ``True``, the data is written to a temporary directory instead, which allows
+                :meth:`refresh` to succeed even when the package is installed in a read-only
+                location, at the cost of the update not persisting between sessions.
 
         Raises:
             ValueError: if the provided service is a non-QiskitRuntimeService instance.
@@ -437,16 +433,26 @@ class FakeBackendV2(BackendV2):
             updated_config = real_config.to_dict()
             updated_config["backend_name"] = self.backend_name
 
-            local_dir = self._local_data_dir()
-            os.makedirs(local_dir, exist_ok=True)
+            if not use_temp_dir:
+                target_dir = self.dirname
+            else:
+                # Write to a temporary directory so that refresh() succeeds even when the
+                # package is installed in a read-only location. Keep a reference to the
+                # directory on the instance so it lives as long as the backend and is cleaned
+                # up automatically when the backend is garbage collected. Point ``dirname`` at
+                # it so subsequent data loads use the refreshed files.
+                self._tmp_data_dir = tempfile.TemporaryDirectory(  # pylint: disable=attribute-defined-outside-init
+                    prefix="qiskit_fake_backend_"
+                )
+                target_dir = self.dirname = self._tmp_data_dir.name
 
             if real_config:
-                config_path = os.path.join(local_dir, self.conf_filename)  # type: ignore[arg-type]
+                config_path = os.path.join(target_dir, self.conf_filename)  # type: ignore[arg-type]
                 with open(config_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_config.to_dict(), cls=BackendEncoder))
 
             if real_props:
-                props_path = os.path.join(local_dir, self.props_filename)  # type: ignore[arg-type]
+                props_path = os.path.join(target_dir, self.props_filename)  # type: ignore[arg-type]
                 with open(props_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_props.to_dict(), cls=BackendEncoder))
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -44,6 +44,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# User-writable directory where refreshed fake backend data is cached. Updates are
+# stored here instead of inside the package installation (e.g. ``site-packages``),
+# which is often read-only and should not be modified at runtime.
+_LOCAL_DATA_DIR = os.path.join(os.path.expanduser("~"), ".qiskit", "fake_provider")
+
 
 class FakeBackendV2(BackendV2):
     """A fake backend class for testing and noisy simulation using real backend snapshots."""
@@ -116,8 +121,23 @@ class FakeBackendV2(BackendV2):
         supported_features = self._conf_dict.get("supported_features") or []
         return "qasm3" in supported_features
 
+    def _local_data_dir(self) -> str:
+        """Return the user-writable directory where refreshed data for this backend is cached."""
+        return os.path.join(_LOCAL_DATA_DIR, self.backend_name)  # type: ignore[arg-type]
+
+    def _resolve_data_path(self, filename: str) -> str:
+        """Return the path to a data file.
+
+        A locally cached copy (written by :meth:`refresh`) in the user's home directory takes
+        precedence over the copy bundled with the package.
+        """
+        local_path = os.path.join(self._local_data_dir(), filename)
+        if os.path.exists(local_path):
+            return local_path
+        return os.path.join(self.dirname, filename)  # type: ignore[arg-type]
+
     def _load_json(self, filename: str) -> dict:
-        with open(os.path.join(self.dirname, filename)) as f_json:
+        with open(self._resolve_data_path(filename)) as f_json:
             the_json = json.load(f_json)
         return the_json
 
@@ -372,15 +392,17 @@ class FakeBackendV2(BackendV2):
     def refresh(self, service: QiskitRuntimeService, use_fractional_gates: bool = False) -> None:
         """Update the data files from its real counterpart.
 
-        This method pulls the latest backend data files from their real counterpart and
-        overwrites the corresponding files in the local installation:
+        This method pulls the latest backend data from its real counterpart and writes it to a
+        user-writable cache directory:
 
-        *  ``../fake_provider/backends/{backend_name}/conf_{backend_name}.json``
-        *  ``../fake_provider/backends/{backend_name}/defs_{backend_name}.json``
-        *  ``../fake_provider/backends/{backend_name}/props_{backend_name}.json``
+        *  ``~/.qiskit/fake_provider/{backend_name}/conf_{backend_name}.json``
+        *  ``~/.qiskit/fake_provider/{backend_name}/props_{backend_name}.json``
 
-        The new data files will persist through sessions so the files will stay updated unless they
-        are manually reverted locally or when ``qiskit-ibm-runtime`` is upgraded or reinstalled.
+        The cached files take precedence over the copies bundled with the package and persist
+        through sessions, so the backend stays updated until the cache is manually removed.
+        Writing to ``~/.qiskit`` rather than the package installation means refreshing works even
+        when ``qiskit-ibm-runtime`` is installed in a read-only location (e.g. ``site-packages``)
+        and avoids modifying the installed package itself.
 
         Args:
             service: A :class:`QiskitRuntimeService` instance
@@ -415,13 +437,16 @@ class FakeBackendV2(BackendV2):
             updated_config = real_config.to_dict()
             updated_config["backend_name"] = self.backend_name
 
+            local_dir = self._local_data_dir()
+            os.makedirs(local_dir, exist_ok=True)
+
             if real_config:
-                config_path = os.path.join(self.dirname, self.conf_filename)
+                config_path = os.path.join(local_dir, self.conf_filename)  # type: ignore[arg-type]
                 with open(config_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_config.to_dict(), cls=BackendEncoder))
 
             if real_props:
-                props_path = os.path.join(self.dirname, self.props_filename)
+                props_path = os.path.join(local_dir, self.props_filename)  # type: ignore[arg-type]
                 with open(props_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_props.to_dict(), cls=BackendEncoder))
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -50,10 +50,10 @@ class FakeBackendV2(BackendV2):
     """A fake backend class for testing and noisy simulation using real backend snapshots."""
 
     # directory and file names for real backend snapshots.
-    dirname: str | None = None
-    conf_filename: str | None = None
-    props_filename: str | None = None
-    backend_name: str | None = None
+    dirname: str
+    conf_filename: str
+    props_filename: str
+    backend_name: str
 
     # When ``refresh(persist=False)`` is called, the refreshed snapshots are written to this
     # temporary directory instead of ``dirname``. While it is set, snapshot data is read from here,
@@ -107,14 +107,14 @@ class FakeBackendV2(BackendV2):
     def _get_conf_dict_from_json(self) -> dict:
         if not self.conf_filename:
             return None
-        conf_dict = self._load_json(self.conf_filename)  # type: ignore
+        conf_dict = self._load_json(self.conf_filename)
         decode_backend_configuration(conf_dict)
         conf_dict["backend_name"] = self.backend_name
         return conf_dict
 
     def _set_props_dict_from_json(self) -> None:
         if self.props_filename:
-            props_dict = self._load_json(self.props_filename)  # type: ignore
+            props_dict = self._load_json(self.props_filename)
             properties_from_server_data(props_dict)
             self._props_dict = props_dict
 
@@ -124,7 +124,7 @@ class FakeBackendV2(BackendV2):
 
     def _load_json(self, filename: str) -> dict:
         dirname = self._tmp_data_dir.name if self._tmp_data_dir else self.dirname
-        with open(os.path.join(dirname, filename)) as f_json:  # type: ignore[arg-type]
+        with open(os.path.join(dirname, filename)) as f_json:
             the_json = json.load(f_json)
         return the_json
 
@@ -425,7 +425,7 @@ class FakeBackendV2(BackendV2):
                 "properties and settings."
             )
 
-        prod_name = self.backend_name.replace("fake", "ibm")  # type: ignore[attr-defined]
+        prod_name = self.backend_name.replace("fake", "ibm")
         try:
             backends = service.backends(prod_name, use_fractional_gates=use_fractional_gates)
             real_backend = backends[0]
@@ -460,12 +460,12 @@ class FakeBackendV2(BackendV2):
                 snapshots_dir = self._tmp_data_dir.name
 
             if real_config:
-                config_path = os.path.join(snapshots_dir, self.conf_filename)  # type: ignore[arg-type]
+                config_path = os.path.join(snapshots_dir, self.conf_filename)
                 with open(config_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_config.to_dict(), cls=BackendEncoder))
 
             if real_props:
-                props_path = os.path.join(snapshots_dir, self.props_filename)  # type: ignore[arg-type]
+                props_path = os.path.join(snapshots_dir, self.props_filename)
                 with open(props_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_props.to_dict(), cls=BackendEncoder))
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -55,6 +55,11 @@ class FakeBackendV2(BackendV2):
     props_filename: str | None = None
     backend_name: str | None = None
 
+    # When ``refresh(use_temp_dir=True)`` is called, the refreshed snapshots are written to this
+    # temporary directory instead of ``dirname``. While it is set, snapshot data is read from here,
+    # so ``dirname`` is left untouched and keeps pointing at the files bundled with the package.
+    _tmp_data_dir: tempfile.TemporaryDirectory | None = None
+
     def __init__(self) -> None:
         self._conf_dict = self._get_conf_dict_from_json()
         self._props_dict: dict | None = None
@@ -118,7 +123,8 @@ class FakeBackendV2(BackendV2):
         return "qasm3" in supported_features
 
     def _load_json(self, filename: str) -> dict:
-        with open(os.path.join(self.dirname, filename)) as f_json:  # type: ignore[arg-type]
+        dirname = self._tmp_data_dir.name if self._tmp_data_dir else self.dirname
+        with open(os.path.join(dirname, filename)) as f_json:  # type: ignore[arg-type]
             the_json = json.load(f_json)
         return the_json
 
@@ -433,18 +439,25 @@ class FakeBackendV2(BackendV2):
             updated_config = real_config.to_dict()
             updated_config["backend_name"] = self.backend_name
 
+            # Explicitly clean up and drop any temporary directory left over from a previous
+            # ``use_temp_dir=True`` call so it is removed now rather than being left to garbage
+            # collection, and ``_load_json`` reads the files written by this call.
+            if self._tmp_data_dir is not None:
+                self._tmp_data_dir.cleanup()
+                self._tmp_data_dir = None
+
             if not use_temp_dir:
+                # Persist to (and read back from) the bundled ``dirname``.
                 target_dir = self.dirname
             else:
                 # Write to a temporary directory so that refresh() succeeds even when the
                 # package is installed in a read-only location. Keep a reference to the
                 # directory on the instance so it lives as long as the backend and is cleaned
-                # up automatically when the backend is garbage collected. Point ``dirname`` at
-                # it so subsequent data loads use the refreshed files.
-                self._tmp_data_dir = tempfile.TemporaryDirectory(  # pylint: disable=attribute-defined-outside-init
-                    prefix="qiskit_fake_backend_"
-                )
-                target_dir = self.dirname = self._tmp_data_dir.name
+                # up automatically when the backend is garbage collected. ``_load_json`` reads
+                # from ``_tmp_data_dir`` while it is set, so ``dirname`` is left unchanged and a
+                # later ``refresh()`` without ``use_temp_dir`` still targets the bundled files.
+                self._tmp_data_dir = tempfile.TemporaryDirectory(prefix="qiskit_fake_backend_")
+                target_dir = self._tmp_data_dir.name
 
             if real_config:
                 config_path = os.path.join(target_dir, self.conf_filename)  # type: ignore[arg-type]

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -448,9 +448,7 @@ class FakeBackendV2(BackendV2):
             updated_config = real_config.to_dict()
             updated_config["backend_name"] = self.backend_name
 
-            # Explicitly clean up and drop any temporary directory left over from a previous
-            # ``persist=False`` call so it is removed now rather than being left to garbage
-            # collection, and ``_load_json`` reads the files written by this call.
+            # Clean up and drop any temporary directory left over from a previous call.
             if self._tmp_data_dir is not None:
                 self._tmp_data_dir.cleanup()
                 self._tmp_data_dir = None
@@ -459,12 +457,7 @@ class FakeBackendV2(BackendV2):
                 # Persist to (and read back from) the bundled ``dirname``.
                 snapshots_dir = self.dirname
             else:
-                # Write to a temporary directory so that refresh() succeeds even when the
-                # package is installed in a read-only location. Keep a reference to the
-                # directory on the instance so it lives as long as the backend and is cleaned
-                # up automatically when the backend is garbage collected. ``_load_json`` reads
-                # from ``_tmp_data_dir`` while it is set, so ``dirname`` is left unchanged and a
-                # later ``refresh()`` with ``persist=True`` still targets the bundled files.
+                # Use a temporary directory instead of persisting to ``dirname``.
                 self._tmp_data_dir = tempfile.TemporaryDirectory(prefix="qiskit_fake_backend_")
                 snapshots_dir = self._tmp_data_dir.name
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -55,7 +55,7 @@ class FakeBackendV2(BackendV2):
     props_filename: str | None = None
     backend_name: str | None = None
 
-    # When ``refresh(use_temp_dir=True)`` is called, the refreshed snapshots are written to this
+    # When ``refresh(persist=False)`` is called, the refreshed snapshots are written to this
     # temporary directory instead of ``dirname``. While it is set, snapshot data is read from here,
     # so ``dirname`` is left untouched and keeps pointing at the files bundled with the package.
     _tmp_data_dir: tempfile.TemporaryDirectory | None = None
@@ -380,12 +380,12 @@ class FakeBackendV2(BackendV2):
         self,
         service: QiskitRuntimeService,
         use_fractional_gates: bool = False,
-        use_temp_dir: bool = False,
+        persist: bool = True,
     ) -> None:
         """Update the data files from its real counterpart.
 
         This method pulls the latest backend data files from their real counterpart and,
-        by default (``use_temp_dir=False``), overwrites the corresponding files in the local
+        by default (``persist=True``), overwrites the corresponding files in the local
         installation:
 
         *  ``../fake_provider/backends/{backend_name}/conf_{backend_name}.json``
@@ -396,7 +396,7 @@ class FakeBackendV2(BackendV2):
 
         Overwriting the installed data files fails, however, when the package is installed in a
         read-only location (e.g. a system-wide ``site-packages`` directory). In that case, or
-        whenever modifying the installed package is undesirable, pass ``use_temp_dir=True`` to write
+        whenever modifying the installed package is undesirable, pass ``persist=False`` to write
         the refreshed data to a temporary directory instead. The backend is still updated for the
         current session, but the changes are not persisted to disk and are lost once the backend is
         garbage collected or the process exits.
@@ -405,9 +405,9 @@ class FakeBackendV2(BackendV2):
             service: A :class:`QiskitRuntimeService` instance
             use_fractional_gates: Set True to allow for the backends to include
                 fractional gates.
-            use_temp_dir: If ``False`` (default), the refreshed data files overwrite the copies
+            persist: If ``True`` (default), the refreshed data files overwrite the copies
                 bundled with the installed package so the update persists across sessions. If
-                ``True``, the data is written to a temporary directory instead, which allows
+                ``False``, the data is written to a temporary directory instead, which allows
                 :meth:`refresh` to succeed even when the package is installed in a read-only
                 location, at the cost of the update not persisting between sessions.
 
@@ -440,13 +440,13 @@ class FakeBackendV2(BackendV2):
             updated_config["backend_name"] = self.backend_name
 
             # Explicitly clean up and drop any temporary directory left over from a previous
-            # ``use_temp_dir=True`` call so it is removed now rather than being left to garbage
+            # ``persist=False`` call so it is removed now rather than being left to garbage
             # collection, and ``_load_json`` reads the files written by this call.
             if self._tmp_data_dir is not None:
                 self._tmp_data_dir.cleanup()
                 self._tmp_data_dir = None
 
-            if not use_temp_dir:
+            if persist:
                 # Persist to (and read back from) the bundled ``dirname``.
                 snapshots_dir = self.dirname
             else:
@@ -455,7 +455,7 @@ class FakeBackendV2(BackendV2):
                 # directory on the instance so it lives as long as the backend and is cleaned
                 # up automatically when the backend is garbage collected. ``_load_json`` reads
                 # from ``_tmp_data_dir`` while it is set, so ``dirname`` is left unchanged and a
-                # later ``refresh()`` without ``use_temp_dir`` still targets the bundled files.
+                # later ``refresh()`` with ``persist=True`` still targets the bundled files.
                 self._tmp_data_dir = tempfile.TemporaryDirectory(prefix="qiskit_fake_backend_")
                 snapshots_dir = self._tmp_data_dir.name
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -448,7 +448,7 @@ class FakeBackendV2(BackendV2):
 
             if not use_temp_dir:
                 # Persist to (and read back from) the bundled ``dirname``.
-                target_dir = self.dirname
+                snapshots_dir = self.dirname
             else:
                 # Write to a temporary directory so that refresh() succeeds even when the
                 # package is installed in a read-only location. Keep a reference to the
@@ -457,15 +457,15 @@ class FakeBackendV2(BackendV2):
                 # from ``_tmp_data_dir`` while it is set, so ``dirname`` is left unchanged and a
                 # later ``refresh()`` without ``use_temp_dir`` still targets the bundled files.
                 self._tmp_data_dir = tempfile.TemporaryDirectory(prefix="qiskit_fake_backend_")
-                target_dir = self._tmp_data_dir.name
+                snapshots_dir = self._tmp_data_dir.name
 
             if real_config:
-                config_path = os.path.join(target_dir, self.conf_filename)  # type: ignore[arg-type]
+                config_path = os.path.join(snapshots_dir, self.conf_filename)  # type: ignore[arg-type]
                 with open(config_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_config.to_dict(), cls=BackendEncoder))
 
             if real_props:
-                props_path = os.path.join(target_dir, self.props_filename)  # type: ignore[arg-type]
+                props_path = os.path.join(snapshots_dir, self.props_filename)  # type: ignore[arg-type]
                 with open(props_path, "w", encoding="utf-8") as fd:
                     fd.write(json.dumps(real_props.to_dict(), cls=BackendEncoder))
 

--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -49,16 +49,25 @@ logger = logging.getLogger(__name__)
 class FakeBackendV2(BackendV2):
     """A fake backend class for testing and noisy simulation using real backend snapshots."""
 
-    # directory and file names for real backend snapshots.
     dirname: str
-    conf_filename: str
-    props_filename: str
-    backend_name: str
+    """Directory for the real backend snapshots."""
 
-    # When ``refresh(persist=False)`` is called, the refreshed snapshots are written to this
-    # temporary directory instead of ``dirname``. While it is set, snapshot data is read from here,
-    # so ``dirname`` is left untouched and keeps pointing at the files bundled with the package.
+    conf_filename: str
+    """Filename for the backend configuration."""
+
+    props_filename: str
+    """Filename for the backend properties."""
+
+    backend_name: str
+    """Name of the backend."""
+
     _tmp_data_dir: tempfile.TemporaryDirectory | None = None
+    """Temporary directory for the real backend snapshots, if using ``refresh(persist=False)``.
+
+    If set, snapshot data is read from this temporary directory instead of ``dirname``. This
+    attribute stores a reference to ensure the temporary directory is bound to the lifetime of
+    the instance (cleaned up automatically when the backend is garbage collected).
+    """
 
     def __init__(self) -> None:
         self._conf_dict = self._get_conf_dict_from_json()

--- a/release-notes/unreleased/2977.bug.rst
+++ b/release-notes/unreleased/2977.bug.rst
@@ -1,8 +1,0 @@
-Fixed :meth:`.FakeBackendV2.refresh` so that it no longer attempts to overwrite the data
-files bundled with the installed package. Previously the refreshed configuration and
-properties were written back into the package installation directory (e.g.
-``site-packages``), which fails with a ``PermissionError`` when the package is installed
-system-wide and is generally undesirable. The refreshed data is now cached under
-``~/.qiskit/fake_provider/{backend_name}/`` instead, and the fake backends load these
-cached files in preference to the bundled ones. Refreshed data still persists across
-sessions and can be reverted by deleting the cached directory.

--- a/release-notes/unreleased/2977.bug.rst
+++ b/release-notes/unreleased/2977.bug.rst
@@ -1,0 +1,8 @@
+Fixed :meth:`.FakeBackendV2.refresh` so that it no longer attempts to overwrite the data
+files bundled with the installed package. Previously the refreshed configuration and
+properties were written back into the package installation directory (e.g.
+``site-packages``), which fails with a ``PermissionError`` when the package is installed
+system-wide and is generally undesirable. The refreshed data is now cached under
+``~/.qiskit/fake_provider/{backend_name}/`` instead, and the fake backends load these
+cached files in preference to the bundled ones. Refreshed data still persists across
+sessions and can be reverted by deleting the cached directory.

--- a/release-notes/unreleased/2977.feat.rst
+++ b/release-notes/unreleased/2977.feat.rst
@@ -1,0 +1,8 @@
+Added an optional ``use_temp_dir`` parameter to :meth:`.FakeBackendV2.refresh`. By default
+(``use_temp_dir=False``) the behavior is unchanged: the refreshed configuration and properties
+overwrite the data files bundled with the installed package so the update persists across
+sessions. Passing ``use_temp_dir=True`` instead writes the refreshed data to a temporary
+directory, which allows :meth:`~.FakeBackendV2.refresh` to succeed even when the package is
+installed in a read-only location (e.g. a system-wide ``site-packages`` directory) where
+overwriting the bundled files would otherwise raise a ``PermissionError``. In that mode the
+backend is updated for the current session only and the changes are not persisted to disk.

--- a/release-notes/unreleased/2977.feat.rst
+++ b/release-notes/unreleased/2977.feat.rst
@@ -1,7 +1,7 @@
-Added an optional ``use_temp_dir`` parameter to :meth:`.FakeBackendV2.refresh`. By default
-(``use_temp_dir=False``) the behavior is unchanged: the refreshed configuration and properties
+Added an optional ``persist`` parameter to :meth:`.FakeBackendV2.refresh`. By default
+(``persist=True``) the behavior is unchanged: the refreshed configuration and properties
 overwrite the data files bundled with the installed package so the update persists across
-sessions. Passing ``use_temp_dir=True`` instead writes the refreshed data to a temporary
+sessions. Passing ``persist=False`` instead writes the refreshed data to a temporary
 directory, which allows :meth:`~.FakeBackendV2.refresh` to succeed even when the package is
 installed in a read-only location (e.g. a system-wide ``site-packages`` directory) where
 overwriting the bundled files would otherwise raise a ``PermissionError``. In that mode the

--- a/test/unit/fake_provider/test_fake_backends.py
+++ b/test/unit/fake_provider/test_fake_backends.py
@@ -27,8 +27,8 @@ from qiskit_ibm_runtime.fake_provider import (
     FakeAthensV2,
     FakePerth,
     FakeProviderForBackendV2,
+    fake_backend,
 )
-from qiskit_ibm_runtime.fake_provider import fake_backend
 
 from ...ibm_test_case import IBMTestCase
 
@@ -98,9 +98,7 @@ class FakeBackendDataCacheTest(IBMTestCase):
     def test_resolve_data_path_without_cache_uses_bundled(self):
         """Without a cached copy, data files resolve to the bundled package location."""
         with tempfile.TemporaryDirectory() as tmp:
-            with mock.patch.object(
-                fake_backend, "_LOCAL_DATA_DIR", os.path.join(tmp, "fp")
-            ):
+            with mock.patch.object(fake_backend, "_LOCAL_DATA_DIR", os.path.join(tmp, "fp")):
                 backend = FakeAthensV2()
                 self.assertEqual(
                     backend._resolve_data_path(backend.conf_filename),
@@ -131,9 +129,7 @@ class FakeBackendDataCacheTest(IBMTestCase):
                     cached_backend._resolve_data_path(cached_backend.conf_filename),
                     os.path.join(local_dir, cached_backend.conf_filename),
                 )
-                self.assertEqual(
-                    cached_backend._conf_dict["backend_version"], "9.9.9-cached"
-                )
+                self.assertEqual(cached_backend._conf_dict["backend_version"], "9.9.9-cached")
 
     def test_refresh_writes_to_local_cache_not_package(self):
         """refresh() writes data to the local cache dir and leaves the package files untouched."""
@@ -169,12 +165,8 @@ class FakeBackendDataCacheTest(IBMTestCase):
                 self.assertIn("has been updated", "".join(logs.output))
 
                 local_dir = os.path.join(local_root, backend.backend_name)
-                self.assertTrue(
-                    os.path.exists(os.path.join(local_dir, backend.conf_filename))
-                )
-                self.assertTrue(
-                    os.path.exists(os.path.join(local_dir, backend.props_filename))
-                )
+                self.assertTrue(os.path.exists(os.path.join(local_dir, backend.conf_filename)))
+                self.assertTrue(os.path.exists(os.path.join(local_dir, backend.props_filename)))
 
                 # The bundled package files must remain untouched.
                 self.assertEqual(os.stat(pkg_conf).st_mtime_ns, pkg_conf_before[1])

--- a/test/unit/fake_provider/test_fake_backends.py
+++ b/test/unit/fake_provider/test_fake_backends.py
@@ -12,9 +12,9 @@
 
 """Test of generated fake backends."""
 
-import json
 import math
 import os
+import shutil
 import tempfile
 import unittest
 from unittest import mock
@@ -87,87 +87,94 @@ class FakeBackendsTest(IBMTestCase):
         self.assertEqual(backend.name, backend_name)
 
 
-class FakeBackendDataCacheTest(IBMTestCase):
-    """Tests for the local caching of refreshed fake backend data.
+class FakeBackendRefreshTest(IBMTestCase):
+    """Tests for the ``use_temp_dir`` behavior of :meth:`.FakeBackendV2.refresh`.
 
-    These guard against regressing the behavior where :meth:`.FakeBackendV2.refresh` must not
-    write into the installed package directory (often read-only, e.g. ``site-packages``) and
-    instead caches data under the user-writable ``~/.qiskit`` directory.
+    With ``use_temp_dir=True`` the refreshed data must be written to a temporary directory rather
+    than into the installed package directory (often read-only, e.g. ``site-packages``), so that
+    :meth:`~.FakeBackendV2.refresh` succeeds without modifying the installed package.
     """
 
-    def test_resolve_data_path_without_cache_uses_bundled(self):
-        """Without a cached copy, data files resolve to the bundled package location."""
-        with tempfile.TemporaryDirectory() as tmp:
-            with mock.patch.object(fake_backend, "_LOCAL_DATA_DIR", os.path.join(tmp, "fp")):
-                backend = FakeAthensV2()
-                self.assertEqual(
-                    backend._resolve_data_path(backend.conf_filename),
-                    os.path.join(backend.dirname, backend.conf_filename),
-                )
+    def _make_refresh_service(self, backend):
+        """Build a mocked service that returns ``backend``'s own bundled data as the real data.
 
-    def test_cached_data_takes_precedence_over_bundled(self):
-        """A cached copy in the local data dir is loaded in preference to the bundled file."""
-        with tempfile.TemporaryDirectory() as tmp:
-            local_root = os.path.join(tmp, "fp")
-            with mock.patch.object(fake_backend, "_LOCAL_DATA_DIR", local_root):
-                backend = FakeAthensV2()
-                conf = backend._load_json(backend.conf_filename)
-                conf["backend_version"] = "9.9.9-cached"
+        This lets ``refresh`` run without any network access. A distinctive ``backend_version`` is
+        injected so tests can assert the in-session update actually took effect.
+        """
+        real_config = backend.configuration()
+        real_config.backend_version = "9.9.9-refreshed"
+        real_props = backend.properties()
 
-                local_dir = os.path.join(local_root, backend.backend_name)
-                os.makedirs(local_dir)
-                with open(
-                    os.path.join(local_dir, backend.conf_filename),
-                    "w",
-                    encoding="utf-8",
-                ) as fd:
-                    json.dump(conf, fd)
+        fake_real_backend = mock.MagicMock()
+        fake_real_backend.properties.return_value = real_props
+        service = mock.MagicMock(spec=QiskitRuntimeService)
+        service.backends.return_value = [fake_real_backend]
 
-                # A freshly constructed backend should pick up the cached data.
-                cached_backend = FakeAthensV2()
-                self.assertEqual(
-                    cached_backend._resolve_data_path(cached_backend.conf_filename),
-                    os.path.join(local_dir, cached_backend.conf_filename),
-                )
-                self.assertEqual(cached_backend._conf_dict["backend_version"], "9.9.9-cached")
+        patcher = mock.patch.object(
+            fake_backend, "configuration_from_server_data", return_value=real_config
+        )
+        return service, patcher
 
-    def test_refresh_writes_to_local_cache_not_package(self):
-        """refresh() writes data to the local cache dir and leaves the package files untouched."""
-        with tempfile.TemporaryDirectory() as tmp:
-            local_root = os.path.join(tmp, "fp")
-            with mock.patch.object(fake_backend, "_LOCAL_DATA_DIR", local_root):
-                backend = FakeAthensV2()
+    def test_refresh_use_temp_dir_leaves_package_untouched(self):
+        """``use_temp_dir=True`` writes to a temp dir and never modifies the bundled files."""
+        backend = FakeAthensV2()
+        pkg_dir = backend.dirname
+        pkg_conf = os.path.join(pkg_dir, backend.conf_filename)
+        pkg_props = os.path.join(pkg_dir, backend.props_filename)
+        pkg_conf_mtime = os.stat(pkg_conf).st_mtime_ns
+        pkg_props_mtime = os.stat(pkg_props).st_mtime_ns
 
-                # Reuse the bundled data to stand in for the "real" backend response, so the test
-                # needs no network access.
-                real_config = backend.configuration()
-                real_props = backend.properties()
+        service, patcher = self._make_refresh_service(backend)
+        with patcher:
+            with self.assertLogs("qiskit_ibm_runtime", level="INFO") as logs:
+                backend.refresh(service, use_temp_dir=True)
 
-                # Snapshot the bundled files so we can assert they are never modified.
-                pkg_conf = os.path.join(backend.dirname, backend.conf_filename)
-                pkg_props = os.path.join(backend.dirname, backend.props_filename)
-                pkg_conf_before = (pkg_conf, os.stat(pkg_conf).st_mtime_ns)
-                pkg_props_before = (pkg_props, os.stat(pkg_props).st_mtime_ns)
+        self.assertIn("has been updated", "".join(logs.output))
 
-                fake_real_backend = mock.MagicMock()
-                fake_real_backend.properties.return_value = real_props
-                service = mock.MagicMock(spec=QiskitRuntimeService)
-                service.backends.return_value = [fake_real_backend]
+        # ``dirname`` now points at a temporary directory holding the refreshed files.
+        self.assertNotEqual(backend.dirname, pkg_dir)
+        self.assertEqual(backend.dirname, backend._tmp_data_dir.name)
+        self.assertTrue(
+            os.path.exists(os.path.join(backend.dirname, backend.conf_filename))
+        )
+        self.assertTrue(
+            os.path.exists(os.path.join(backend.dirname, backend.props_filename))
+        )
 
-                with mock.patch.object(
-                    fake_backend,
-                    "configuration_from_server_data",
-                    return_value=real_config,
-                ):
-                    with self.assertLogs("qiskit_ibm_runtime", level="INFO") as logs:
-                        backend.refresh(service)
+        # The backend was updated in-session.
+        self.assertEqual(backend._conf_dict["backend_version"], "9.9.9-refreshed")
 
-                self.assertIn("has been updated", "".join(logs.output))
+        # The bundled package files must remain untouched.
+        self.assertEqual(os.stat(pkg_conf).st_mtime_ns, pkg_conf_mtime)
+        self.assertEqual(os.stat(pkg_props).st_mtime_ns, pkg_props_mtime)
 
-                local_dir = os.path.join(local_root, backend.backend_name)
-                self.assertTrue(os.path.exists(os.path.join(local_dir, backend.conf_filename)))
-                self.assertTrue(os.path.exists(os.path.join(local_dir, backend.props_filename)))
+    def test_refresh_default_writes_in_place(self):
+        """The default (``use_temp_dir=False``) writes back into ``dirname`` without a temp dir.
 
-                # The bundled package files must remain untouched.
-                self.assertEqual(os.stat(pkg_conf).st_mtime_ns, pkg_conf_before[1])
-                self.assertEqual(os.stat(pkg_props).st_mtime_ns, pkg_props_before[1])
+        ``dirname`` is redirected to a writable copy of the bundled data so the test never touches
+        the real installed package files.
+        """
+        backend = FakeAthensV2()
+        with tempfile.TemporaryDirectory() as data_dir:
+            shutil.copy(os.path.join(backend.dirname, backend.conf_filename), data_dir)
+            shutil.copy(os.path.join(backend.dirname, backend.props_filename), data_dir)
+            backend.dirname = data_dir
+
+            service, patcher = self._make_refresh_service(backend)
+            with patcher:
+                with self.assertLogs("qiskit_ibm_runtime", level="INFO") as logs:
+                    backend.refresh(service)
+
+            self.assertIn("has been updated", "".join(logs.output))
+
+            # No temporary directory is created and ``dirname`` is unchanged.
+            self.assertEqual(backend.dirname, data_dir)
+            self.assertFalse(hasattr(backend, "_tmp_data_dir"))
+
+            # The in-place data file was overwritten with the refreshed data, and a freshly
+            # constructed backend pointed at the same directory picks up the update.
+            reloaded = FakeAthensV2()
+            reloaded.dirname = data_dir
+            reloaded._conf_dict = reloaded._get_conf_dict_from_json()
+            self.assertEqual(reloaded._conf_dict["backend_version"], "9.9.9-refreshed")
+            self.assertEqual(backend._conf_dict["backend_version"], "9.9.9-refreshed")

--- a/test/unit/fake_provider/test_fake_backends.py
+++ b/test/unit/fake_provider/test_fake_backends.py
@@ -12,14 +12,23 @@
 
 """Test of generated fake backends."""
 
+import json
 import math
+import os
+import tempfile
 import unittest
+from unittest import mock
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit.utils import optionals
 
-from qiskit_ibm_runtime import SamplerV2
-from qiskit_ibm_runtime.fake_provider import FakeAthensV2, FakePerth, FakeProviderForBackendV2
+from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2
+from qiskit_ibm_runtime.fake_provider import (
+    FakeAthensV2,
+    FakePerth,
+    FakeProviderForBackendV2,
+)
+from qiskit_ibm_runtime.fake_provider import fake_backend
 
 from ...ibm_test_case import IBMTestCase
 
@@ -76,3 +85,97 @@ class FakeBackendsTest(IBMTestCase):
         backend_name = "fake_jakarta"
         backend = provider.backend(backend_name)
         self.assertEqual(backend.name, backend_name)
+
+
+class FakeBackendDataCacheTest(IBMTestCase):
+    """Tests for the local caching of refreshed fake backend data.
+
+    These guard against regressing the behavior where :meth:`.FakeBackendV2.refresh` must not
+    write into the installed package directory (often read-only, e.g. ``site-packages``) and
+    instead caches data under the user-writable ``~/.qiskit`` directory.
+    """
+
+    def test_resolve_data_path_without_cache_uses_bundled(self):
+        """Without a cached copy, data files resolve to the bundled package location."""
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(
+                fake_backend, "_LOCAL_DATA_DIR", os.path.join(tmp, "fp")
+            ):
+                backend = FakeAthensV2()
+                self.assertEqual(
+                    backend._resolve_data_path(backend.conf_filename),
+                    os.path.join(backend.dirname, backend.conf_filename),
+                )
+
+    def test_cached_data_takes_precedence_over_bundled(self):
+        """A cached copy in the local data dir is loaded in preference to the bundled file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            local_root = os.path.join(tmp, "fp")
+            with mock.patch.object(fake_backend, "_LOCAL_DATA_DIR", local_root):
+                backend = FakeAthensV2()
+                conf = backend._load_json(backend.conf_filename)
+                conf["backend_version"] = "9.9.9-cached"
+
+                local_dir = os.path.join(local_root, backend.backend_name)
+                os.makedirs(local_dir)
+                with open(
+                    os.path.join(local_dir, backend.conf_filename),
+                    "w",
+                    encoding="utf-8",
+                ) as fd:
+                    json.dump(conf, fd)
+
+                # A freshly constructed backend should pick up the cached data.
+                cached_backend = FakeAthensV2()
+                self.assertEqual(
+                    cached_backend._resolve_data_path(cached_backend.conf_filename),
+                    os.path.join(local_dir, cached_backend.conf_filename),
+                )
+                self.assertEqual(
+                    cached_backend._conf_dict["backend_version"], "9.9.9-cached"
+                )
+
+    def test_refresh_writes_to_local_cache_not_package(self):
+        """refresh() writes data to the local cache dir and leaves the package files untouched."""
+        with tempfile.TemporaryDirectory() as tmp:
+            local_root = os.path.join(tmp, "fp")
+            with mock.patch.object(fake_backend, "_LOCAL_DATA_DIR", local_root):
+                backend = FakeAthensV2()
+
+                # Reuse the bundled data to stand in for the "real" backend response, so the test
+                # needs no network access.
+                real_config = backend.configuration()
+                real_props = backend.properties()
+
+                # Snapshot the bundled files so we can assert they are never modified.
+                pkg_conf = os.path.join(backend.dirname, backend.conf_filename)
+                pkg_props = os.path.join(backend.dirname, backend.props_filename)
+                pkg_conf_before = (pkg_conf, os.stat(pkg_conf).st_mtime_ns)
+                pkg_props_before = (pkg_props, os.stat(pkg_props).st_mtime_ns)
+
+                fake_real_backend = mock.MagicMock()
+                fake_real_backend.properties.return_value = real_props
+                service = mock.MagicMock(spec=QiskitRuntimeService)
+                service.backends.return_value = [fake_real_backend]
+
+                with mock.patch.object(
+                    fake_backend,
+                    "configuration_from_server_data",
+                    return_value=real_config,
+                ):
+                    with self.assertLogs("qiskit_ibm_runtime", level="INFO") as logs:
+                        backend.refresh(service)
+
+                self.assertIn("has been updated", "".join(logs.output))
+
+                local_dir = os.path.join(local_root, backend.backend_name)
+                self.assertTrue(
+                    os.path.exists(os.path.join(local_dir, backend.conf_filename))
+                )
+                self.assertTrue(
+                    os.path.exists(os.path.join(local_dir, backend.props_filename))
+                )
+
+                # The bundled package files must remain untouched.
+                self.assertEqual(os.stat(pkg_conf).st_mtime_ns, pkg_conf_before[1])
+                self.assertEqual(os.stat(pkg_props).st_mtime_ns, pkg_props_before[1])

--- a/test/unit/fake_provider/test_fake_backends.py
+++ b/test/unit/fake_provider/test_fake_backends.py
@@ -134,12 +134,8 @@ class FakeBackendRefreshTest(IBMTestCase):
         # ``dirname`` now points at a temporary directory holding the refreshed files.
         self.assertNotEqual(backend.dirname, pkg_dir)
         self.assertEqual(backend.dirname, backend._tmp_data_dir.name)
-        self.assertTrue(
-            os.path.exists(os.path.join(backend.dirname, backend.conf_filename))
-        )
-        self.assertTrue(
-            os.path.exists(os.path.join(backend.dirname, backend.props_filename))
-        )
+        self.assertTrue(os.path.exists(os.path.join(backend.dirname, backend.conf_filename)))
+        self.assertTrue(os.path.exists(os.path.join(backend.dirname, backend.props_filename)))
 
         # The backend was updated in-session.
         self.assertEqual(backend._conf_dict["backend_version"], "9.9.9-refreshed")

--- a/test/unit/fake_provider/test_fake_backends.py
+++ b/test/unit/fake_provider/test_fake_backends.py
@@ -131,11 +131,14 @@ class FakeBackendRefreshTest(IBMTestCase):
 
         self.assertIn("has been updated", "".join(logs.output))
 
-        # ``dirname`` now points at a temporary directory holding the refreshed files.
-        self.assertNotEqual(backend.dirname, pkg_dir)
-        self.assertEqual(backend.dirname, backend._tmp_data_dir.name)
-        self.assertTrue(os.path.exists(os.path.join(backend.dirname, backend.conf_filename)))
-        self.assertTrue(os.path.exists(os.path.join(backend.dirname, backend.props_filename)))
+        # ``dirname`` is left untouched (still pointing at the bundled files).
+        # The refreshed data is written to and read from the temporary directory instead.
+        self.assertEqual(backend.dirname, pkg_dir)
+        self.assertIsNotNone(backend._tmp_data_dir)
+        tmp_dir = backend._tmp_data_dir.name
+        self.assertNotEqual(tmp_dir, pkg_dir)
+        self.assertTrue(os.path.exists(os.path.join(tmp_dir, backend.conf_filename)))
+        self.assertTrue(os.path.exists(os.path.join(tmp_dir, backend.props_filename)))
 
         # The backend was updated in-session.
         self.assertEqual(backend._conf_dict["backend_version"], "9.9.9-refreshed")
@@ -143,6 +146,32 @@ class FakeBackendRefreshTest(IBMTestCase):
         # The bundled package files must remain untouched.
         self.assertEqual(os.stat(pkg_conf).st_mtime_ns, pkg_conf_mtime)
         self.assertEqual(os.stat(pkg_props).st_mtime_ns, pkg_props_mtime)
+
+    def test_refresh_in_place_after_temp_dir_targets_bundled_files(self):
+        """A default ``refresh()`` after a ``use_temp_dir=True`` one still targets ``dirname``.
+
+        Since ``use_temp_dir=True`` no longer overwrites ``dirname``, a subsequent in-place
+        ``refresh()`` writes back into the (writable copy of the) bundled directory as expected.
+        """
+        backend = FakeAthensV2()
+        with tempfile.TemporaryDirectory() as data_dir:
+            shutil.copy(os.path.join(backend.dirname, backend.conf_filename), data_dir)
+            shutil.copy(os.path.join(backend.dirname, backend.props_filename), data_dir)
+            backend.dirname = data_dir
+
+            service, patcher = self._make_refresh_service(backend)
+            with patcher:
+                backend.refresh(service, use_temp_dir=True)
+                self.assertIsNotNone(backend._tmp_data_dir)
+
+                backend.refresh(service)
+
+            # The in-place refresh writes back into ``dirname`` (the writable copy).
+            self.assertEqual(backend.dirname, data_dir)
+            reloaded = FakeAthensV2()
+            reloaded.dirname = data_dir
+            reloaded._conf_dict = reloaded._get_conf_dict_from_json()
+            self.assertEqual(reloaded._conf_dict["backend_version"], "9.9.9-refreshed")
 
     def test_refresh_default_writes_in_place(self):
         """The default (``use_temp_dir=False``) writes back into ``dirname`` without a temp dir.
@@ -165,7 +194,7 @@ class FakeBackendRefreshTest(IBMTestCase):
 
             # No temporary directory is created and ``dirname`` is unchanged.
             self.assertEqual(backend.dirname, data_dir)
-            self.assertFalse(hasattr(backend, "_tmp_data_dir"))
+            self.assertIsNone(backend._tmp_data_dir)
 
             # The in-place data file was overwritten with the refreshed data, and a freshly
             # constructed backend pointed at the same directory picks up the update.

--- a/test/unit/fake_provider/test_fake_backends.py
+++ b/test/unit/fake_provider/test_fake_backends.py
@@ -88,9 +88,9 @@ class FakeBackendsTest(IBMTestCase):
 
 
 class FakeBackendRefreshTest(IBMTestCase):
-    """Tests for the ``use_temp_dir`` behavior of :meth:`.FakeBackendV2.refresh`.
+    """Tests for the ``persist`` behavior of :meth:`.FakeBackendV2.refresh`.
 
-    With ``use_temp_dir=True`` the refreshed data must be written to a temporary directory rather
+    With ``persist=False`` the refreshed data must be written to a temporary directory rather
     than into the installed package directory (often read-only, e.g. ``site-packages``), so that
     :meth:`~.FakeBackendV2.refresh` succeeds without modifying the installed package.
     """
@@ -115,8 +115,8 @@ class FakeBackendRefreshTest(IBMTestCase):
         )
         return service, patcher
 
-    def test_refresh_use_temp_dir_leaves_package_untouched(self):
-        """``use_temp_dir=True`` writes to a temp dir and never modifies the bundled files."""
+    def test_refresh_no_persist_leaves_package_untouched(self):
+        """``persist=False`` writes to a temp dir and never modifies the bundled files."""
         backend = FakeAthensV2()
         pkg_dir = backend.dirname
         pkg_conf = os.path.join(pkg_dir, backend.conf_filename)
@@ -127,7 +127,7 @@ class FakeBackendRefreshTest(IBMTestCase):
         service, patcher = self._make_refresh_service(backend)
         with patcher:
             with self.assertLogs("qiskit_ibm_runtime", level="INFO") as logs:
-                backend.refresh(service, use_temp_dir=True)
+                backend.refresh(service, persist=False)
 
         self.assertIn("has been updated", "".join(logs.output))
 
@@ -147,10 +147,10 @@ class FakeBackendRefreshTest(IBMTestCase):
         self.assertEqual(os.stat(pkg_conf).st_mtime_ns, pkg_conf_mtime)
         self.assertEqual(os.stat(pkg_props).st_mtime_ns, pkg_props_mtime)
 
-    def test_refresh_in_place_after_temp_dir_targets_bundled_files(self):
-        """A default ``refresh()`` after a ``use_temp_dir=True`` one still targets ``dirname``.
+    def test_refresh_persist_after_no_persist_targets_bundled_files(self):
+        """A ``persist=True`` ``refresh()`` after a ``persist=False`` one still targets ``dirname``.
 
-        Since ``use_temp_dir=True`` no longer overwrites ``dirname``, a subsequent in-place
+        Since ``persist=False`` no longer overwrites ``dirname``, a subsequent persisting
         ``refresh()`` writes back into the (writable copy of the) bundled directory as expected.
         """
         backend = FakeAthensV2()
@@ -161,7 +161,7 @@ class FakeBackendRefreshTest(IBMTestCase):
 
             service, patcher = self._make_refresh_service(backend)
             with patcher:
-                backend.refresh(service, use_temp_dir=True)
+                backend.refresh(service, persist=False)
                 self.assertIsNotNone(backend._tmp_data_dir)
 
                 backend.refresh(service)
@@ -174,7 +174,7 @@ class FakeBackendRefreshTest(IBMTestCase):
             self.assertEqual(reloaded._conf_dict["backend_version"], "9.9.9-refreshed")
 
     def test_refresh_default_writes_in_place(self):
-        """The default (``use_temp_dir=False``) writes back into ``dirname`` without a temp dir.
+        """The default (``persist=True``) writes back into ``dirname`` without a temp dir.
 
         ``dirname`` is redirected to a writable copy of the bundled data so the test never touches
         the real installed package files.


### PR DESCRIPTION
### Summary

`FakeBackendV2.refresh()` writes the updated `conf_*.json` / `props_*.json` back into the package's own directory. When the package is installed system-wide that directory is read-only (`PermissionError`), and even when writable it's bad practice to mutate files inside site-packages.

~Instead, let's keep the .json files in the `~/.qiskit` directory which is already used for storing the IBM Quantum platform credentials.~

As suggested [here](https://github.com/Qiskit/qiskit-ibm-runtime/issues/2976#issuecomment-4852615378), the new proposal leaves the default behavior unchanged, i.e., `refresh()` tries to modify the backend json files in site-packages. With ~`use_temp_dir=True`~ `persist=False`, the updated json files are stored in a temp directory. This allows to use this method in installations where the package's files are read-only or the user does not have permissions to modify those files.

### Details and comments

- I tested this change locally and in the Arch Linux package and I didn't have any issues.
- I used `os.path` instead of `pathlib.Path` because this was used elsewhere. If you want I can refactor this using `pathlib`

Fixes #2976

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Opus 4.8 for writing the unit tests
