### PR TITLE
NLV3 - updating `find_learning_protocol` to avoid undressed boxes for Clifford validation

### DIFF
--- a/qiskit_ibm_runtime/noise_learner_v3/find_learning_protocol.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/find_learning_protocol.py
@@ -42,10 +42,11 @@ def find_learning_protocol(instruction: BoxOp) -> LearningProtocol | None:
     Raises:
         IBMInputValueError: If ``instruction`` does not contain a box.
     """
-    if (name := instruction.operation.name) != "box":
+    box = instruction.operation
+    if (name := box.name) != "box":
         raise IBMInputValueError(f"Expected a 'box' but found '{name}'.")
 
-    undressed_box = undress_box(instruction.operation)
+    undressed_box = undress_box(box)
 
     if len(undressed_box.body) == 0:
         return LearningProtocol.PAULI_LINDBLAD
@@ -56,22 +57,22 @@ def find_learning_protocol(instruction: BoxOp) -> LearningProtocol | None:
     ]
     is_layer = len(active_qubits) == len(set(active_qubits))
 
-    # Check if the undressed box only contains two-qubit Clifford gates
-    has_only_2q_clifford_gates = all(
-        (op.is_standard_gate() and op.operation.num_qubits == 2) or op.name == "barrier"
-        for op in undressed_box.body
+    # Check if the dressed box is Clifford
+    is_clifford = all(
+        (op.is_standard_gate() and op.operation.num_qubits <= 2) or op.name == "barrier"
+        for op in box.body
     )
-    if has_only_2q_clifford_gates:
+    if is_clifford:
         try:
-            Clifford(undressed_box.body)
+            Clifford(box.body)
         except QiskitError:
-            has_only_2q_clifford_gates = False
+            is_clifford = False
+
+    if is_layer and is_clifford:
+        return LearningProtocol.PAULI_LINDBLAD
 
     # Check if the undressed box only contains measurements
     has_only_meas = all(op.name in ["measure", "barrier"] for op in undressed_box.body)
-
-    if is_layer and has_only_2q_clifford_gates:
-        return LearningProtocol.PAULI_LINDBLAD
 
     if is_layer and has_only_meas and len(instruction.qubits) == len(active_qubits):
         return LearningProtocol.TREX

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -103,6 +103,20 @@ class NoiseLearnerV3:
     def run(self, instructions: Iterable[CircuitInstruction]) -> RuntimeJobV2:
         """Submit a request to the noise learner program.
 
+        Two protocols are supported:
+
+        - Lindblad: for boxed instructions which content can be cast to
+            :class:`~.qiskit.quantum_info.Clifford` and contain a single layer of
+            (up to) two qubit gates.
+
+        - TREX: for boxed instructions which content can contain exactly one measurement per qubit.
+
+        .. note::
+
+            To minimize the number of noise learning experiments, call
+            :meth:`~samplomatic.utils.find_unique_box_instructions` before
+            running the noise learning job.
+
         Args:
             instructions: The instructions to learn the noise of.
 

--- a/test/unit/noise_learner_v3/test_find_learning_protocol.py
+++ b/test/unit/noise_learner_v3/test_find_learning_protocol.py
@@ -39,9 +39,12 @@ class TestFindLearningProtocol(IBMTestCase):
             circuit.cx(1, 2)
         with circuit.box([Twirl()]):
             circuit.rzz(0.01, 0, 1)
+        with circuit.box([Twirl()]):
+            circuit.rz(1.2, 0)
+            circuit.cz(0, 1)
 
         protocols = [find_learning_protocol(instr) for instr in circuit]
-        self.assertEqual(protocols, ["pauli_lindblad"] * 2 + [None] * 2)
+        self.assertEqual(protocols, ["pauli_lindblad"] * 2 + [None] * 3)
 
     def test_measure_instructions(self):
         """Test measure instructions."""


### PR DESCRIPTION
### Summary

Updating the find_learning_protocol validation method in the noise learner v3 to avoid using the undressed box for Clifford validation.

### Details and comments

An example like
```
circuit = QuantumCircuit(backend.num_qubits)
with circuit.box([Twirl()]):
    circuit.rz(1.2, 0)
    circuit.cz(0, 1)
```
will now raise.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
