### PR TITLE
Bug fix in test_backend.py

### DIFF
--- a/test/unit/test_backend.py
+++ b/test/unit/test_backend.py
@@ -71,9 +71,9 @@ class TestBackend(IBMTestCase):
         sampler = SamplerV2(ibm_backend)
 
         with self.assertRaises(ValueError) as err:
-            sampler.run([transpiled])
+            sampler.run(transpiled)
 
-        self.assertIn("inhomogeneous", str(err.exception))
+        self.assertIn("faulty", str(err.exception))
 
     def test_raise_faulty_edge(self):
         """Test faulty edge is raised."""


### PR DESCRIPTION
### Summary

A bug caused the warning
```
site-packages/qiskit/primitives/containers/bindings_array.py:129: DeprecationWarning: Treating CircuitInstruction as an iterable is deprecated legacy behavior since Qiskit 1.2, and will be removed in Qiskit 3.0. Instead, use the `operation`, `qubits` and `clbits` named attributes.
    ): np.asarray(val, dtype=float)
```
This turned out not to be just a annoying warning to take care of, but a genuine bug in the test.

### Details and comments

sampler.run([transpiled]) is wrong and meaningless, therefore it emits an error, which is not related at all to faulty qubits. This unrelated error contains the word `inhomogeneous` (full sentence is `inhomogeneous shape`), and the assertion succeeded.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Bob
