### PR TITLE
Bump samplomatic to 0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ dependencies = [
     "pydantic>=2.11.0",
     "qiskit>=2.3.0",
     "pybase64>=1.4.0",
-    "samplomatic>=0.17.0"
+    "samplomatic>=0.18.0"
 ]
 
 [project.entry-points."qiskit.transpiler.translation"]

--- a/release-notes/unreleased/2925.upgrade.rst
+++ b/release-notes/unreleased/2925.upgrade.rst
@@ -1,1 +1,1 @@
-The minimal version of Qiskit required is now ``2.3.0``, and that of Samplomatic is ``0.17.0``.
+The minimal version of Qiskit required is now ``2.3.0``, and that of Samplomatic is ``0.18.0``.


### PR DESCRIPTION
### Summary
Closes #3027

### Details and comments
#2998 uses the `add_tags` argument which was only added in `samplomatic==0.18.0`. Accordingly, samplomatic needs to be bumped to that version. With 0.18.0, all tests pass.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.