### PR TITLE
Allow adding `add_tags` argument to the boxing pass manager used by the executor-based estimator

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -53,6 +53,7 @@ def prepare_pec(
     pec_options: PecOptions,
     noise_model_mapping: dict[str, PauliLindbladMap],
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
+    add_tags: bool = False,
 ) -> QuantumProgram:
     """Convert estimator PUBs to a quantum program with PEC mitigation.
 
@@ -68,6 +69,7 @@ def prepare_pec(
         noise_model_mapping: Mapping between layer ref to a noise model to use for PEC mitigation
             method. The dict contains layers from all pubs. Assumes that the unique layers
             used for noise learning were extracted using the ``get_layers`` method.
+        add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,
@@ -105,6 +107,7 @@ def prepare_pec(
         twirling_options,
         measure_noise_learning,
         inject_noise=True,
+        add_tags=add_tags,
     )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -112,7 +112,7 @@ def prepare_pec(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        boxed_circuit = box_circuit(circuit=pub.circuit, inject_noise=True, **pm_kwargs)
+        boxed_circuit = box_circuit(circuit=pub.circuit, **pm_kwargs)
 
         # Build the template and the samplex
         template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -70,6 +70,10 @@ def prepare_pec(
             method. The dict contains layers from all pubs. Assumes that the unique layers
             used for noise learning were extracted using the ``get_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
+            ``False`` will cause no tags to be added (will pass the "none" value to the relevant
+            attribute), while ``True`` will cause tags with the twirled boxes hash to be added
+            (using the "unique_box" value of the relevant attribute). These tags can help
+            injecting noise in simulators.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -47,6 +47,7 @@ def prepare(
     twirling_options: TwirlingOptions,
     shots: int,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
+    add_tags: bool = False,
 ) -> QuantumProgram:
     """Convert estimator PUBs to a quantum program.
 
@@ -58,6 +59,7 @@ def prepare(
             and twirling is on.
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
+        add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,
@@ -89,6 +91,7 @@ def prepare(
         twirling_options,
         measure_noise_learning,
         inject_noise=False,
+        add_tags=add_tags,
     )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -96,7 +96,7 @@ def prepare(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        boxed_circuit = box_circuit(circuit=pub.circuit, inject_noise=False, **pm_kwargs)
+        boxed_circuit = box_circuit(circuit=pub.circuit, **pm_kwargs)
 
         # Build the template and the samplex
         template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -60,6 +60,10 @@ def prepare(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
+            ``False`` will cause no tags to be added (will pass the "none" value to the relevant
+            attribute), while ``True`` will cause tags with the twirled boxes hash to be added
+            (using the "unique_box" value of the relevant attribute). These tags can help
+            injecting noise in simulators.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -53,6 +53,7 @@ def prepare_pea(
     zne_options: ZneOptions,
     noise_model_mapping: dict[str, PauliLindbladMap],
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
+    add_tags: bool = False,
 ) -> QuantumProgram:
     """Convert estimator PUBs to a quantum program.
 
@@ -68,6 +69,7 @@ def prepare_pea(
         noise_model_mapping: Mapping between layer ref to a noise model to use for noise
             amplification. The dict contains layers from all pubs. Assumes that the unique
             layers used for noise learning were extracted using the ``get_layers`` method.
+        add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,
@@ -106,6 +108,7 @@ def prepare_pea(
         twirling_options,
         measure_noise_learning,
         inject_noise=True,
+        add_tags=add_tags,
     )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -113,7 +113,7 @@ def prepare_pea(
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))
 
-        boxed_circuit = box_circuit(circuit=pub.circuit, inject_noise=True, **pm_kwargs)
+        boxed_circuit = box_circuit(circuit=pub.circuit, **pm_kwargs)
 
         # Build the template and the samplex
         template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -70,6 +70,10 @@ def prepare_pea(
             amplification. The dict contains layers from all pubs. Assumes that the unique
             layers used for noise learning were extracted using the ``get_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
+            ``False`` will cause no tags to be added (will pass the "none" value to the relevant
+            attribute), while ``True`` will cause tags with the twirled boxes hash to be added
+            (using the "unique_box" value of the relevant attribute). These tags can help
+            injecting noise in simulators.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -286,9 +286,7 @@ def get_layers(
         inject_noise,
         add_tags=add_tags,
     )
-    boxed_circuits = (
-        box_circuit(circuit=pub.circuit, inject_noise=inject_noise, **pm_kwargs) for pub in pubs
-    )
+    boxed_circuits = (box_circuit(circuit=pub.circuit, **pm_kwargs) for pub in pubs)
     instructions = (box for boxed_circuit in boxed_circuits for box in boxed_circuit)
     return find_unique_box_instructions(
         instructions=instructions, normalize_annotations=None, undress_boxes=True

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -18,7 +18,7 @@ permanent location (qiskit-addons or qiskit core) in the future.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -167,7 +167,7 @@ def box_circuit(
     measure_annotations: str,
     twirling_strategy: str,
     inject_noise: bool = False,
-    add_tags: str = "none",
+    add_tags: Literal["none", "unique_box", "unique_instance", "noise_ref"] = "none",
 ) -> QuantumCircuit:
     """Group the operations in the given ``circuit`` into boxes.
 
@@ -242,7 +242,10 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be accounted for in boxing.
         inject_noise: Whether to inject noise.
-        add_tags: Whether to include tags for the boxes.
+        add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
+            (will pass the "none" value to the relevant attribute), while ``True`` will cause tags
+            with the twirled boxes hash to be added (using the "unique_box" value of the relevant
+            attribute). These tags can help injecting noise in simulators.
 
     Returns:
         Options to the boxing passmanager.

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -167,6 +167,7 @@ def box_circuit(
     measure_annotations: str,
     twirling_strategy: str,
     inject_noise: bool = False,
+    add_tags: str = "none",
 ) -> QuantumCircuit:
     """Group the operations in the given ``circuit`` into boxes.
 
@@ -197,6 +198,7 @@ def box_circuit(
             ``inject_noise_targets`` and ``inject_noise_strategy`` set to ``"none"`` and
             ``"no_modification"``. See the Samplomatic API docs for more details regarding these
             values.
+        add_tags: Whether to include tags for the boxes.
 
     Returns:
         The boxed circuit.
@@ -221,6 +223,7 @@ def box_circuit(
         inject_noise_site="after",
         inject_noise_targets="gates" if inject_noise else "none",
         inject_noise_strategy="uniform_modification" if inject_noise else "no_modification",
+        add_tags=add_tags,
     )
     boxed_circuit = boxing_pm.run(prepared_circuit)
     return boxed_circuit
@@ -230,7 +233,8 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None,
     inject_noise: bool,
-):
+    add_tags: bool = False,
+) -> dict[str, Any]:
     """A helper to map options to kwargs for the boxing passmanager.
 
     Args:
@@ -238,9 +242,10 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be accounted for in boxing.
         inject_noise: Whether to inject noise.
+        add_tags: Whether to include tags for the boxes.
 
     Returns:
-        Unique layers for each pub.
+        Options to the boxing passmanager.
     """
     return {
         "enable_gates": twirling_options.enable_gates or inject_noise,
@@ -248,6 +253,7 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
         if twirling_options.enable_measure or (measure_noise_learning is not None)
         else "change_basis",
         "twirling_strategy": twirling_options.strategy.replace("-", "_"),
+        "add_tags": "unique_box" if add_tags else "none",
     }
 
 
@@ -256,7 +262,8 @@ def get_layers(
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     inject_noise: bool = False,
-) -> list[list[CircuitInstruction]]:
+    add_tags: bool = False,
+) -> list[CircuitInstruction]:
     """Find unique layers of the circuit of each pub.
 
     Uses the input options to box the circuit, and find its unique layers.
@@ -268,6 +275,7 @@ def get_layers(
             Error eXtinction (TREX) mitigation method will be accounted for in boxing.
         inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
             of gates.
+        add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
 
     Returns:
         Unique layers for each pub.
@@ -276,15 +284,15 @@ def get_layers(
         twirling_options,
         measure_noise_learning,
         inject_noise,
+        add_tags=add_tags,
     )
-    return [
-        find_unique_box_instructions(
-            box_circuit(circuit=pub.circuit, inject_noise=inject_noise, **pm_kwargs),
-            normalize_annotations=None,
-            undress_boxes=True,
-        )
-        for pub in pubs
-    ]
+    boxed_circuits = (
+        box_circuit(circuit=pub.circuit, inject_noise=inject_noise, **pm_kwargs) for pub in pubs
+    )
+    instructions = (box for boxed_circuit in boxed_circuits for box in boxed_circuit)
+    return find_unique_box_instructions(
+        instructions=instructions, normalize_annotations=None, undress_boxes=True
+    )
 
 
 def compute_samplex_arguments(

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -288,9 +288,7 @@ def find_unique_layers(
         inject_noise,
         add_tags=add_tags,
     )
-    boxed_circuits = (
-        box_circuit(circuit=pub.circuit, **pm_kwargs) for pub in pubs
-    )
+    boxed_circuits = (box_circuit(circuit=pub.circuit, **pm_kwargs) for pub in pubs)
     instructions = (box for boxed_circuit in boxed_circuits for box in boxed_circuit)
     return find_unique_box_instructions(
         instructions=instructions, normalize_annotations=None, undress_boxes=True

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -137,7 +137,7 @@ def prepare_zne(
             folding_pm = PassManager([GateFolding(noise_factor, folding_method)])
             folded_circuit = folding_pm.run(pub.circuit)
 
-            boxed_circuit = box_circuit(circuit=folded_circuit, inject_noise=False, **pm_kwargs)
+            boxed_circuit = box_circuit(circuit=folded_circuit, **pm_kwargs)
 
             # Build the template and the samplex
             template, samplex = build(boxed_circuit)

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -53,6 +53,7 @@ def prepare_zne(
     shots: int,
     zne_options: ZneOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
+    add_tags: bool = False,
 ) -> QuantumProgram:
     """Convert estimator PUBs to a quantum program.
 
@@ -65,6 +66,7 @@ def prepare_zne(
         zne_options: The options for ZNE mitigation.
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
+        add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,
@@ -109,6 +111,7 @@ def prepare_zne(
         twirling_options,
         measure_noise_learning,
         inject_noise=False,
+        add_tags=add_tags,
     )
     for i, pub in enumerate(pubs):
         logger.info("Processing pub %d/%d", i + 1, len(pubs))

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -67,6 +67,10 @@ def prepare_zne(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
+            ``False`` will cause no tags to be added (will pass the "none" value to the relevant
+            attribute), while ``True`` will cause tags with the twirled boxes hash to be added
+            (using the "unique_box" value of the relevant attribute). These tags can help
+            injecting noise in simulators.
 
     Returns:
         :class:`~.QuantumProgram` with :class:`~.SamplexItem` objects for each pub,

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -18,7 +18,9 @@ from ddt import data, ddt
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import Pauli, SparsePauliOp
+from samplomatic import Tag
 from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.utils import (
@@ -270,3 +272,63 @@ class TestBoxCircuit(unittest.TestCase):
         expected_circuit = pm.run(expected_circuit)
 
         self.assertEqual(circuit_out, expected_circuit)
+
+    @data("none", "unique_box", "unique_instance", "noise_ref")
+    def test_add_tags(self, add_tags):
+        """Tests for the ``add_tags`` argument.
+
+        Checks that the circuit produced by ``box_circuit`` matches the expected circuit
+        produced by ``generate_boxing_pass_manager`` with the same ``add_tags`` value, and
+        that boxes carry :class:`~samplomatic.Tag` annotations if and only if ``add_tags``
+        is not ``"none"``.
+        """
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(1, 2)
+        circuit.measure_all()
+
+        circuit_out = box_circuit(
+            circuit,
+            enable_gates=True,
+            measure_annotations="all",
+            twirling_strategy="all",
+            add_tags=add_tags,
+        )
+
+        pm = generate_boxing_pass_manager(
+            enable_gates=True,
+            measure_annotations="all",
+            twirling_strategy="all",
+            add_tags=add_tags,
+        )
+
+        expected_circuit = circuit.remove_final_measurements(inplace=False)
+        expected_circuit.add_register(ClassicalRegister(expected_circuit.num_qubits, "_meas"))
+        expected_circuit.barrier()
+        expected_circuit.measure(range(3), range(3))
+        expected_circuit = pm.run(expected_circuit)
+
+        self.assertEqual(circuit_out, expected_circuit)
+
+        # Verify Tag annotations on box instructions.
+        # "noise_ref" only tags boxes that are paired with injected-noise boxes; without
+        # inject_noise=True there are no such pairs, so no tags are produced.
+        box_instructions = [instr for instr in circuit_out if instr.operation.name == "box"]
+        tagged_boxes = [
+            instr for instr in box_instructions if get_annotation(instr.operation, Tag) is not None
+        ]
+        if add_tags in ("none", "noise_ref"):
+            self.assertEqual(
+                len(tagged_boxes),
+                0,
+                msg=f"Expected no tagged boxes for add_tags={add_tags!r} (without inject_noise), "
+                f"but found {len(tagged_boxes)}.",
+            )
+        else:
+            self.assertGreater(
+                len(tagged_boxes),
+                0,
+                msg=f"Expected at least one tagged box for add_tags={add_tags!r}, "
+                f"but found none.",
+            )

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -329,6 +329,5 @@ class TestBoxCircuit(unittest.TestCase):
             self.assertGreater(
                 len(tagged_boxes),
                 0,
-                msg=f"Expected at least one tagged box for add_tags={add_tags!r}, "
-                f"but found none.",
+                msg=f"Expected at least one tagged box for add_tags={add_tags!r}, but found none.",
             )


### PR DESCRIPTION
### Summary
Allow adding `add_tags` argument to the boxing pass manager to allow additional debugging functionalities.

### Details and comments

updated version to the PR #2939.
This PR relies on #2994 on the changes to the `get_layers` function (the tests will pass after merging this PR)

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
