### PR TITLE
Improve handling of options in executor-based Estimator and Sampler

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 from qiskit.primitives.base import BaseEstimatorV2
@@ -91,8 +91,7 @@ class EstimatorV2(BaseEstimatorV2):
             for all available options.
     """
 
-    options: EstimatorOptions
-    """The options of this Estimator."""
+    _options_class: EstimatorOptions
 
     def __init__(
         self,
@@ -103,23 +102,18 @@ class EstimatorV2(BaseEstimatorV2):
 
         self._executor = Executor(mode=mode)
 
-        # Coerced to `SampEstimatorOptionslerOptions` via `__setattr__()`.
-        self.options = options if options is not None else EstimatorOptions()  # type: ignore[assignment]
+        self._options: EstimatorOptions
+        if options is None:
+            self._options = EstimatorOptions()
+        elif isinstance(options, dict):
+            self._options = EstimatorOptions(**options)
+        else:
+            self._options = options
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Set attribute ``name`` to ``value``.
-
-        Handle ``options`` as a special case, ensuring it is set to an ``EstimatorOptions``
-        instance. This is an alternative to using ``@setter``, as the setter causes issues in
-        ``ipython`` autocomplete features.
-        """
-        if name == "options":
-            if isinstance(value, dict):
-                value = EstimatorOptions(**value)
-            elif not isinstance(value, EstimatorOptions):
-                raise TypeError(f"Expected EstimatorOptions or dict, got {type(value)}")
-
-        super().__setattr__(name, value)
+    @property
+    def options(self) -> EstimatorOptions:
+        """The options in this estimator."""
+        return self._options
 
     def run(
         self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -32,7 +32,6 @@ from .utils import extract_shots_from_pubs, validate_meas_type_twirling, validat
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
-    from typing import Any
 
     from qiskit.primitives.containers.sampler_pub import SamplerPubLike
     from qiskit.providers import BackendV2
@@ -97,7 +96,7 @@ class SamplerV2(BaseSamplerV2):
             for all available options.
     """
 
-    options: SamplerOptions
+    _options_class: SamplerOptions
     """The options of this Sampler."""
 
     def __init__(
@@ -109,23 +108,18 @@ class SamplerV2(BaseSamplerV2):
 
         self._executor = Executor(mode=mode)
 
-        # Coerced to `SamplerOptions` via `__setattr__()`.
-        self.options = options if options is not None else SamplerOptions()  # type: ignore[assignment]
+        self._options: SamplerOptions
+        if options is None:
+            self._options = SamplerOptions()
+        elif isinstance(options, dict):
+            self._options = SamplerOptions(**options)
+        else:
+            self._options = options
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Set attribute ``name`` to ``value``.
-
-        Handle ``options`` as a special case, ensuring it is set to an ``SamplerOptions`` instance.
-        This is an alternative to using ``@setter``, as the setter causes issues in ``ipython``
-        autocomplete features.
-        """
-        if name == "options":
-            if isinstance(value, dict):
-                value = SamplerOptions(**value)
-            elif not isinstance(value, SamplerOptions):
-                raise TypeError(f"Expected SamplerOptions or dict, got {type(value)}")
-
-        super().__setattr__(name, value)
+    @property
+    def options(self) -> SamplerOptions:
+        """The options in this sampler."""
+        return self._options
 
     def run(self, pubs: Iterable[SamplerPubLike], *, shots: int | None = None) -> RuntimeJobV2:
         """Submit a request to the sampler primitive.

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -129,41 +129,6 @@ class TestEstimatorUsingOptions(IBMTestCase):
         self.assertIsNone(estimator.options.execution.rep_delay)
         self.assertEqual(estimator.options.environment, EnvironmentOptions())
 
-    def test_options_constructor_invalid_type(self):
-        """Test that an invalid options type raises TypeError."""
-        with self.assertRaisesRegex(TypeError, "Expected EstimatorOptions or dict"):
-            EstimatorV2(mode=get_mocked_backend(), options="invalid")
-
-    def test_setter_with_instance(self):
-        """Test setting options via the setter with an EstimatorOptions instance."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
-        new_opts = EstimatorOptions(execution=ExecutionOptions(init_qubits=False))
-        estimator.options = new_opts
-        self.assertIs(estimator.options, new_opts)
-
-    def test_setter_with_dict(self):
-        """Test setting options via the setter with a dict."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
-        estimator.options = {"execution": {"init_qubits": False}}
-        self.assertIsInstance(estimator.options, EstimatorOptions)
-        self.assertFalse(estimator.options.execution.init_qubits)
-
-    def test_setter_invalid_type(self):
-        """Test that setting options with an invalid type raises TypeError."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
-        with self.assertRaisesRegex(TypeError, "Expected EstimatorOptions or dict"):
-            estimator.options = 42
-
-    def test_setter_replaces_options(self):
-        """Test that the setter replaces (not updates) the options."""
-        estimator = EstimatorV2(
-            mode=get_mocked_backend(), options={"environment": {"log_level": "DEBUG"}}
-        )
-        estimator.options = {"execution": {"init_qubits": False}}
-        # environment should be back to defaults since we replaced, not updated
-        self.assertEqual(estimator.options.environment.log_level, "WARNING")
-        self.assertFalse(estimator.options.execution.init_qubits)
-
     def test_experimental_options_default_empty(self):
         """Test that experimental options default to empty dict."""
         estimator = EstimatorV2(mode=get_mocked_backend())
@@ -180,12 +145,6 @@ class TestEstimatorUsingOptions(IBMTestCase):
         opts = EstimatorOptions(experimental={"custom_key": "custom_value"})
         estimator = EstimatorV2(mode=get_mocked_backend(), options=opts)
         self.assertEqual(estimator.options.experimental, {"custom_key": "custom_value"})
-
-    def test_experimental_options_setter(self):
-        """Test setting experimental options via the setter."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
-        estimator.options = {"experimental": {"test": "value"}}
-        self.assertEqual(estimator.options.experimental, {"test": "value"})
 
     def test_validation_on_mutation(self):
         """Test validation errors are raised on mutation, not just construction."""

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -95,6 +95,21 @@ class TestEstimatorOptions(unittest.TestCase):
 class TestEstimatorUsingOptions(IBMTestCase):
     """Tests option setting on the ``Estimator`` class."""
 
+    def test_init_types(self):
+        """Test the various types that can be set at init time."""
+        estimator = EstimatorV2(mode=get_mocked_backend())
+        self.assertEqual(estimator.options, EstimatorOptions())
+
+        options = EstimatorOptions()
+        options.twirling.strategy = "all"
+        estimator = EstimatorV2(mode=get_mocked_backend(), options=options)
+        self.assertEqual(estimator.options, options)
+
+        estimator = EstimatorV2(
+            mode=get_mocked_backend(), options={"twirling": {"strategy": "all"}}
+        )
+        self.assertEqual(estimator.options, options)
+
     def test_default_options(self):
         """Test that default options are set when none are provided."""
         estimator = EstimatorV2(mode=get_mocked_backend())

--- a/test/unit/executor_sampler/test_sampler_v2_options.py
+++ b/test/unit/executor_sampler/test_sampler_v2_options.py
@@ -140,41 +140,6 @@ class TestSamplerUsingOptions(IBMTestCase):
         self.assertIsNone(sampler.options.execution.rep_delay)
         self.assertEqual(sampler.options.environment, SamplerEnvironmentOptions())
 
-    def test_options_constructor_invalid_type(self):
-        """Test that an invalid options type raises TypeError."""
-        with self.assertRaisesRegex(TypeError, "Expected SamplerOptions or dict"):
-            SamplerV2(mode=get_mocked_backend(), options="invalid")
-
-    def test_setter_with_instance(self):
-        """Test setting options via the setter with an SamplerOptions instance."""
-        sampler = SamplerV2(mode=get_mocked_backend())
-        new_opts = SamplerOptions(execution=SamplerExecutionOptions(init_qubits=False))
-        sampler.options = new_opts
-        self.assertIs(sampler.options, new_opts)
-
-    def test_setter_with_dict(self):
-        """Test setting options via the setter with a dict."""
-        sampler = SamplerV2(mode=get_mocked_backend())
-        sampler.options = {"execution": {"init_qubits": False}}
-        self.assertIsInstance(sampler.options, SamplerOptions)
-        self.assertFalse(sampler.options.execution.init_qubits)
-
-    def test_setter_invalid_type(self):
-        """Test that setting options with an invalid type raises TypeError."""
-        sampler = SamplerV2(mode=get_mocked_backend())
-        with self.assertRaisesRegex(TypeError, "Expected SamplerOptions or dict"):
-            sampler.options = 42
-
-    def test_setter_replaces_options(self):
-        """Test that the setter replaces (not updates) the options."""
-        sampler = SamplerV2(
-            mode=get_mocked_backend(), options={"environment": {"log_level": "DEBUG"}}
-        )
-        sampler.options = {"execution": {"init_qubits": False}}
-        # environment should be back to defaults since we replaced, not updated
-        self.assertEqual(sampler.options.environment.log_level, "WARNING")
-        self.assertFalse(sampler.options.execution.init_qubits)
-
     def test_experimental_options_default_empty(self):
         """Test that experimental options default to empty dict."""
         sampler = SamplerV2(mode=get_mocked_backend())
@@ -191,12 +156,6 @@ class TestSamplerUsingOptions(IBMTestCase):
         opts = SamplerOptions(experimental={"custom_key": "custom_value"})
         sampler = SamplerV2(mode=get_mocked_backend(), options=opts)
         self.assertEqual(sampler.options.experimental, {"custom_key": "custom_value"})
-
-    def test_experimental_options_setter(self):
-        """Test setting experimental options via the setter."""
-        sampler = SamplerV2(mode=get_mocked_backend())
-        sampler.options = {"experimental": {"test": "value"}}
-        self.assertEqual(sampler.options.experimental, {"test": "value"})
 
     def test_validation_on_mutation(self):
         """Test validation errors are raised on mutation, not just construction."""

--- a/test/unit/executor_sampler/test_sampler_v2_options.py
+++ b/test/unit/executor_sampler/test_sampler_v2_options.py
@@ -28,6 +28,19 @@ from ...ibm_test_case import IBMTestCase
 class TestSamplerOptionsToExecutorOptions(unittest.TestCase):
     """Tests for SamplerOptions.to_executor_options() method."""
 
+    def test_init_types(self):
+        """Test the various types that can be set at init time."""
+        estimator = SamplerV2(mode=get_mocked_backend())
+        self.assertEqual(estimator.options, SamplerOptions())
+
+        options = SamplerOptions()
+        options.twirling.strategy = "all"
+        estimator = SamplerV2(mode=get_mocked_backend(), options=options)
+        self.assertEqual(estimator.options, options)
+
+        estimator = SamplerV2(mode=get_mocked_backend(), options={"twirling": {"strategy": "all"}})
+        self.assertEqual(estimator.options, options)
+
     def test_default_options_mapping(self):
         """Test that default options are correctly mapped."""
         options = SamplerOptions()


### PR DESCRIPTION
### Summary
Upon initialization, the executor-based estimator and sampler accept options of type `None | dict | EstimatorOptions`. Behind-the-scenes coercion to `EstimatorOptions`/`SamplerOptions` is operated via `__setattr__`. This approach is more complex than necessary, causes issues with mypy, and unintentionally allows users to assign to `estimator.options`/`sampler.options`, which is not supported by the legacy estimator.

Closes #2989
Closes #2990

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
