### PR TITLE
Small improvements to prepare functions

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -140,8 +140,9 @@ def prepare_pec(
         if pec_options.noise_gain == "auto":
             # calculate the gamma factor without scaling it by noise_factor
             gamma = calculate_gamma(boxed_circuit, noise_model_mapping, 1)
-            # calculate the noise factor based on gamma and max_overhead
-            noise_gain = 1 - np.log(max_overhead) / np.log(gamma**2)
+            # calculate the noise factor based on gamma and max_overhead, setting it to ``1``
+            # if ``gamma`` is ``1``--i.e., if there is no noise to mitigate.
+            noise_gain = 1 if gamma == 1 else 1 - np.log(max_overhead) / np.log(gamma**2)
             # Truncate noise_gain to [0, 1]
             noise_gain = min(1, max(0, noise_gain))
         else:

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -167,9 +167,7 @@ def prepare_pec(
             try:
                 pub_noise_model[ref] = noise_model_mapping[ref]
             except KeyError:
-                raise IBMInputValueError(
-                    f"noise_model_mapping is missing noise map for layer reference {ref}"
-                )
+                raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
             # noise_scales and pauli_lindblad_maps should have the same refs
             samplex_arguments[f"noise_scales.{ref}"] = noise_scale
 

--- a/qiskit_ibm_runtime/executor_estimator/pec/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/utils.py
@@ -18,6 +18,8 @@ import logging
 import math
 from typing import TYPE_CHECKING
 
+from ...exceptions import IBMInputValueError
+
 if TYPE_CHECKING:
     from qiskit import QuantumCircuit
     from qiskit.quantum_info import PauliLindbladMap
@@ -50,10 +52,14 @@ def calculate_gamma(
     gamma = 1.0
     for instr in boxed_circuit:
         if annot := get_annotation(instr.operation, InjectNoise):
-            plm = noise_model_mapping[annot.ref]
+            ref = annot.ref
+            try:
+                noise_model = noise_model_mapping[ref]
+            except KeyError:
+                raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
             # scale the noise by noise_factor
-            plm = plm.scale_rates(noise_factor)
-            gamma *= plm.inverse().gamma()
+            noise_model = noise_model.scale_rates(noise_factor)
+            gamma *= noise_model.inverse().gamma()
     return gamma
 
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -146,11 +146,11 @@ def prepare_pea(
         pub_noise_model = {}
         for spec in specs:
             ref = spec.name.split(".")[-1]
-            if ref not in noise_model_mapping.keys():
-                raise IBMInputValueError(
-                    f"noise_model_mapping is missing noise map for layer reference {ref}"
-                )
-            pub_noise_model[ref] = noise_model_mapping[ref]
+            try:
+                noise_model = noise_model_mapping[ref]
+            except KeyError:
+                raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
+            pub_noise_model[ref] = noise_model
             samplex_arguments[f"noise_scales.{ref}"] = noise_scales
 
         samplex_arguments["pauli_lindblad_maps"] = pub_noise_model

--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -239,10 +239,8 @@ class TestPreparePeaFunction(unittest.TestCase):
         twirling_options.enable_gates = True
         twirling_options.enable_measure = True
 
-        with self.assertRaises(IBMInputValueError) as context:
+        with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
             prepare_pea([pub], twirling_options, 1024, zne_options, {})
-
-        self.assertIn("noise_model_mapping", str(context.exception))
 
     def test_prepare_pea_raises_error_with_missing_noise_model_key(self):
         """Test that prepare_pea raises error when noise_model_mapping is missing a noise model."""
@@ -278,10 +276,8 @@ class TestPreparePeaFunction(unittest.TestCase):
         twirling_options.enable_gates = True
         twirling_options.enable_measure = True
 
-        with self.assertRaises(IBMInputValueError) as context:
+        with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
             prepare_pea([pub1, pub2], twirling_options, 1024, zne_options, noise_model_mapping)
-
-        self.assertIn("noise_model_mapping", str(context.exception))
 
     def test_prepare_pea_with_measure_noise_learning(self):
         """Test prepare_pea with measure noise learning (TREX)."""

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -503,3 +503,32 @@ class TestPreparePecFunction(unittest.TestCase):
         passthrough = cast("dict[str, Any]", quantum_program.passthrough_data)
         self.assertEqual(passthrough["post_processor"]["measure_mitigation"], "True")
         self.assertIn("pec_gammas", passthrough["post_processor"])
+
+    def test_prepare_pec_with_trivial_noise_maps(self):
+        """Test ``prepare_pec`` with noise maps set to identity."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+        pub = EstimatorPub.coerce((circuit, observable))
+
+        # Create a simple noise model
+        layers = find_unique_layers([pub], TwirlingOptions(), inject_noise=True)
+        noise_layer_ref = ""
+        for layer in layers:
+            if annot := get_annotation(layer.operation, InjectNoise):
+                noise_layer_ref = annot.ref
+        noise_model_mapping = {noise_layer_ref: PauliLindbladMap.identity(num_qubits=2)}
+
+        pec_options = PecOptions()
+        twirling_options = TwirlingOptions()
+        twirling_options.enable_gates = True
+        twirling_options.enable_measure = True
+
+        shots = 1024
+        quantum_program = prepare_pec(
+            [pub], twirling_options, shots, pec_options, noise_model_mapping
+        )
+        item = cast("SamplexItem", quantum_program.items[0])
+        self.assertEqual(item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], 0)

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -196,6 +196,23 @@ class TestCalculateGamma(unittest.TestCase):
         # Gamma should be 1.0 when noise is scaled to zero
         self.assertAlmostEqual(result, 1.0)
 
+    def test_missing_map_raises(self):
+        """Test that gamma calculation raises if maps are missing from ``noise_model_mapping``."""
+        # Create a simple circuit with one two-qubit gate annotated with noise
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[InjectNoise(ref="ref", site="after")]):
+            circuit.h(0)
+            circuit.cx(0, 1)
+
+        # Create a two-qubit noise model with known gamma
+        noise_model = PauliLindbladMap.from_sparse_list(
+            [("ZX", [0, 1], 0.1), ("XZ", [0, 1], 0.1)], num_qubits=2
+        )
+        noise_model_mapping = {"another_ref": noise_model}
+
+        with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
+            calculate_gamma(circuit, noise_model_mapping, noise_factor=1)
+
 
 @ddt
 class TestPreparePecFunction(unittest.TestCase):
@@ -408,10 +425,8 @@ class TestPreparePecFunction(unittest.TestCase):
         twirling_options.enable_gates = True
         twirling_options.enable_measure = True
 
-        with self.assertRaises(IBMInputValueError) as context:
+        with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
             prepare_pec([pub], twirling_options, 1024, pec_options, {})
-
-        self.assertIn("noise_model_mapping", str(context.exception))
 
     def test_prepare_pec_raises_error_with_missing_noise_model_key(self):
         """Test that prepare_pec raises error when noise_model_mapping is missing a noise model."""
@@ -445,10 +460,8 @@ class TestPreparePecFunction(unittest.TestCase):
         twirling_options.enable_gates = True
         twirling_options.enable_measure = True
 
-        with self.assertRaises(IBMInputValueError) as context:
+        with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
             prepare_pec([pub1, pub2], twirling_options, 1024, pec_options, noise_model_mapping)
-
-        self.assertIn("noise_model_mapping", str(context.exception))
 
     def test_prepare_pec_with_measure_noise_learning(self):
         """Test prepare_pec with measure noise learning (TREX)."""


### PR DESCRIPTION
### Summary
This PR adds two small improvements to the existing functions:
- Firstly, it modifies `prepare_pec` so that when `gamma` is `1`, the calculation of `noise_gain` does not raise a "dividing-by-zero" warning, which currently shows up (eg in tests) when users try `prepare_pec` passing trivial maps.
- Secondly, it adds a graceful error message to `calculate_gamma` for the case where a ref is missing from the noise models map.
- Finally, it rewrites all the error messages for the case of missing refs consistently.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
