### PR TITLE
Add convenience function to executor-based estimator to identify unique layers to learn

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -132,14 +132,9 @@ class EstimatorV2(BaseEstimatorV2):
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
-            twirling_options: Twirling options.
-            measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
-                Error eXtinction (TREX) mitigation method will be accounted for in boxing.
-            inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
-                of gates.
 
         Returns:
-            Unique layers for each pub.
+            The unique boxed layers found across the given PUBs.
         """
         return find_unique_layers(
             pubs,

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -139,8 +139,9 @@ class EstimatorV2(BaseEstimatorV2):
         Returns:
             The unique boxed layers found across the given PUBs.
         """
+        coerced_pubs = [EstimatorPub.coerce(pub, None) for pub in pubs]
         return find_unique_layers(
-            pubs,
+            pubs=coerced_pubs,
             twirling_options=self.options.twirling,
             measure_noise_learning=self.options.resilience.measure_noise_learning,
             inject_noise=self.options.resilience.pec_mitigation,  # TODO: Add PEA once available

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -123,7 +123,12 @@ class EstimatorV2(BaseEstimatorV2):
         super().__setattr__(name, value)
 
     def find_unique_layers(self, pubs: Iterable[EstimatorPubLike]) -> list[CircuitInstruction]:
-        """Return the list of instructions that contain unique boxes.
+        """Return the unique boxed layers found across the given PUBs.
+
+        The returned list contains one instance of each distinct boxed layer (represented as a
+        :class:`~.CircuitInstruction`) appearing in the input PUBs. This list can be passed
+        directly to the :meth:`~.qiskit_ibm_runtime.noise_learner_v3.NoiseLearner.run` method
+        for characterization, avoiding redundant learning of identical layers.
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -142,7 +142,7 @@ class EstimatorV2(BaseEstimatorV2):
             pubs,
             twirling_options=self.options.twirling,
             measure_noise_learning=self.options.resilience.measure_noise_learning,
-            inject_noise=False,  # TODO: Change after introducing PEA and PEC options
+            inject_noise=self.options.resilience.pec_mitigation,  # TODO: Add PEA once available
         )
 
     def run(

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -26,11 +26,12 @@ from ..executor import Executor
 from ..executor.dynamical_decoupling import apply_dynamical_decoupling
 from ..options_models.estimator_options import EstimatorOptions
 from .prepare import prepare
-from .utils import resolve_precision
+from .utils import find_unique_layers, resolve_precision
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from qiskit.circuit import CircuitInstruction
     from qiskit.primitives.containers.estimator_pub import EstimatorPubLike
     from qiskit.providers import BackendV2
 
@@ -120,6 +121,27 @@ class EstimatorV2(BaseEstimatorV2):
                 raise TypeError(f"Expected EstimatorOptions or dict, got {type(value)}")
 
         super().__setattr__(name, value)
+
+    def find_unique_layers(self, pubs: Iterable[EstimatorPubLike]) -> list[CircuitInstruction]:
+        """Return the list of instructions that contain unique boxes.
+
+        Args:
+            pubs: The list of PUBs to return a list of unique boxes for.
+            twirling_options: Twirling options.
+            measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
+                Error eXtinction (TREX) mitigation method will be accounted for in boxing.
+            inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
+                of gates.
+
+        Returns:
+            Unique layers for each pub.
+        """
+        return find_unique_layers(
+            pubs,
+            twirling_options=self.options.twirling,
+            measure_noise_learning=self.options.resilience.measure_noise_learning,
+            inject_noise=False,  # TODO: Change after introducing PEA and PEC options
+        )
 
     def run(
         self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -129,7 +129,7 @@ class EstimatorV2(BaseEstimatorV2):
 
         The returned list contains one instance of each distinct boxed layer (represented as a
         :class:`~.CircuitInstruction`) appearing in the input PUBs. This list can be passed
-        directly to the :meth:`~.qiskit_ibm_runtime.noise_learner_v3.NoiseLearner.run` method
+        directly to the :meth:`~.qiskit_ibm_runtime.noise_learner_v3.NoiseLearnerV3.run` method
         for characterization, avoiding redundant learning of identical layers.
 
         Args:

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -67,7 +67,7 @@ def prepare_pec(
         pec_options: The options for PEC mitigation.
         noise_model_mapping: Mapping between layer ref to a noise model to use for PEC mitigation
             method. The dict contains layers from all pubs. Assumes that the unique layers
-            used for noise learning were extracted using the ``get_layers`` method.
+            used for noise learning were extracted using the ``find_unique_layers`` method.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -67,7 +67,7 @@ def prepare_pea(
         zne_options: The options for PEA mitigation (which have the same options as ZNE).
         noise_model_mapping: Mapping between layer ref to a noise model to use for noise
             amplification. The dict contains layers from all pubs. Assumes that the unique
-            layers used for noise learning were extracted using the ``get_layers`` method.
+            layers used for noise learning were extracted using the ``find_unique_layers`` method.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -268,7 +268,7 @@ def find_unique_layers(
             of gates.
 
     Returns:
-        Unique layers for each pub.
+        Unique boxed layers found across the given PUBs.
     """
     pm_kwargs = options_to_boxing_pm_kwargs(
         twirling_options,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -257,7 +257,7 @@ def find_unique_layers(
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     inject_noise: bool = False,
 ) -> list[CircuitInstruction]:
-    """Return the list of instructions that contain unique boxes.
+    """Return the unique boxed layers found across the given PUBs.
 
     Args:
         pubs: The list of PUBs to return a list of unique boxes for.

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -280,9 +280,7 @@ def get_layers(
     )
     instructions = (box for boxed_circuit in boxed_circuits for box in boxed_circuit)
     return find_unique_box_instructions(
-        instructions,
-        normalize_annotations=None,
-        undress_boxes=True,
+        instructions=instructions, normalize_annotations=None, undress_boxes=True
     )
 
 

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -256,13 +256,11 @@ def get_layers(
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     inject_noise: bool = False,
-) -> list[list[CircuitInstruction]]:
-    """Find unique layers of the circuit of each pub.
-
-    Uses the input options to box the circuit, and find its unique layers.
+) -> list[CircuitInstruction]:
+    """Return the list of instructions that contain unique boxes.
 
     Args:
-        pubs: list of estimators pubs.
+        pubs: The list of PUBs to return a list of unique boxes for.
         twirling_options: Twirling options.
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be accounted for in boxing.
@@ -277,14 +275,15 @@ def get_layers(
         measure_noise_learning,
         inject_noise,
     )
-    return [
-        find_unique_box_instructions(
-            box_circuit(circuit=pub.circuit, inject_noise=inject_noise, **pm_kwargs),
-            normalize_annotations=None,
-            undress_boxes=True,
-        )
-        for pub in pubs
-    ]
+    boxed_circuits = (
+        box_circuit(circuit=pub.circuit, inject_noise=inject_noise, **pm_kwargs) for pub in pubs
+    )
+    instructions = (box for boxed_circuit in boxed_circuits for box in boxed_circuit)
+    return find_unique_box_instructions(
+        instructions,
+        normalize_annotations=None,
+        undress_boxes=True,
+    )
 
 
 def compute_samplex_arguments(

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -251,7 +251,7 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
     }
 
 
-def get_layers(
+def find_unique_layers(
     pubs: Sequence[EstimatorPub],
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable
 
     import numpy.typing as npt
     from qiskit import QuantumCircuit
@@ -252,7 +252,7 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
 
 
 def find_unique_layers(
-    pubs: Sequence[EstimatorPub],
+    pubs: Iterable[EstimatorPub],
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     inject_noise: bool = False,

--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -56,7 +56,7 @@ class TestPreparePeaFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
@@ -137,10 +137,9 @@ class TestPreparePeaFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub1, pub2], TwirlingOptions(), inject_noise=True)
         noise_layer_refs = []
-        for pub_layers in layers:
-            for layer in pub_layers:
-                if annot := get_annotation(layer.operation, InjectNoise):
-                    noise_layer_refs.append(annot.ref)
+        for layer in layers:
+            if annot := get_annotation(layer.operation, InjectNoise):
+                noise_layer_refs.append(annot.ref)
 
         noise_model_mapping = {
             noise_layer_refs[0]: noise_model_1,
@@ -251,7 +250,7 @@ class TestPreparePeaFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub1], TwirlingOptions(), inject_noise=True)
         noise_layer_ref_pub1 = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref_pub1 = annot.ref
 
@@ -281,7 +280,7 @@ class TestPreparePeaFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
@@ -360,7 +359,7 @@ class TestPreparePeaFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 

--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -26,7 +26,7 @@ from samplomatic.utils import get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.prepare_pea import prepare_pea
-from qiskit_ibm_runtime.executor_estimator.utils import get_layers
+from qiskit_ibm_runtime.executor_estimator.utils import find_unique_layers
 from qiskit_ibm_runtime.options_models.measure_noise_learning_options import (
     MeasureNoiseLearningOptions,
 )
@@ -54,7 +54,7 @@ class TestPreparePeaFunction(unittest.TestCase):
             [("XX", [0, 1], 0.1), ("ZZ", [0, 1], 0.05)], num_qubits=2
         )
         # find layers first to extract the layers ref
-        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -135,7 +135,7 @@ class TestPreparePeaFunction(unittest.TestCase):
         noise_model_2b = PauliLindbladMap.from_sparse_list([("ZX", [1, 2], 0.2)], num_qubits=3)
 
         # find layers first to extract the layers ref
-        layers = get_layers([pub1, pub2], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub1, pub2], TwirlingOptions(), inject_noise=True)
         noise_layer_refs = []
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -248,7 +248,7 @@ class TestPreparePeaFunction(unittest.TestCase):
         # Only provide noise model for one pub, but we have two pubs
         noise_model = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
         # find layers first to extract the layers ref
-        layers = get_layers([pub1], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub1], TwirlingOptions(), inject_noise=True)
         noise_layer_ref_pub1 = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -278,7 +278,7 @@ class TestPreparePeaFunction(unittest.TestCase):
         noise_model = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
 
         # find layers first to extract the layers ref
-        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -357,7 +357,7 @@ class TestPreparePeaFunction(unittest.TestCase):
             [("XX", [0, 1], 0.1), ("ZZ", [0, 1], 0.05)], num_qubits=2
         )
         # find layers first to extract the layers ref
-        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -27,7 +27,7 @@ from samplomatic.utils import get_annotation
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.pec.prepare_pec import prepare_pec
 from qiskit_ibm_runtime.executor_estimator.pec.utils import calculate_gamma
-from qiskit_ibm_runtime.executor_estimator.utils import get_layers
+from qiskit_ibm_runtime.executor_estimator.utils import find_unique_layers
 from qiskit_ibm_runtime.options_models.measure_noise_learning_options import (
     MeasureNoiseLearningOptions,
 )
@@ -215,7 +215,7 @@ class TestPreparePecFunction(unittest.TestCase):
             [("XX", [0, 1], 0.1), ("ZZ", [0, 1], 0.05)], num_qubits=2
         )
         # find layers first to extract the layers ref
-        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -289,7 +289,7 @@ class TestPreparePecFunction(unittest.TestCase):
         noise_model_2b = PauliLindbladMap.from_sparse_list([("ZX", [1, 2], 0.2)], num_qubits=3)
 
         # find layers first to extract the layers ref
-        layers = get_layers([pub1, pub2], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub1, pub2], TwirlingOptions(), inject_noise=True)
         noise_layer_refs = []
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -353,7 +353,7 @@ class TestPreparePecFunction(unittest.TestCase):
         max_overhead = 10
         noise_model = PauliLindbladMap.from_sparse_list([("IX", [0, 1], err_rate)], num_qubits=2)
         # find layers first to extract the layers ref
-        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -414,7 +414,7 @@ class TestPreparePecFunction(unittest.TestCase):
         # Only provide noise model for one pub, but we have two pubs
         noise_model = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
         # find layers first to extract the layers ref
-        layers = get_layers([pub1], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub1], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
@@ -441,7 +441,7 @@ class TestPreparePecFunction(unittest.TestCase):
 
         noise_model = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
         # find layers first to extract the layers ref
-        layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
+        layers = find_unique_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -217,7 +217,7 @@ class TestPreparePecFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
@@ -291,10 +291,9 @@ class TestPreparePecFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub1, pub2], TwirlingOptions(), inject_noise=True)
         noise_layer_refs = []
-        for pub_layers in layers:
-            for layer in pub_layers:
-                if annot := get_annotation(layer.operation, InjectNoise):
-                    noise_layer_refs.append(annot.ref)
+        for layer in layers:
+            if annot := get_annotation(layer.operation, InjectNoise):
+                noise_layer_refs.append(annot.ref)
 
         noise_model_mapping = {
             noise_layer_refs[0]: noise_model_1,
@@ -356,7 +355,7 @@ class TestPreparePecFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
@@ -417,7 +416,7 @@ class TestPreparePecFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub1], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
@@ -444,7 +443,7 @@ class TestPreparePecFunction(unittest.TestCase):
         # find layers first to extract the layers ref
         layers = get_layers([pub], TwirlingOptions(), inject_noise=True)
         noise_layer_ref = ""
-        for layer in layers[0]:
+        for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 


### PR DESCRIPTION
### Summary

This PR adds a function to the executor-based estimator to identify unique layers to learn, that can be passed straight to NLV3. It also flattens the output of the convenience function, to tailor it to the input required by NLV3.

Fixes #2993


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
