### PR TITLE
Set default value of `inject_noise_site`

### DIFF
--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -44,7 +44,7 @@ class TestCalculateGamma(unittest.TestCase):
         """Test gamma calculation for a circuit with a single noisy two-qubit gate."""
         # Create a simple circuit with one two-qubit gate annotated with noise
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[InjectNoise(ref="layer_0")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_0", site="after")]):
             circuit.h(0)
             circuit.cx(0, 1)
 
@@ -65,10 +65,10 @@ class TestCalculateGamma(unittest.TestCase):
         """Test gamma calculation for a circuit with multiple noisy gates."""
         # Create a circuit with multiple gates
         circuit = QuantumCircuit(3)
-        with circuit.box(annotations=[InjectNoise(ref="layer_0")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_0", site="after")]):
             circuit.h(0)
             circuit.cx(0, 1)
-        with circuit.box(annotations=[InjectNoise(ref="layer_1")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_1", site="after")]):
             circuit.cx(1, 2)
 
         # Create noise models
@@ -89,10 +89,10 @@ class TestCalculateGamma(unittest.TestCase):
         """Test gamma calculation for a circuit with multiple noisy gates."""
         # Create a circuit with multiple gates
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[InjectNoise(ref="layer_0")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_0", site="after")]):
             circuit.h(0)
             circuit.cx(0, 1)
-        with circuit.box(annotations=[InjectNoise(ref="layer_0")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_0", site="after")]):
             circuit.h(0)
             circuit.cx(0, 1)
 
@@ -127,7 +127,7 @@ class TestCalculateGamma(unittest.TestCase):
         """Test gamma calculation with noise factor amplification."""
         # Create a circuit with one noisy two-qubit gate
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[InjectNoise(ref="layer_0")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_0", site="after")]):
             circuit.h(0)
             circuit.cx(0, 1)
 
@@ -154,13 +154,13 @@ class TestCalculateGamma(unittest.TestCase):
         """Test gamma calculation for circuit with both noisy and noiseless gates."""
         # Create a circuit with multiple gates, only some annotated
         circuit = QuantumCircuit(3)
-        with circuit.box(annotations=[InjectNoise(ref="layer_0")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_0", site="after")]):
             circuit.h(0)  # This will be noisy
             circuit.cx(0, 1)
         with circuit.box():  # Box without InjectNoise annotation
             circuit.x(1)  # This will be noiseless
             circuit.cx(0, 2)
-        with circuit.box(annotations=[InjectNoise(ref="layer_1")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_1", site="after")]):
             circuit.cx(1, 2)  # This will be noisy
 
         noise_model_0 = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=3)
@@ -180,7 +180,7 @@ class TestCalculateGamma(unittest.TestCase):
         """Test gamma calculation with zero noise factor."""
         # Create a circuit with one noisy two-qubit gate
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[InjectNoise(ref="layer_0")]):
+        with circuit.box(annotations=[InjectNoise(ref="layer_0", site="after")]):
             circuit.h(0)
             circuit.cx(0, 1)
 

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -174,6 +174,7 @@ class TestBoxCircuit(unittest.TestCase):
             enable_gates=enable_gates,
             measure_annotations="all",
             twirling_strategy="all",
+            inject_noise_site="after",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -203,6 +204,7 @@ class TestBoxCircuit(unittest.TestCase):
             enable_gates=True,
             measure_annotations=measure_annotations,
             twirling_strategy="all",
+            inject_noise_site="after",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -232,6 +234,7 @@ class TestBoxCircuit(unittest.TestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy=twirling_strategy,
+            inject_noise_site="after",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -264,6 +267,7 @@ class TestBoxCircuit(unittest.TestCase):
             twirling_strategy="all",
             inject_noise_targets="gates" if inject_noise else "none",
             inject_noise_strategy="uniform_modification" if inject_noise else "no_modification",
+            inject_noise_site="after",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -301,6 +305,7 @@ class TestBoxCircuit(unittest.TestCase):
             measure_annotations="all",
             twirling_strategy="all",
             add_tags=add_tags,
+            inject_noise_site="after",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -125,7 +125,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             NoiseLearnerV3Result.from_generators(self.generators, rates) for rates in self.rates
         ]
         self.pauli_lindblad_maps = [result.to_pauli_lindblad_map() for result in self.results]
-        self.inject_noise_annotations = [InjectNoise(ref) for ref in ["hi", "bye"]]
+        self.inject_noise_annotations = [InjectNoise(ref, site="after") for ref in ["hi", "bye"]]
 
     def test_properties_of_iterable(self):
         """Test elementary methods of ``NoiseLearnerV3Results``.

--- a/test/unit/quantum_program/converters/test_converters_0_1.py
+++ b/test/unit/quantum_program/converters/test_converters_0_1.py
@@ -67,10 +67,10 @@ class TestQuantumProgramConverters(IBMTestCase):
         )
 
         circuit2 = QuantumCircuit(2)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0", site="after")]):
             circuit2.rx(Parameter("p"), 0)
             circuit2.cx(0, 1)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
             circuit2.measure_all()
 
         template_circuit, samplex = build(circuit2)

--- a/test/unit/quantum_program/converters/test_converters_0_2.py
+++ b/test/unit/quantum_program/converters/test_converters_0_2.py
@@ -72,10 +72,10 @@ class TestQuantumProgramConverters(IBMTestCase):
         )
 
         circuit2 = QuantumCircuit(2)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0", site="after")]):
             circuit2.rx(Parameter("p"), 0)
             circuit2.cx(0, 1)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
             circuit2.measure_all()
 
         template_circuit, samplex = build(circuit2)

--- a/test/unit/quantum_program/converters/test_converters_1_0.py
+++ b/test/unit/quantum_program/converters/test_converters_1_0.py
@@ -73,10 +73,10 @@ class TestQuantumProgramConverters(IBMTestCase):
         )
 
         circuit2 = QuantumCircuit(2)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0", site="after")]):
             circuit2.rx(Parameter("p"), 0)
             circuit2.cx(0, 1)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
             circuit2.measure_all()
 
         template_circuit, samplex = build(circuit2)

--- a/test/unit/quantum_program/converters/test_converters_1_1.py
+++ b/test/unit/quantum_program/converters/test_converters_1_1.py
@@ -73,10 +73,10 @@ class TestQuantumProgramConverters(IBMTestCase):
         )
 
         circuit2 = QuantumCircuit(2)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0", site="after")]):
             circuit2.rx(Parameter("p"), 0)
             circuit2.cx(0, 1)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
             circuit2.measure_all()
 
         template_circuit, samplex = build(circuit2)

--- a/test/unit/quantum_program/test_quantum_program.py
+++ b/test/unit/quantum_program/test_quantum_program.py
@@ -48,10 +48,10 @@ class TestQuantumProgram(IBMTestCase):
         )
 
         circuit2 = QuantumCircuit(2)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0", site="after")]):
             circuit2.rx(Parameter("p"), 0)
             circuit2.cx(0, 1)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
             circuit2.measure_all()
 
         template_circuit, samplex = build(circuit2)
@@ -126,7 +126,7 @@ class TestQuantumProgram(IBMTestCase):
         )
 
         circuit2 = QuantumCircuit(2)
-        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1")]):
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
             circuit2.measure_all()
 
         template_circuit, samplex = build(circuit2)

--- a/test/unit/quantum_program/test_samplex_item.py
+++ b/test/unit/quantum_program/test_samplex_item.py
@@ -134,10 +134,10 @@ class TestSamplexItem(IBMTestCase):
     def test_samplex_item_with_noise(self):
         """Test ``SamplexItem`` with noise annotations."""
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r0")]):
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r0", site="after")]):
             circuit.rx(Parameter("p"), 0)
             circuit.cx(0, 1)
-        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r1")]):
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r1", site="after")]):
             circuit.measure_all()
 
         template_circuit, samplex = build(circuit)
@@ -177,10 +177,10 @@ class TestSamplexItem(IBMTestCase):
         a Pauli-Lindblad map for a noise annotation.
         """
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r0")]):
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r0", site="after")]):
             circuit.rx(Parameter("p"), 0)
             circuit.cx(0, 1)
-        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r1")]):
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r1", site="after")]):
             circuit.measure_all()
 
         template_circuit, samplex = build(circuit)


### PR DESCRIPTION
### Summary
This PR removes some more Samplomatic warnings that were left behind by PR #2952.
We are down to 10 now, but removing them requires fixes in Samplomatic -- specifically, to the `find_unique_box_instructions`, see [this issue](https://github.com/Qiskit/samplomatic/issues/385).

Fixes #2951

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
