### PR TITLE
Keep .utils.json (as deprecated, with no imports from .utils)

### DIFF
--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -1,0 +1,39 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024-2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utility functions for the runtime service."""
+
+import warnings
+
+from qiskit_ibm_runtime.json import (  # noqa: F401
+    SERVICE_MAX_SUPPORTED_QPY_VERSION,
+    LEGACY_NOISE_LEARNER_MODULE,
+    CURRENT_NOISE_LEARNER_MODULE,
+    to_base64_string,
+    _serialize_and_encode,
+    _decode_and_deserialize,
+    _deserialize_from_json,
+    _deserialize_from_settings,
+    _set_int_keys_flag,
+    _cast_strings_keys_to_int,
+    RuntimeDecoder,
+    RuntimeEncoder,
+)
+
+warnings.warn(
+    "The `qiskit_ibm_runtime.utils.json` package has been moved to `qiskit_ibm_runtime.json` as "
+    "of qiskit_ibm_runtime v0.48.0, and it will ne its only location in a future release, 3 months "
+    "or more after v0.48.0. Please adjust your imports accordingly, and note that the only public "
+    "items are `RuntimeDecoder` and `RuntimeEncoder`, which are available as top-level imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -15,23 +15,23 @@
 import warnings
 
 from qiskit_ibm_runtime.json import (  # noqa: F401
-    SERVICE_MAX_SUPPORTED_QPY_VERSION,
-    LEGACY_NOISE_LEARNER_MODULE,
     CURRENT_NOISE_LEARNER_MODULE,
-    to_base64_string,
-    _serialize_and_encode,
+    LEGACY_NOISE_LEARNER_MODULE,
+    SERVICE_MAX_SUPPORTED_QPY_VERSION,
+    RuntimeDecoder,
+    RuntimeEncoder,
+    _cast_strings_keys_to_int,
     _decode_and_deserialize,
     _deserialize_from_json,
     _deserialize_from_settings,
+    _serialize_and_encode,
     _set_int_keys_flag,
-    _cast_strings_keys_to_int,
-    RuntimeDecoder,
-    RuntimeEncoder,
+    to_base64_string,
 )
 
 warnings.warn(
     "The `qiskit_ibm_runtime.utils.json` package has been moved to `qiskit_ibm_runtime.json` as "
-    "of qiskit_ibm_runtime v0.48.0, and it will ne its only location in a future release, 3 months "
+    "of qiskit_ibm_runtime v0.48.0, and it will be its only location in a future release, 3 months "
     "or more after v0.48.0. Please adjust your imports accordingly, and note that the only public "
     "items are `RuntimeDecoder` and `RuntimeEncoder`, which are available as top-level imports.",
     DeprecationWarning,


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Even if `RuntimeDecoder` and `RuntimeEncoder` are the only public items from the `json` module (via the top-level imports, which remained unchanged in #2894), reintroduce the `qiskit_ibm_runtime.utils.json` module with all their private members as a convenience for users that might be consuming private members, easing the transition.

### Details and comments

Related to #2749, #2920

This does not provide full compatibility, as the

```python
from .json import RuntimeEncoder, RuntimeDecoder, to_base64_string
```

from `qiskit_ibm_runtime/utils/__init__.py` is not included (on purpose, as it would defeat the goal of reducing import cycles).



### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
