### PR TITLE
Size TREX calibration randomizations from twirling

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -97,6 +97,10 @@ def prepare_pec(
         twirling_options.num_randomizations,
         twirling_options.shots_per_randomization,
     )
+    # Preserve the twirling randomization count: ``num_randomizations`` is scaled
+    # per-pub by the PEC sampling overhead below, but the TREX calibration should
+    # follow the (unscaled) twirling value.
+    twirling_num_randomizations = num_randomizations
 
     # set max_overhead
     max_overhead = pec_options.max_overhead
@@ -222,7 +226,9 @@ def prepare_pec(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(pubs, measure_noise_learning)
+        trex_item = create_trex_calibration_circuit(
+            pubs, measure_noise_learning, twirling_num_randomizations
+        )
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -34,7 +34,7 @@ from samplomatic import build
 from ...exceptions import IBMInputValueError
 from ...quantum_program import QuantumProgram
 from ...quantum_program.quantum_program import SamplexItem
-from ..trex_utils import create_trex_calibration_circuit
+from ..trex_utils import create_trex_calibration_circuit, resolve_trex_num_randomizations
 from ..utils import (
     box_circuit,
     compute_samplex_arguments,
@@ -226,9 +226,10 @@ def prepare_pec(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(
-            pubs, measure_noise_learning, twirling_num_randomizations
+        trex_num_randomizations = resolve_trex_num_randomizations(
+            measure_noise_learning, twirling_num_randomizations
         )
+        trex_item = create_trex_calibration_circuit(pubs, trex_num_randomizations)
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -164,7 +164,9 @@ def prepare(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(pubs, measure_noise_learning)
+        trex_item = create_trex_calibration_circuit(
+            pubs, measure_noise_learning, num_randomizations
+        )
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -31,7 +31,7 @@ from ..exceptions import IBMInputValueError
 from ..executor.calculate_twirling_shots import calculate_twirling_shots
 from ..quantum_program import QuantumProgram
 from ..quantum_program.quantum_program import SamplexItem
-from .trex_utils import create_trex_calibration_circuit
+from .trex_utils import create_trex_calibration_circuit, resolve_trex_num_randomizations
 from .utils import (
     box_circuit,
     compute_samplex_arguments,
@@ -164,9 +164,10 @@ def prepare(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(
-            pubs, measure_noise_learning, num_randomizations
+        trex_num_randomizations = resolve_trex_num_randomizations(
+            measure_noise_learning, num_randomizations
         )
+        trex_item = create_trex_calibration_circuit(pubs, trex_num_randomizations)
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -200,7 +200,9 @@ def prepare_pea(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(pubs, measure_noise_learning)
+        trex_item = create_trex_calibration_circuit(
+            pubs, measure_noise_learning, num_randomizations
+        )
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -35,7 +35,7 @@ from ..executor.calculate_twirling_shots import calculate_twirling_shots
 from ..options_models.zne_options import PEA_DEFAULT_NOISE_FACTORS
 from ..quantum_program import QuantumProgram
 from ..quantum_program.quantum_program import SamplexItem
-from .trex_utils import create_trex_calibration_circuit
+from .trex_utils import create_trex_calibration_circuit, resolve_trex_num_randomizations
 from .utils import (
     box_circuit,
     compute_samplex_arguments,
@@ -200,9 +200,10 @@ def prepare_pea(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(
-            pubs, measure_noise_learning, num_randomizations
+        trex_num_randomizations = resolve_trex_num_randomizations(
+            measure_noise_learning, num_randomizations
         )
+        trex_item = create_trex_calibration_circuit(pubs, trex_num_randomizations)
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/executor_estimator/trex_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/trex_utils.py
@@ -37,7 +37,7 @@ def resolve_trex_num_randomizations(
     """Resolve the number of TREX calibration randomizations.
 
     ``measure_noise_learning.num_randomizations`` may be an explicit ``int`` or
-    ``"auto"`` (the default). When ``"auto"``, the TREX calibration uses the same
+    ``"auto"``. When ``"auto"``, the TREX calibration uses the same
     number of randomizations as the estimation twirling
     (``twirling_num_randomizations``); an explicit ``int`` is used as-is.
 
@@ -66,7 +66,7 @@ def create_trex_calibration_circuit(
     Args:
         pubs: List of estimator pubs to extract relevant qubits from.
         num_randomizations: The number of TREX calibration randomizations (already
-            resolved, see :func:`resolve_trex_num_randomizations`).
+            resolved, see :func:`~.resolve_trex_num_randomizations`).
 
     Returns:
         Samplex item containing calibration circuit for TREX factors calculation.

--- a/qiskit_ibm_runtime/executor_estimator/trex_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/trex_utils.py
@@ -30,8 +30,35 @@ from samplomatic.transpiler import generate_boxing_pass_manager
 from ..quantum_program.quantum_program import SamplexItem
 
 
+def resolve_trex_num_randomizations(
+    measure_noise_learning: MeasureNoiseLearningOptions,
+    twirling_num_randomizations: int,
+) -> int:
+    """Resolve the number of TREX calibration randomizations.
+
+    ``measure_noise_learning.num_randomizations`` may be an explicit ``int`` or
+    ``"auto"`` (the default). When ``"auto"``, the TREX calibration uses the same
+    number of randomizations as the estimation twirling
+    (``twirling_num_randomizations``); an explicit ``int`` is used as-is.
+
+    Args:
+        measure_noise_learning: Measure noise learning options.
+        twirling_num_randomizations: The number of randomizations used by the
+            estimation twirling.
+
+    Returns:
+        The number of TREX calibration randomizations to use.
+    """
+    num_randomizations = measure_noise_learning.num_randomizations
+    if num_randomizations == "auto":
+        return twirling_num_randomizations
+    return num_randomizations
+
+
 def create_trex_calibration_circuit(
-    pubs: Sequence[EstimatorPub], measure_noise_learning: MeasureNoiseLearningOptions
+    pubs: Sequence[EstimatorPub],
+    measure_noise_learning: MeasureNoiseLearningOptions,
+    twirling_num_randomizations: int,
 ) -> SamplexItem:
     """Creates a TREX calibration circuit.
 
@@ -40,10 +67,16 @@ def create_trex_calibration_circuit(
     Args:
         pubs: List of estimator pubs to extract relevant qubits from.
         measure_noise_learning: Measure noise learning options.
+        twirling_num_randomizations: The number of randomizations used by the
+            estimation twirling, used to resolve ``num_randomizations="auto"``
+            (see :func:`resolve_trex_num_randomizations`).
 
     Returns:
         Samplex item containing calibration circuit for TREX factors calculation.
     """
+    num_randomizations = resolve_trex_num_randomizations(
+        measure_noise_learning, twirling_num_randomizations
+    )
     # create the combined noise learning layer of all given inputs
     max_num_qubits = max(pub.circuit.num_qubits for pub in pubs)
 
@@ -62,7 +95,7 @@ def create_trex_calibration_circuit(
     trex_calibration_item = SamplexItem(
         circuit=template_trex_circuit,
         samplex=trex_samplex,
-        shape=(measure_noise_learning.num_randomizations,),
+        shape=(num_randomizations,),
     )
 
     return trex_calibration_item

--- a/qiskit_ibm_runtime/executor_estimator/trex_utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/trex_utils.py
@@ -57,8 +57,7 @@ def resolve_trex_num_randomizations(
 
 def create_trex_calibration_circuit(
     pubs: Sequence[EstimatorPub],
-    measure_noise_learning: MeasureNoiseLearningOptions,
-    twirling_num_randomizations: int,
+    num_randomizations: int,
 ) -> SamplexItem:
     """Creates a TREX calibration circuit.
 
@@ -66,17 +65,12 @@ def create_trex_calibration_circuit(
 
     Args:
         pubs: List of estimator pubs to extract relevant qubits from.
-        measure_noise_learning: Measure noise learning options.
-        twirling_num_randomizations: The number of randomizations used by the
-            estimation twirling, used to resolve ``num_randomizations="auto"``
-            (see :func:`resolve_trex_num_randomizations`).
+        num_randomizations: The number of TREX calibration randomizations (already
+            resolved, see :func:`resolve_trex_num_randomizations`).
 
     Returns:
         Samplex item containing calibration circuit for TREX factors calculation.
     """
-    num_randomizations = resolve_trex_num_randomizations(
-        measure_noise_learning, twirling_num_randomizations
-    )
     # create the combined noise learning layer of all given inputs
     max_num_qubits = max(pub.circuit.num_qubits for pub in pubs)
 

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -203,7 +203,9 @@ def prepare_zne(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(pubs, measure_noise_learning)
+        trex_item = create_trex_calibration_circuit(
+            pubs, measure_noise_learning, num_randomizations
+        )
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -35,7 +35,7 @@ from ...executor.calculate_twirling_shots import calculate_twirling_shots
 from ...options_models.zne_options import ZNE_DEFAULT_NOISE_FACTORS
 from ...quantum_program import QuantumProgram
 from ...quantum_program.quantum_program import SamplexItem
-from ..trex_utils import create_trex_calibration_circuit
+from ..trex_utils import create_trex_calibration_circuit, resolve_trex_num_randomizations
 from ..utils import (
     box_circuit,
     compute_samplex_arguments,
@@ -203,9 +203,10 @@ def prepare_zne(
             raise IBMInputValueError(
                 "shots_per_randomization must be the same for twirling and measure_noise_learning"
             )
-        trex_item = create_trex_calibration_circuit(
-            pubs, measure_noise_learning, num_randomizations
+        trex_num_randomizations = resolve_trex_num_randomizations(
+            measure_noise_learning, num_randomizations
         )
+        trex_item = create_trex_calibration_circuit(pubs, trex_num_randomizations)
         quantum_program.items.append(trex_item)
         passthrough_data["post_processor"]["measure_mitigation"] = "True"
 

--- a/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
+++ b/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
@@ -30,8 +30,12 @@ class MeasureNoiseLearningOptions:
         technique that requires measurement noise learning.
     """
 
-    num_randomizations: int = 32
-    """The number of random circuits to draw for the measurement learning experiment."""
+    num_randomizations: int | Literal["auto"] = "auto"
+    """The number of random circuits to draw for the measurement learning experiment.
+
+    If "auto", the calibration uses the same number of randomizations
+    as the estimation twirling.
+    """
 
     shots_per_randomization: int | Literal["auto"] = "auto"
     """The number of shots to use for the learning experiment per random circuit.

--- a/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
+++ b/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
@@ -34,7 +34,7 @@ class MeasureNoiseLearningOptions:
     """The number of random circuits to draw for the measurement learning experiment.
 
     If "auto", the calibration uses the same number of randomizations
-    as the estimation twirling.
+    as specified in the estimator's twirling options.
     """
 
     shots_per_randomization: int | Literal["auto"] = "auto"

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -42,7 +42,7 @@ class TestEstimatorOptions(unittest.TestCase):
         self.assertIsNone(options.max_execution_time)
         self.assertIsInstance(options.environment, EnvironmentOptions)
         self.assertIsNone(options.resilience.measure_mitigation)
-        self.assertEqual(options.resilience.measure_noise_learning.num_randomizations, 32)
+        self.assertEqual(options.resilience.measure_noise_learning.num_randomizations, "auto")
         self.assertEqual(options.resilience.measure_noise_learning.shots_per_randomization, "auto")
 
     def test_set_default_precision(self):

--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -386,7 +386,7 @@ class TestPrepareFunction(unittest.TestCase):
         )
 
     def test_prepare_with_measure_noise_learning_default_num_randomizations(self):
-        """Test that TREX item uses default num_randomizations=32 when not specified."""
+        """With num_randomizations="auto" (default), TREX follows the twirling randomizations."""
         circuit = QuantumCircuit(2)
         circuit.h(0)
         circuit.cx(0, 1)
@@ -395,7 +395,7 @@ class TestPrepareFunction(unittest.TestCase):
         pub = EstimatorPub.coerce((circuit, observable))
 
         shots = 1024
-        # Create MeasureNoiseLearningOptions without setting num_randomizations
+        # Create MeasureNoiseLearningOptions without setting num_randomizations ("auto")
         measure_noise_learning = MeasureNoiseLearningOptions()
 
         twirling_options = TwirlingOptions()
@@ -404,15 +404,16 @@ class TestPrepareFunction(unittest.TestCase):
 
         quantum_program = prepare([pub], twirling_options, shots, measure_noise_learning)
 
-        # Get the TREX calibration item (last item)
+        # The estimation item's randomization count (its shape's first dimension).
+        estimation_num_randomizations = quantum_program.items[0].shape[0]
+
+        # TREX item (last item) should use the same number of randomizations as twirling.
         trex_item = quantum_program.items[-1]
         self.assertIsInstance(trex_item, SamplexItem)
-
-        # Verify the shape uses default value of 32
         self.assertEqual(
             trex_item.shape,
-            (32,),
-            "Expected TREX item shape (32,) when num_randomizations is not set",
+            (estimation_num_randomizations,),
+            'Expected TREX to follow the twirling randomizations when num_randomizations="auto"',
         )
 
     def test_prepare_with_measure_noise_learning_multiple_pubs_num_randomizations(self):

--- a/test/unit/executor_estimator/test_estimator_v2_trex_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_trex_utils.py
@@ -18,7 +18,10 @@ from qiskit import QuantumCircuit
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import SparsePauliOp
 
-from qiskit_ibm_runtime.executor_estimator.trex_utils import create_trex_calibration_circuit
+from qiskit_ibm_runtime.executor_estimator.trex_utils import (
+    create_trex_calibration_circuit,
+    resolve_trex_num_randomizations,
+)
 from qiskit_ibm_runtime.options_models.measure_noise_learning_options import (
     MeasureNoiseLearningOptions,
 )
@@ -28,8 +31,8 @@ from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
 class TestCreateTrexCalibrationCircuit(unittest.TestCase):
     """Tests for create_trex_calibration_circuit function."""
 
-    def test_creates_samplex_item_with_max_qubits_and_requested_randomizations(self):
-        """Test calibration circuit shape and size are derived from inputs."""
+    def test_explicit_num_randomizations_is_used(self):
+        """An explicit num_randomizations is used as-is, ignoring the twirling value."""
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
         circuit1.cx(0, 1)
@@ -45,21 +48,26 @@ class TestCreateTrexCalibrationCircuit(unittest.TestCase):
         measure_noise_learning = MeasureNoiseLearningOptions()
         measure_noise_learning.num_randomizations = 16
 
-        result = create_trex_calibration_circuit([pub1, pub2], measure_noise_learning)
+        # twirling_num_randomizations (8) is ignored because num_randomizations is explicit.
+        result = create_trex_calibration_circuit(
+            [pub1, pub2], measure_noise_learning, twirling_num_randomizations=8
+        )
 
         self.assertIsInstance(result, SamplexItem)
         self.assertEqual(result.shape, (16,))
         self.assertEqual(result.circuit.num_qubits, 3)
         self.assertIn("_trex_cal", result.circuit.cregs[0].name)
 
-    def test_uses_default_randomizations_when_not_integer(self):
-        """Test default randomizations value is used when option is not an integer."""
+    def test_auto_follows_twirling_num_randomizations(self):
+        """With num_randomizations="auto" (default), TREX follows the twirling value."""
         circuit = QuantumCircuit(2)
         pub = EstimatorPub.coerce((circuit, SparsePauliOp.from_list([("ZZ", 1)])))
 
-        measure_noise_learning = MeasureNoiseLearningOptions()
+        measure_noise_learning = MeasureNoiseLearningOptions()  # num_randomizations="auto"
 
-        result = create_trex_calibration_circuit([pub], measure_noise_learning)
+        result = create_trex_calibration_circuit(
+            [pub], measure_noise_learning, twirling_num_randomizations=32
+        )
 
         self.assertEqual(result.shape, (32,))
 
@@ -70,8 +78,25 @@ class TestCreateTrexCalibrationCircuit(unittest.TestCase):
         circuit.cx(0, 1)
         pub = EstimatorPub.coerce((circuit, SparsePauliOp.from_list([("ZZ", 1)])))
 
-        result = create_trex_calibration_circuit([pub], MeasureNoiseLearningOptions())
+        result = create_trex_calibration_circuit(
+            [pub], MeasureNoiseLearningOptions(), twirling_num_randomizations=32
+        )
 
         operation_names = {instruction.operation.name for instruction in result.circuit.data}
         self.assertIn("measure", operation_names)
         self.assertFalse({"h", "x", "cx"} & operation_names)
+
+
+class TestResolveTrexNumRandomizations(unittest.TestCase):
+    """Tests for resolve_trex_num_randomizations."""
+
+    def test_auto_returns_twirling_value(self):
+        """'auto' resolves to the twirling num_randomizations."""
+        options = MeasureNoiseLearningOptions()  # num_randomizations="auto"
+        self.assertEqual(resolve_trex_num_randomizations(options, 12), 12)
+
+    def test_explicit_int_is_returned(self):
+        """An explicit int is returned unchanged, regardless of the twirling value."""
+        options = MeasureNoiseLearningOptions()
+        options.num_randomizations = 50
+        self.assertEqual(resolve_trex_num_randomizations(options, 12), 50)

--- a/test/unit/executor_estimator/test_estimator_v2_trex_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_trex_utils.py
@@ -31,8 +31,8 @@ from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
 class TestCreateTrexCalibrationCircuit(unittest.TestCase):
     """Tests for create_trex_calibration_circuit function."""
 
-    def test_explicit_num_randomizations_is_used(self):
-        """An explicit num_randomizations is used as-is, ignoring the twirling value."""
+    def test_creates_samplex_item_with_given_randomizations(self):
+        """Test calibration circuit shape and size are derived from inputs."""
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
         circuit1.cx(0, 1)
@@ -45,31 +45,12 @@ class TestCreateTrexCalibrationCircuit(unittest.TestCase):
         pub1 = EstimatorPub.coerce((circuit1, SparsePauliOp.from_list([("ZZ", 1)])))
         pub2 = EstimatorPub.coerce((circuit2, SparsePauliOp.from_list([("ZZZ", 1)])))
 
-        measure_noise_learning = MeasureNoiseLearningOptions()
-        measure_noise_learning.num_randomizations = 16
-
-        # twirling_num_randomizations (8) is ignored because num_randomizations is explicit.
-        result = create_trex_calibration_circuit(
-            [pub1, pub2], measure_noise_learning, twirling_num_randomizations=8
-        )
+        result = create_trex_calibration_circuit([pub1, pub2], num_randomizations=16)
 
         self.assertIsInstance(result, SamplexItem)
         self.assertEqual(result.shape, (16,))
         self.assertEqual(result.circuit.num_qubits, 3)
         self.assertIn("_trex_cal", result.circuit.cregs[0].name)
-
-    def test_auto_follows_twirling_num_randomizations(self):
-        """With num_randomizations="auto" (default), TREX follows the twirling value."""
-        circuit = QuantumCircuit(2)
-        pub = EstimatorPub.coerce((circuit, SparsePauliOp.from_list([("ZZ", 1)])))
-
-        measure_noise_learning = MeasureNoiseLearningOptions()  # num_randomizations="auto"
-
-        result = create_trex_calibration_circuit(
-            [pub], measure_noise_learning, twirling_num_randomizations=32
-        )
-
-        self.assertEqual(result.shape, (32,))
 
     def test_creates_measurement_only_calibration_circuit(self):
         """Test generated TREX circuit contains measurements and no state-preparation gates."""
@@ -78,9 +59,7 @@ class TestCreateTrexCalibrationCircuit(unittest.TestCase):
         circuit.cx(0, 1)
         pub = EstimatorPub.coerce((circuit, SparsePauliOp.from_list([("ZZ", 1)])))
 
-        result = create_trex_calibration_circuit(
-            [pub], MeasureNoiseLearningOptions(), twirling_num_randomizations=32
-        )
+        result = create_trex_calibration_circuit([pub], num_randomizations=32)
 
         operation_names = {instruction.operation.name for instruction in result.circuit.data}
         self.assertIn("measure", operation_names)

--- a/test/unit/executor_estimator/test_resilience_options.py
+++ b/test/unit/executor_estimator/test_resilience_options.py
@@ -28,7 +28,7 @@ class TestResilienceOptionsDefaults(unittest.TestCase):
         """All fields carry their documented default values."""
         opts = ResilienceOptions()
         self.assertIsNone(opts.measure_mitigation)
-        self.assertEqual(opts.measure_noise_learning.num_randomizations, 32)
+        self.assertEqual(opts.measure_noise_learning.num_randomizations, "auto")
         self.assertEqual(opts.measure_noise_learning.shots_per_randomization, "auto")
         self.assertFalse(opts.pec_mitigation)
         self.assertEqual(opts.pec.max_overhead, 100)


### PR DESCRIPTION
### Summary
Measure_noise_learning.num_randomizations now defaults at "auto", which will re-use the twirling num_randomizations. If it is explicitly set to an int, then it will use that int.

Fixes #3023 

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude
