### PR TITLE
Dispatch to `prepare_zne` when ZNE error mitigation is enabled

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -29,6 +29,7 @@ from ..options_models.estimator_options import EstimatorOptions
 from .pec.prepare_pec import prepare_pec
 from .prepare import prepare
 from .utils import resolve_precision
+from .zne.prepare_zne import prepare_zne
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -186,6 +187,16 @@ class EstimatorV2(BaseEstimatorV2):
                 shots=shots,
                 pec_options=self.options.resilience.pec,
                 noise_model_mapping=self.options.resilience.noise_model_mapping,
+                measure_noise_learning=self.options.resilience.measure_noise_learning
+                if self.options.resilience.measure_mitigation
+                else None,
+            )
+        elif self.options.resilience.zne_mitigation:
+            quantum_program = prepare_zne(
+                pubs=coerced_pubs,
+                twirling_options=self.options.twirling,
+                shots=shots,
+                zne_options=self.options.resilience.zne,
                 measure_noise_learning=self.options.resilience.measure_noise_learning
                 if self.options.resilience.measure_mitigation
                 else None,

--- a/qiskit_ibm_runtime/options_models/resilience_options.py
+++ b/qiskit_ibm_runtime/options_models/resilience_options.py
@@ -21,6 +21,7 @@ from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
 from .measure_noise_learning_options import MeasureNoiseLearningOptions
 from .pec_options import PecOptions
 from .utils import PRIMITIVES_CONFIG
+from .zne_options import ZneOptions
 
 
 @dataclass(config=PRIMITIVES_CONFIG)
@@ -56,6 +57,19 @@ class ResilienceOptions:
     """Additional probabalistic error cancellation mitigation options.
 
     See :class:`PecOptions` for all options.
+    """
+
+    zne_mitigation: bool = False
+    """Whether to turn on Zero Noise Extrapolation error mitigation method.
+
+    If you enable ZNE, you can fine-tune its options by using :attr:`~zne`.
+    See :class:`ZneOptions` for additional ZNE-related options.
+    """
+
+    zne: ZneOptions = Field(default_factory=ZneOptions)
+    """Additional zero noise extrapolation mitigation options.
+
+    See :class:`ZneOptions` for all options.
     """
 
     noise_model_mapping: dict[str, PauliLindbladMap] | None = None

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -20,7 +20,7 @@ from ddt import data, ddt, unpack
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
-from qiskit.quantum_info import SparsePauliOp
+from qiskit.quantum_info import PauliLindbladMap, SparsePauliOp
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor import Executor
@@ -394,3 +394,52 @@ class TestEstimatorV2Run(unittest.TestCase):
             "When PEC mitigation is enabled, you must provide a noise model",
         ):
             estimator.run([(circuit, observable)], precision=0.03125)
+
+    @patch("qiskit_ibm_runtime.executor_estimator.estimator.prepare_pec")
+    def test_run_dispatches_to_prepare_pec_when_pec_enabled(self, mock_prepare_pec):
+        """Test that run calls prepare_pec when pec_mitigation is enabled."""
+        estimator = EstimatorV2(mode=self.backend)
+        estimator.options.resilience.pec_mitigation = True
+        noise_model_mapping = {"layer_0": PauliLindbladMap.identity(num_qubits=2)}
+        estimator.options.resilience.noise_model_mapping = noise_model_mapping
+
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+
+        # Mock prepare_pec to return a valid QuantumProgram
+        mock_qp = MagicMock(spec=QuantumProgram)
+        mock_qp.shots = 1024
+        mock_qp.passthrough_data = {"post_processor": {}}
+        mock_qp.items = []
+        mock_prepare_pec.return_value = mock_qp
+
+        estimator.run([(circuit, observable)], precision=0.03125)
+
+        mock_prepare_pec.assert_called_once()
+        call_kwargs = mock_prepare_pec.call_args
+        self.assertEqual(call_kwargs.kwargs["pec_options"], estimator.options.resilience.pec)
+        self.assertEqual(call_kwargs.kwargs["noise_model_mapping"], noise_model_mapping)
+
+    @patch("qiskit_ibm_runtime.executor_estimator.estimator.prepare_zne")
+    def test_run_dispatches_to_prepare_zne_when_zne_enabled(self, mock_prepare_zne):
+        """Test that run calls prepare_zne when zne_mitigation is enabled."""
+        estimator = EstimatorV2(mode=self.backend)
+        estimator.options.resilience.zne_mitigation = True
+
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+
+        # Mock prepare_zne to return a valid QuantumProgram
+        mock_qp = MagicMock(spec=QuantumProgram)
+        mock_qp.shots = 1024
+        mock_qp.passthrough_data = {"post_processor": {}}
+        mock_qp.items = []
+        mock_prepare_zne.return_value = mock_qp
+
+        estimator.run([(circuit, observable)], precision=0.03125)
+
+        mock_prepare_zne.assert_called_once()
+        call_kwargs = mock_prepare_zne.call_args
+        self.assertEqual(call_kwargs.kwargs["zne_options"], estimator.options.resilience.zne)

--- a/test/unit/executor_estimator/test_resilience_options.py
+++ b/test/unit/executor_estimator/test_resilience_options.py
@@ -33,6 +33,9 @@ class TestResilienceOptionsDefaults(unittest.TestCase):
         self.assertFalse(opts.pec_mitigation)
         self.assertEqual(opts.pec.max_overhead, 100)
         self.assertEqual(opts.pec.noise_gain, "auto")
+        self.assertFalse(opts.zne_mitigation)
+        self.assertEqual(opts.zne.amplifier, "gate_folding")
+        self.assertEqual(opts.zne.noise_factors, "auto")
         self.assertIsNone(opts.noise_model_mapping)
 
     def test_set_all_options(self):
@@ -46,6 +49,8 @@ class TestResilienceOptionsDefaults(unittest.TestCase):
             measure_noise_learning={"num_randomizations": 64, "shots_per_randomization": 1024},
             pec_mitigation=True,
             pec={"max_overhead": 50, "noise_gain": 0.5},
+            zne_mitigation=True,
+            zne={"amplifier": "gate_folding_front", "noise_factors": [1, 3, 5]},
             noise_model_mapping=mapping,
         )
         self.assertFalse(opts.measure_mitigation)
@@ -54,6 +59,9 @@ class TestResilienceOptionsDefaults(unittest.TestCase):
         self.assertTrue(opts.pec_mitigation)
         self.assertEqual(opts.pec.max_overhead, 50)
         self.assertEqual(opts.pec.noise_gain, 0.5)
+        self.assertTrue(opts.zne_mitigation)
+        self.assertEqual(opts.zne.amplifier, "gate_folding_front")
+        self.assertEqual(list(opts.zne.noise_factors), [1, 3, 5])
         self.assertEqual(set(opts.noise_model_mapping.keys()), {"layer_0", "layer_1"})
 
 


### PR DESCRIPTION
### Summary
Part of #2980

### Details and comments
This PR adds the ZNE options to the estimator options, and dispatches to the correct prepare function when ZNE is enabled.

### AI/LLM disclosure

- [X] I used the following tool to generate or modify code: IBM BOB
