### PR TITLE
Fix typos in docstrings and comments

### DIFF
--- a/qiskit_ibm_runtime/visualization/embeddings.py
+++ b/qiskit_ibm_runtime/visualization/embeddings.py
@@ -91,7 +91,7 @@ def _heavy_hex_coords(
         rows: A sequence of rows, sorted from top to bottom. Rows are specified as an iterable of
             integers, where every integer represents a column index.
         row_major: Whether qubits should be labelled in row-major order (by ``x`` first and, in
-            case of a tie, by ``y``) or in colum-major order.
+            case of a tie, by ``y``) or in column-major order.
 
     Returns:
         A list of qubit coordinates, where list position corresponds with qubit index.
@@ -104,7 +104,7 @@ def _heavy_hex_coords(
         for col_idx in row:
             coordinates += [(row_idx, col_idx)]
 
-    # Sort if colum-major order is required
+    # Sort if column-major order is required
     if not row_major:
         coordinates = sorted(coordinates, key=lambda p: (p[1], p[0]))
 

--- a/test/integration/test_account.py
+++ b/test/integration/test_account.py
@@ -84,7 +84,7 @@ class TestQuantumPlatform(IBMIntegrationTestCase):
             message = logs.output[1]
             self.assertIn("Free and trial", message)
 
-        # no defualt instance and plans_preference
+        # no default instance and plans_preference
         with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
             service = QiskitRuntimeService(
                 token=self.dependencies.token,
@@ -97,7 +97,7 @@ class TestQuantumPlatform(IBMIntegrationTestCase):
             self.assertNotIn("Free and trial", message)
             self.assertIn("available account instances are", message)
 
-        # no defualt instance and region
+        # no default instance and region
         region = "us-east"
         with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
             service = QiskitRuntimeService(

--- a/test/unit/decoders/executor_sampler/test_utils.py
+++ b/test/unit/decoders/executor_sampler/test_utils.py
@@ -256,7 +256,7 @@ class TestExecutorMetadataToSamplerMetadata(unittest.TestCase):
         self.assertEqual(spans, expected_spans)
 
     def test_incorrect_pub_shapes_raises(self):
-        """Test that an error is raised when pub shapes is of incorrect lenght."""
+        """Test that an error is raised when pub shapes is of incorrect length."""
         chunk_timing = [
             ChunkSpan(
                 start=datetime(2025, 12, 30, 14, 10),

--- a/test/unit/test_execution_span.py
+++ b/test/unit/test_execution_span.py
@@ -111,12 +111,12 @@ class TestSliceSpan(IBMTestCase):
     )
     @ddt.unpack
     def test_contains_pub(self, idx, span1_expected_res, span2_expected_res):
-        """The the contains_pub method."""
+        """Test the contains_pub method."""
         self.assertEqual(self.span1.contains_pub(idx), span1_expected_res)
         self.assertEqual(self.span2.contains_pub(idx), span2_expected_res)
 
     def test_filter_by_pub(self):
-        """The the filter_by_pub method."""
+        """Test the filter_by_pub method."""
         self.assertEqual(self.span1.filter_by_pub([]), SliceSpan(self.start1, self.stop1, {}))
         self.assertEqual(self.span2.filter_by_pub([]), SliceSpan(self.start2, self.stop2, {}))
 
@@ -210,12 +210,12 @@ class TestDoubleSliceSpan(IBMTestCase):
     )
     @ddt.unpack
     def test_contains_pub(self, idx, span1_expected_res, span2_expected_res):
-        """The the contains_pub method."""
+        """Test the contains_pub method."""
         self.assertEqual(self.span1.contains_pub(idx), span1_expected_res)
         self.assertEqual(self.span2.contains_pub(idx), span2_expected_res)
 
     def test_filter_by_pub(self):
-        """The the filter_by_pub method."""
+        """Test the filter_by_pub method."""
         self.assertEqual(self.span1.filter_by_pub([]), DoubleSliceSpan(self.start1, self.stop1, {}))
         self.assertEqual(self.span2.filter_by_pub([]), DoubleSliceSpan(self.start2, self.stop2, {}))
 
@@ -337,12 +337,12 @@ class TestTwirledSliceSpan(IBMTestCase):
     )
     @ddt.unpack
     def test_contains_pub(self, idx, span1_expected_res, span2_expected_res):
-        """The the contains_pub method."""
+        """Test the contains_pub method."""
         self.assertEqual(self.span1.contains_pub(idx), span1_expected_res)
         self.assertEqual(self.span2.contains_pub(idx), span2_expected_res)
 
     def test_filter_by_pub(self):
-        """The the filter_by_pub method."""
+        """Test the filter_by_pub method."""
         self.assertEqual(
             self.span1.filter_by_pub([]), TwirledSliceSpan(self.start1, self.stop1, {})
         )
@@ -392,7 +392,7 @@ class TestExecutionSpans(IBMTestCase):
         self.assertEqual(self.spans.duration, 8.5)
 
     def test_filter_by_pub(self):
-        """The the filter_by_pub method."""
+        """Test the filter_by_pub method."""
         self.assertEqual(
             self.spans.filter_by_pub([]),
             ExecutionSpans(

--- a/test/unit/transpiler/passes/scheduling/test_scheduler.py
+++ b/test/unit/transpiler/passes/scheduling/test_scheduler.py
@@ -3385,7 +3385,7 @@ class TestALAPSchedulingAndPaddingPass(IBMTestCase):
     def test_scheduling_nonuniform_durations(self, use_target):
         """Test scheduling uses the instruction durations correctly.
 
-        Test that scheduling withing control flow blocks uses the instruction durations on the
+        Test that scheduling within control flow blocks uses the instruction durations on the
         correct qubit indices.
         """
         backend = FakeJakartaV2()

--- a/test/utils.py
+++ b/test/utils.py
@@ -450,7 +450,7 @@ def transpile_pubs(in_pubs, backend, program):
 
 
 def remap_observables(observables, isa_circuit):
-    """Remap observables based on input cirucit."""
+    """Remap observables based on input circuit."""
 
     def _convert_paul_or_str(_obs):
         if isinstance(_obs, str):


### PR DESCRIPTION
### Summary

Correct several misspellings in test docstrings, comments, and one
visualization source file. Documentation-only changes with no effect on
behavior.

### Details and comments

Fixed the following typos:

- `qiskit_ibm_runtime/visualization/embeddings.py`: "colum" → "column" (column-major order)
- `test/integration/test_account.py`: "defualt" → "default"
- `test/unit/decoders/executor_sampler/test_utils.py`: "lenght" → "length"
- `test/unit/test_execution_span.py`: "The the" → "Test the" (docstrings)
- `test/unit/transpiler/passes/scheduling/test_scheduler.py`: "withing" → "within"
- `test/utils.py`: "cirucit" → "circuit"


Fixes #

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:


I don't think it's necessary to open an issue for this PR, but I can create one if needed.