### PR TITLE
Pass finalized options in WrapperEstimator

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -289,7 +289,7 @@ class EstimatorV2(BaseEstimatorV2):
         # Check if we're in local simulator mode
         if self._executor is None:
             logger.info("Running in local simulator mode")
-            return self._run_simulator(coerced_pubs, shots)
+            return self._run_simulator(coerced_pubs, options, shots)
 
         # Convert pubs to QuantumProgram and map options using the selected prepare function
         logger.info("Starting pre-processing")
@@ -369,17 +369,20 @@ class EstimatorV2(BaseEstimatorV2):
 
         return self._executor.run(quantum_program)
 
-    def _run_simulator(self, pubs: list[EstimatorPub], shots: int) -> LocalRuntimeJob:
+    def _run_simulator(
+        self, pubs: list[EstimatorPub], options: EstimatorOptions, shots: int
+    ) -> LocalRuntimeJob:
         """Run estimator in local simulator mode using BackendEstimatorV2.
 
         Args:
             pubs: List of estimator PUBs to run.
+            options: The user options, finalized.
             shots: The number of shots to use.
 
         Returns:
             A LocalRuntimeJob.
         """
-        options_dict = asdict(self.options)  # type: ignore[call-overload]
+        options_dict = asdict(options)  # type: ignore[call-overload]
         options_dict["default_shots"] = shots
 
         inputs = {


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of landing #3014 and #3009, I did not spot during the final review of #3009 that `_run_simulator` is using the non-finalized options. This PR fixes it so both wrapper primitives behave the same way.

### Details and comments

Related to #2965

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
