### PR TITLE
Minor edits to QuantumProgram docs and repr

### DIFF
--- a/qiskit_ibm_runtime/quantum_program/quantum_program.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program.py
@@ -232,7 +232,7 @@ class QuantumProgram:
                     data point (resulting from kerneling the measurement trace) in arbitrary units.
                 * "avg_kerneled": Classical register data is returned as a complex array with the
                     intrinsic shape ``(creg_size,)``, where data is equivalent to "kerneled" except
-                    additionally averagedover shots.
+                    additionally averaged over shots.
 
             passthrough_data: Arbitrary nested data passed through execution without modification.
     """

--- a/qiskit_ibm_runtime/quantum_program/quantum_program.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program.py
@@ -130,7 +130,7 @@ class CircuitItem(QuantumProgramItem):
 
         chunk_size = "" if self.chunk_size is None else f", chunk_size={self.chunk_size}"
 
-        return f"QuantumProgramSimpleItem({circuit}{circuit_args}{chunk_size})"
+        return f"CircuitItem({circuit}{circuit_args}{chunk_size})"
 
 
 class SamplexItem(QuantumProgramItem):
@@ -205,7 +205,7 @@ class SamplexItem(QuantumProgramItem):
         shape = f", shape={self.shape}"
         chunk_size = "" if self.chunk_size is None else f", chunk_size={self.chunk_size}"
 
-        return f"QuantumProgramSamplexItem({circuit}{samplex}{samplex_args}{shape}{chunk_size})"
+        return f"SamplexItem({circuit}{samplex}{samplex_args}{shape}{chunk_size})"
 
 
 class QuantumProgram:

--- a/qiskit_ibm_runtime/quantum_program/quantum_program.py
+++ b/qiskit_ibm_runtime/quantum_program/quantum_program.py
@@ -220,7 +220,21 @@ class QuantumProgram:
         shots: The number of shots for each circuit execution.
         items: Items that comprise the program.
         noise_maps: Noise maps to use with samplex items.
-        passthrough_data: Arbitrary nested data passed through execution without modification.
+        meas_level: The level at which to return all classical register measurement results. This
+            value sets the return type of all classical registers in all quantum program items and
+            determines whether the raw complex data from low-level measurement devices is
+            discriminated into bits or not. The supported values are
+
+                * "classified": Classical register data is returned as boolean arrays with the
+                    intrinsic shape ``(num_shots, creg_size)``.
+                * "kerneled": Classical register data is returned as a complex array with the
+                    intrinsic shape ``(num_shots, creg_size)``, where each entry represents an IQ
+                    data point (resulting from kerneling the measurement trace) in arbitrary units.
+                * "avg_kerneled": Classical register data is returned as a complex array with the
+                    intrinsic shape ``(creg_size,)``, where data is equivalent to "kerneled" except
+                    additionally averagedover shots.
+
+            passthrough_data: Arbitrary nested data passed through execution without modification.
     """
 
     def __init__(


### PR DESCRIPTION
### Summary
This PR:
- Adds missing docs for `meas_type` to the init of quantum program
- Fixes the `repr` of CircuitItem (formerly QuantumProgramSimpleItem) and SamplexItem (previously QuantumProgramSamplexItem)

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
