### PR TITLE
Include towncrier as a dev dependency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 ⚠️ The pull request title should be short detailed and understandable for all.
-⚠️ Also, please add a release note file using reno if the change needs to be
-  documented in the release notes.
+⚠️ Also, please add a release note file using towncrier if the change needs to
+  be documented in the release notes.
 ⚠️ If your pull request fixes an open issue, please link to the issue.
 
 ✅ I have added the tests to cover my changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,11 @@ Then, identify which type of change your release note is:
 * `other` (other note)
 
 Now, create a new file in the `release-notes/unreleased` folder in the format `<github-number>.<type>.rst`,
-such as `156.bug.rst` or `231.feat.rst`.
+such as `156.bug.rst` or `231.feat.rst` via:
+
+```sh
+towncrier create 156.bug.rst
+```
 
 Open up the new release note file and provide a description of the change, such as what users need
 to do. The files use RST syntax and you can use mechanisms like code blocks and cross-references.

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -209,8 +209,8 @@ def deprecated_function():
 ```
 
 
-You should also document the deprecation in the changelog by using `towncrier`. Explain the deprecation
-and how to migrate.
+You should also document the deprecation in the changelog by using `towncrier`. Explain the
+deprecation and how to migrate.
 
 In particular situations where a deprecation or change might be a major disruptor for users, a
 *migration guide* might be needed. Please write these guides in Qiskit's documentation at

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -209,7 +209,7 @@ def deprecated_function():
 ```
 
 
-You should also document the deprecation in the changelog by using Reno. Explain the deprecation
+You should also document the deprecation in the changelog by using `towncrier`. Explain the deprecation
 and how to migrate.
 
 In particular situations where a deprecation or change might be a major disruptor for users, a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ doc = [
     "pylatexenc",
     "Sphinx>=8,<9",
     "sphinxcontrib-katex==0.9.9",
+    "towncrier",
 ]
 
 dev = [


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add `towncrier` to the list of dev dependencies, as it is not installed by default currently as is needed when dealing with release notes. Additionally, fixes some old references to `reno`.

### Details and comments

Fixes N/A

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
