### PR TITLE
Getting rid of two warnings in tests

### DIFF
--- a/qiskit_ibm_runtime/json.py
+++ b/qiskit_ibm_runtime/json.py
@@ -513,7 +513,7 @@ class RuntimeDecoder(json.JSONDecoder):
                 # circuit to deserialize load qpy circuit and return first instruction object in
                 # that circuit.
                 circuit = _decode_and_deserialize(obj_val, load)[0]
-                return circuit.data[0][0]
+                return circuit.data[0].operation
             if obj_type == "settings":
                 if obj["__module__"].startswith(
                     "qiskit.quantum_info.operators",

--- a/test/unit/test_ibm_primitives_v2.py
+++ b/test/unit/test_ibm_primitives_v2.py
@@ -261,6 +261,7 @@ class TestPrimitivesV2(IBMTestCase):
     def test_parameters_single_circuit(self, primitive):
         """Test parameters for a single circuit."""
         circ = real_amplitudes(num_qubits=2, reps=1)
+        circ.measure_all()
         backend = get_mocked_backend()
         circ = transpile(circ, backend=backend)
 
@@ -293,6 +294,7 @@ class TestPrimitivesV2(IBMTestCase):
     def test_nd_parameters(self, primitive):
         """Test with parameters of different dimensions."""
         circ = real_amplitudes(num_qubits=2, reps=1)
+        circ.measure_all()
         backend = get_mocked_backend()
         circ = transpile(circ, backend=backend)
         inst = primitive(mode=backend)
@@ -312,10 +314,16 @@ class TestPrimitivesV2(IBMTestCase):
     def test_parameters_multiple_circuits(self, primitive):
         """Test multiple parameters for multiple circuits."""
         backend = get_mocked_backend()
+        qc2 = QuantumCircuit(2)
+        qc2.measure_all()
+        ra2 = real_amplitudes(num_qubits=2, reps=1)
+        ra2.measure_all()
+        ra3 = real_amplitudes(num_qubits=3, reps=1)
+        ra3.measure_all()
         circuits = [
-            transpile(QuantumCircuit(2), backend=backend),
-            transpile(real_amplitudes(num_qubits=2, reps=1), backend=backend),
-            transpile(real_amplitudes(num_qubits=3, reps=1), backend=backend),
+            transpile(qc2, backend=backend),
+            transpile(ra2, backend=backend),
+            transpile(ra3, backend=backend),
         ]
 
         param_vals = [

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -34,6 +34,20 @@ from .mock.fake_api_backend import FakeApiBackendSpecs
 from .mock.fake_runtime_service import FakeRuntimeService
 
 
+def _measured(n):
+    """Return an n-qubit circuit with all qubits measured."""
+    qc = QuantumCircuit(n)
+    qc.measure_all()
+    return qc
+
+
+def _real_amplitudes_measured(num_qubits, reps):
+    """Return a real_amplitudes circuit with all qubits measured."""
+    qc = real_amplitudes(num_qubits=num_qubits, reps=reps)
+    qc.measure_all()
+    return qc
+
+
 @ddt
 class TestSamplerV2(IBMTestCase):
     """Class for testing the Estimator class."""
@@ -44,9 +58,9 @@ class TestSamplerV2(IBMTestCase):
         self.circuit = QuantumCircuit(1, 1)
 
     @data(
-        [(real_amplitudes(num_qubits=2, reps=1), [1, 2, 3, 4])],
-        [(QuantumCircuit(2),)],
-        [(real_amplitudes(num_qubits=1, reps=1), [1, 2]), (QuantumCircuit(3),)],
+        [(_real_amplitudes_measured(num_qubits=2, reps=1), [1, 2, 3, 4])],
+        [(_measured(2),)],
+        [(_real_amplitudes_measured(num_qubits=1, reps=1), [1, 2]), (_measured(3),)],
     )
     def test_run_program_inputs(self, in_pubs):
         """Verify program inputs are correct."""
@@ -288,6 +302,7 @@ class TestSamplerV2(IBMTestCase):
 
         circ = QuantumCircuit(2)
         circ.rzz(angle, 0, 1)
+        circ.measure_all()
 
         if angle == 1:
             SamplerV2(backend).run(pubs=[circ])
@@ -307,6 +322,7 @@ class TestSamplerV2(IBMTestCase):
 
         circ = QuantumCircuit(2)
         circ.rzz(param, 0, 1)
+        circ.measure_all()
 
         if angle == 1:
             SamplerV2(backend).run(pubs=[(circ, [angle])])
@@ -328,6 +344,7 @@ class TestSamplerV2(IBMTestCase):
 
         circ = QuantumCircuit(2)
         circ.rzz(2 * p2 + p1, 0, 1)
+        circ.measure_all()
 
         if val2 == 0:
             SamplerV2(backend).run(pubs=[(circ, [val1, val2])])


### PR DESCRIPTION
### Summary

A lot of warnings get fired during test execution. Some of them - the more important ones - require fixes in the code body (not in tests). They may manifest for users when they run their code, and we opened Issue #2764 to eliminate them. Others require fixes only in the tests, and it's always nice to fix those too.

### Details and comments

Part of #2764.

The following warning is completely eliminated:
```
UserWarning: The <some number>-th circuit has no output classical registers so the result will be empty. Did you mean to add measurement instructions?
```

In addition one of two instances of the following warning:
```
DeprecationWarning: Treating CircuitInstruction as an iterable is deprecated legacy behavior since Qiskit 1.2, and will be removed in Qiskit 3.0. Instead, use the `operation`, `qubits` and `clbits` named attributes.
```

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Bob or Claude Code
