### PR TITLE
Homogenize imports towards relative imports

### DIFF
--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from qiskit_ibm_runtime.api.session import RetrySession
-
+from ...api.session import RetrySession
 from ..rest.runtime import Runtime
 from .backend import BaseBackendClient
 

--- a/qiskit_ibm_runtime/api/rest/cloud_backend.py
+++ b/qiskit_ibm_runtime/api/rest/cloud_backend.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from qiskit_ibm_runtime.api.rest.base import RestAdapterBase
+from .base import RestAdapterBase
 
 if TYPE_CHECKING:
     from datetime import datetime as python_datetime

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -18,12 +18,11 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from qiskit_ibm_runtime.api.rest.base import RestAdapterBase
-from qiskit_ibm_runtime.api.rest.program_job import ProgramJob
-from qiskit_ibm_runtime.utils import local_to_utc
-
 from ...json import RuntimeEncoder
+from ...utils import local_to_utc
+from .base import RestAdapterBase
 from .cloud_backend import CloudBackend
+from .program_job import ProgramJob
 from .runtime_session import RuntimeSession
 
 if TYPE_CHECKING:

--- a/qiskit_ibm_runtime/base_runtime_job.py
+++ b/qiskit_ibm_runtime/base_runtime_job.py
@@ -33,10 +33,9 @@ if TYPE_CHECKING:
     from qiskit.providers.backend import Backend
     from qiskit.providers.jobstatus import JobStatus as RuntimeJobStatus
 
-    from qiskit_ibm_runtime import qiskit_runtime_service
-
     from .api.clients import RuntimeClient
     from .models import BackendProperties
+    from .qiskit_runtime_service import QiskitRuntimeService
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +79,7 @@ class BaseRuntimeJob(ABC):
         api_client: RuntimeClient,
         job_id: str,
         program_id: str,
-        service: qiskit_runtime_service.QiskitRuntimeService,
+        service: QiskitRuntimeService,
         creation_date: str | None = None,
         result_decoder: type[ResultDecoder] | Sequence[type[ResultDecoder]] | None = None,
         image: str | None = "",

--- a/qiskit_ibm_runtime/batch.py
+++ b/qiskit_ibm_runtime/batch.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from qiskit_ibm_runtime import QiskitRuntimeService
-
+from .qiskit_runtime_service import QiskitRuntimeService
 from .session import Session
 
 if TYPE_CHECKING:

--- a/qiskit_ibm_runtime/calibrator.py
+++ b/qiskit_ibm_runtime/calibrator.py
@@ -18,10 +18,10 @@ import logging
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
-from qiskit_ibm_runtime.base_primitive import get_mode_service_backend
-from qiskit_ibm_runtime.fake_provider.local_service import QiskitRuntimeLocalService
-from qiskit_ibm_runtime.options_models.calibrator_options import CalibratorOptions
-from qiskit_ibm_runtime.utils.default_session import get_cm_session
+from .base_primitive import get_mode_service_backend
+from .fake_provider.local_service import QiskitRuntimeLocalService
+from .options_models.calibrator_options import CalibratorOptions
+from .utils.default_session import get_cm_session
 
 if TYPE_CHECKING:
     from qiskit.providers import BackendV2

--- a/qiskit_ibm_runtime/debug_tools/neat.py
+++ b/qiskit_ibm_runtime/debug_tools/neat.py
@@ -20,8 +20,8 @@ from qiskit.exceptions import QiskitError
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.transpiler.passmanager import PassManager
 
-from qiskit_ibm_runtime.debug_tools.neat_results import NeatPubResult, NeatResult
-from qiskit_ibm_runtime.transpiler.passes.cliffordization import ConvertISAToClifford
+from ..transpiler.passes.cliffordization import ConvertISAToClifford
+from .neat_results import NeatPubResult, NeatResult
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/qiskit_ibm_runtime/decoders/executor_sampler/utils.py
+++ b/qiskit_ibm_runtime/decoders/executor_sampler/utils.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from qiskit_ibm_runtime.execution_span import DoubleSliceSpan, TwirledSliceSpanV2
+from ...execution_span import DoubleSliceSpan, TwirledSliceSpanV2
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/qiskit_ibm_runtime/decoders/executor_sampler/utils.py
+++ b/qiskit_ibm_runtime/decoders/executor_sampler/utils.py
@@ -24,11 +24,7 @@ from ...execution_span import DoubleSliceSpan, TwirledSliceSpanV2
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from qiskit_ibm_runtime.results.quantum_program import (
-        ChunkSpan,
-        Metadata,
-        QuantumProgramItemResult,
-    )
+    from ...results.quantum_program import ChunkSpan, Metadata, QuantumProgramItemResult
 
 TWIRLING_PREFIX = "measurement_flips."
 """The prefix used to store the twirling bitflips."""

--- a/qiskit_ibm_runtime/decoders/noise_learner.py
+++ b/qiskit_ibm_runtime/decoders/noise_learner.py
@@ -21,7 +21,7 @@ from ..results.noise_learner import LayerError, NoiseLearnerResult, PauliLindbla
 from .result_decoder import ResultDecoder
 
 if TYPE_CHECKING:
-    from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Results
+    from ..results.noise_learner_v3 import NoiseLearnerV3Results
 
 
 class NoiseLearnerResultDecoder(ResultDecoder):

--- a/qiskit_ibm_runtime/decoders/noise_learner_v3/decoder.py
+++ b/qiskit_ibm_runtime/decoders/noise_learner_v3/decoder.py
@@ -35,7 +35,7 @@ from .converters import (
 )
 
 if TYPE_CHECKING:
-    from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Results
+    from ...results.noise_learner_v3 import NoiseLearnerV3Results
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit_ibm_runtime/decoders/result_decoder.py
+++ b/qiskit_ibm_runtime/decoders/result_decoder.py
@@ -15,7 +15,7 @@
 import json
 from typing import Any
 
-from qiskit_ibm_runtime.json import RuntimeDecoder
+from ..json import RuntimeDecoder
 
 
 class ResultDecoder:

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -20,11 +20,10 @@ from typing import TYPE_CHECKING
 from qiskit.primitives.base import BaseEstimatorV2
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 
-from qiskit_ibm_runtime.utils.deprecation import issue_deprecation_msg
-
 from .base_primitive import BasePrimitiveV2
 from .options.estimator_options import EstimatorOptions
 from .utils import validate_estimator_pubs
+from .utils.deprecation import issue_deprecation_msg
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -18,9 +18,8 @@ import logging
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
-from qiskit_ibm_runtime.base_primitive import get_mode_service_backend
-from qiskit_ibm_runtime.fake_provider.local_service import QiskitRuntimeLocalService
-
+from ..base_primitive import get_mode_service_backend
+from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.executor_options import ExecutorOptions
 from ..quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
 from ..utils.default_session import get_cm_session

--- a/qiskit_ibm_runtime/fake_provider/backends/aachen/fake_aachen.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/aachen/fake_aachen.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeAachen(fake_backend.FakeBackendV2):
+class FakeAachen(FakeBackendV2):
     """A fake 156 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/algiers/fake_algiers.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/algiers/fake_algiers.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeAlgiers(fake_backend.FakeBackendV2):
+class FakeAlgiers(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeAlmadenV2(fake_backend.FakeBackendV2):
+class FakeAlmadenV2(FakeBackendV2):
     """A fake Almaden V2 backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeArmonkV2(fake_backend.FakeBackendV2):
+class FakeArmonkV2(FakeBackendV2):
     """A fake 1 qubit backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeAthensV2(fake_backend.FakeBackendV2):
+class FakeAthensV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py
@@ -15,10 +15,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeAuckland(fake_backend.FakeBackendV2):
+class FakeAuckland(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBelemV2(fake_backend.FakeBackendV2):
+class FakeBelemV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/berlin/fake_berlin.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/berlin/fake_berlin.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBerlin(fake_backend.FakeBackendV2):
+class FakeBerlin(FakeBackendV2):
     """A fake 120 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBoeblingenV2(fake_backend.FakeBackendV2):
+class FakeBoeblingenV2(FakeBackendV2):
     """A fake Boeblingen V2 backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBogotaV2(fake_backend.FakeBackendV2):
+class FakeBogotaV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/boston/fake_boston.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/boston/fake_boston.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBoston(fake_backend.FakeBackendV2):
+class FakeBoston(FakeBackendV2):
     """A fake 156 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/brisbane/fake_brisbane.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/brisbane/fake_brisbane.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBrisbane(fake_backend.FakeBackendV2):
+class FakeBrisbane(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBrooklynV2(fake_backend.FakeBackendV2):
+class FakeBrooklynV2(FakeBackendV2):
     """A fake Brooklyn V2 backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/brussels/fake_brussels.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/brussels/fake_brussels.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBrussels(fake_backend.FakeBackendV2):
+class FakeBrussels(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeBurlingtonV2(fake_backend.FakeBackendV2):
+class FakeBurlingtonV2(FakeBackendV2):
     """A fake 5 qubit backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeCairoV2(fake_backend.FakeBackendV2):
+class FakeCairoV2(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeCambridgeV2(fake_backend.FakeBackendV2):
+class FakeCambridgeV2(FakeBackendV2):
     """A fake Cambridge backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeCasablancaV2(fake_backend.FakeBackendV2):
+class FakeCasablancaV2(FakeBackendV2):
     """A fake 7 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/cusco/fake_cusco.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/cusco/fake_cusco.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeCusco(fake_backend.FakeBackendV2):
+class FakeCusco(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeEssexV2(fake_backend.FakeBackendV2):
+class FakeEssexV2(FakeBackendV2):
     """A fake 5 qubit backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/fez/fake_fez.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/fez/fake_fez.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeFez(fake_backend.FakeBackendV2):
+class FakeFez(FakeBackendV2):
     """A fake 156 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/fractional/fake_fractional.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/fractional/fake_fractional.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeFractionalBackend(fake_backend.FakeBackendV2):
+class FakeFractionalBackend(FakeBackendV2):
     """A fake 5 qubit backend with dynamic and fractional feature modeled based on FakeLima.
 
     This backend include following features.

--- a/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py
@@ -15,10 +15,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeGeneva(fake_backend.FakeBackendV2):
+class FakeGeneva(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeGuadalupeV2(fake_backend.FakeBackendV2):
+class FakeGuadalupeV2(FakeBackendV2):
     """A fake 16 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeHanoiV2(fake_backend.FakeBackendV2):
+class FakeHanoiV2(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeJakartaV2(fake_backend.FakeBackendV2):
+class FakeJakartaV2(FakeBackendV2):
     """A fake 7 qubit V2 backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeJohannesburgV2(fake_backend.FakeBackendV2):
+class FakeJohannesburgV2(FakeBackendV2):
     """A fake Johannesburg V2 backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/kawasaki/fake_kawasaki.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kawasaki/fake_kawasaki.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeKawasaki(fake_backend.FakeBackendV2):
+class FakeKawasaki(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/kingston/fake_kingston.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kingston/fake_kingston.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeKingston(fake_backend.FakeBackendV2):
+class FakeKingston(FakeBackendV2):
     """A fake 156 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeKolkataV2(fake_backend.FakeBackendV2):
+class FakeKolkataV2(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/kyiv/fake_kyiv.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kyiv/fake_kyiv.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeKyiv(fake_backend.FakeBackendV2):
+class FakeKyiv(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/kyoto/fake_kyoto.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/kyoto/fake_kyoto.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeKyoto(fake_backend.FakeBackendV2):
+class FakeKyoto(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeLagosV2(fake_backend.FakeBackendV2):
+class FakeLagosV2(FakeBackendV2):
     """A fake 7 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeLimaV2(fake_backend.FakeBackendV2):
+class FakeLimaV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeLondonV2(fake_backend.FakeBackendV2):
+class FakeLondonV2(FakeBackendV2):
     """A fake 5 qubit backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeManhattanV2(fake_backend.FakeBackendV2):
+class FakeManhattanV2(FakeBackendV2):
     """A fake Manhattan backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeManilaV2(fake_backend.FakeBackendV2):
+class FakeManilaV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/marrakesh/fake_marrakesh.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/marrakesh/fake_marrakesh.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeMarrakesh(fake_backend.FakeBackendV2):
+class FakeMarrakesh(FakeBackendV2):
     """A fake 156 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeMelbourneV2(fake_backend.FakeBackendV2):
+class FakeMelbourneV2(FakeBackendV2):
     """A fake 15 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/miami/fake_miami.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/miami/fake_miami.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeMiami(fake_backend.FakeBackendV2):
+class FakeMiami(FakeBackendV2):
     """A fake 120 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeMontrealV2(fake_backend.FakeBackendV2):
+class FakeMontrealV2(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeMumbaiV2(fake_backend.FakeBackendV2):
+class FakeMumbaiV2(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeNairobiV2(fake_backend.FakeBackendV2):
+class FakeNairobiV2(FakeBackendV2):
     """A fake 7 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from ...fake_backend import FakeBackendV2
 
 if TYPE_CHECKING:
-    from qiskit_ibm_runtime import QiskitRuntimeService
+    from ....qiskit_runtime_service import QiskitRuntimeService
 
 DISPLAY_WARNING = True
 

--- a/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
@@ -18,7 +18,7 @@ import os
 import warnings
 from typing import TYPE_CHECKING
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 if TYPE_CHECKING:
     from qiskit_ibm_runtime import QiskitRuntimeService
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 DISPLAY_WARNING = True
 
 
-class FakeNighthawk(fake_backend.FakeBackendV2):
+class FakeNighthawk(FakeBackendV2):
     """A fake 120 qubit backend.
 
     Its coupling map and basis gates match those of a real Nighthawk backend, but the properties

--- a/qiskit_ibm_runtime/fake_provider/backends/osaka/fake_osaka.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/osaka/fake_osaka.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeOsaka(fake_backend.FakeBackendV2):
+class FakeOsaka(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py
@@ -15,10 +15,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeOslo(fake_backend.FakeBackendV2):
+class FakeOslo(FakeBackendV2):
     """A fake 7 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeOurenseV2(fake_backend.FakeBackendV2):
+class FakeOurenseV2(FakeBackendV2):
     """A fake 5 qubit backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeParisV2(fake_backend.FakeBackendV2):
+class FakeParisV2(FakeBackendV2):
     """A fake Paris backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/peekskill/fake_peekskill.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/peekskill/fake_peekskill.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakePeekskill(fake_backend.FakeBackendV2):
+class FakePeekskill(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py
@@ -15,10 +15,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakePerth(fake_backend.FakeBackendV2):
+class FakePerth(FakeBackendV2):
     """A fake 7 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/pittsburgh/fake_pittsburgh.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/pittsburgh/fake_pittsburgh.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakePittsburgh(fake_backend.FakeBackendV2):
+class FakePittsburgh(FakeBackendV2):
     """A fake 156 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakePoughkeepsieV2(fake_backend.FakeBackendV2):
+class FakePoughkeepsieV2(FakeBackendV2):
     """A fake Poughkeepsie backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py
@@ -15,10 +15,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakePrague(fake_backend.FakeBackendV2):
+class FakePrague(FakeBackendV2):
     """A fake 33 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/quebec/fake_quebec.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/quebec/fake_quebec.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeQuebec(fake_backend.FakeBackendV2):
+class FakeQuebec(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeQuitoV2(fake_backend.FakeBackendV2):
+class FakeQuitoV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeRochesterV2(fake_backend.FakeBackendV2):
+class FakeRochesterV2(FakeBackendV2):
     """A fake Rochester backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeRomeV2(fake_backend.FakeBackendV2):
+class FakeRomeV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeSantiagoV2(fake_backend.FakeBackendV2):
+class FakeSantiagoV2(FakeBackendV2):
     """A fake Santiago backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeSherbrooke(fake_backend.FakeBackendV2):
+class FakeSherbrooke(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeSingaporeV2(fake_backend.FakeBackendV2):
+class FakeSingaporeV2(FakeBackendV2):
     """A fake Singapore backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/strasbourg/fake_strasbourg.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/strasbourg/fake_strasbourg.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeStrasbourg(fake_backend.FakeBackendV2):
+class FakeStrasbourg(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeSydneyV2(fake_backend.FakeBackendV2):
+class FakeSydneyV2(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/torino/fake_torino.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/torino/fake_torino.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeTorino(fake_backend.FakeBackendV2):
+class FakeTorino(FakeBackendV2):
     """A fake 133 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeTorontoV2(fake_backend.FakeBackendV2):
+class FakeTorontoV2(FakeBackendV2):
     """A fake 27 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeValenciaV2(fake_backend.FakeBackendV2):
+class FakeValenciaV2(FakeBackendV2):
     """A fake 5 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeVigoV2(fake_backend.FakeBackendV2):
+class FakeVigoV2(FakeBackendV2):
     """A fake 5 qubit backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeWashingtonV2(fake_backend.FakeBackendV2):
+class FakeWashingtonV2(FakeBackendV2):
     """A fake 127 qubit backend."""
 
     dirname = os.path.dirname(__file__)

--- a/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py
@@ -14,10 +14,10 @@
 
 import os
 
-from qiskit_ibm_runtime.fake_provider import fake_backend
+from ...fake_backend import FakeBackendV2
 
 
-class FakeYorktownV2(fake_backend.FakeBackendV2):
+class FakeYorktownV2(FakeBackendV2):
     """A fake 5 qubit backend.
 
     .. code-block:: text

--- a/qiskit_ibm_runtime/fake_provider/local_runtime_job.py
+++ b/qiskit_ibm_runtime/fake_provider/local_runtime_job.py
@@ -20,8 +20,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from qiskit.primitives.primitive_job import PrimitiveJob
 
 if TYPE_CHECKING:
-    from qiskit_ibm_runtime.models import BackendProperties
-
+    from ..models import BackendProperties
     from .fake_backend import FakeBackendV2
 
 

--- a/qiskit_ibm_runtime/json.py
+++ b/qiskit_ibm_runtime/json.py
@@ -469,7 +469,7 @@ class RuntimeDecoder(json.JSONDecoder):
                 try:
                     # importing here and not at the top of the file,
                     # to prevent circular imports
-                    from qiskit_ibm_runtime.noise_learner_v3.params_converters import (
+                    from .noise_learner_v3.params_converters import (
                         NOISE_LEARNER_V3_PARAMS_CONVERTERS,
                     )
 

--- a/qiskit_ibm_runtime/json.py
+++ b/qiskit_ibm_runtime/json.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, get_args
 import dateutil.parser
 import numpy as np
 
-from qiskit_ibm_runtime.quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
+from .quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
 
 try:
     from qiskit.quantum_info import PauliLindbladMap
@@ -58,16 +58,15 @@ from qiskit.result import Result
 from qiskit.transpiler import CouplingMap
 from qiskit.utils import LazyImportTester
 
-from qiskit_ibm_runtime.execution_span import (
+from .execution_span import (
     DoubleSliceSpan,
     ExecutionSpans,
     SliceSpan,
     TwirledSliceSpan,
     TwirledSliceSpanV2,
 )
-from qiskit_ibm_runtime.options.zne_options import ExtrapolatorType
-from qiskit_ibm_runtime.results.estimator_pub import EstimatorPubResult
-
+from .options.zne_options import ExtrapolatorType
+from .results.estimator_pub import EstimatorPubResult
 from .results.noise_learner import NoiseLearnerResult
 
 if TYPE_CHECKING:

--- a/qiskit_ibm_runtime/noise_learner_v3/find_learning_protocol.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/find_learning_protocol.py
@@ -21,8 +21,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.quantum_info import Clifford
 from samplomatic.utils import undress_box
 
-from qiskit_ibm_runtime.exceptions import IBMInputValueError
-
+from ..exceptions import IBMInputValueError
 from .learning_protocol import LearningProtocol
 
 if TYPE_CHECKING:

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from ibm_quantum_schemas.common import BaseParamsModel
     from qiskit.circuit import CircuitInstruction
 
-    from qiskit_ibm_runtime.options_models import NoiseLearnerV3Options
+    from ..options_models import NoiseLearnerV3Options
 
 
 class ParamsConverter(NamedTuple):

--- a/qiskit_ibm_runtime/options_models/estimator_options.py
+++ b/qiskit_ibm_runtime/options_models/estimator_options.py
@@ -20,11 +20,10 @@ from typing import Literal
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
-from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
-from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
-
 from .dynamical_decoupling_options import DynamicalDecouplingOptions
 from .environment_options import EnvironmentOptions
+from .execution_options import ExecutionOptions
+from .executor_options import ExecutorOptions
 from .resilience_options import ResilienceOptions
 from .simulator_options import SimulatorOptions
 from .twirling_options import TwirlingOptions

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -22,8 +22,6 @@ from urllib.parse import quote
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
 
-from qiskit_ibm_runtime import ibm_backend
-
 from .accounts import Account, AccountManager
 from .api.client_parameters import ClientParameters
 from .api.clients.runtime import RuntimeClient
@@ -34,6 +32,7 @@ from .exceptions import (
     RuntimeJobNotFound,
     RuntimeProgramNotFound,
 )
+from .ibm_backend import IBMBackend, IBMRetiredBackend
 from .proxies import ProxyConfiguration
 from .runtime_job_v2 import RuntimeJobV2
 from .runtime_options import RuntimeOptions
@@ -48,7 +47,6 @@ if TYPE_CHECKING:
 
     from .accounts import ChannelType, PlanType, RegionType
     from .decoders.result_decoder import ResultDecoder
-    from .ibm_backend import IBMBackend
     from .models import QasmBackendConfiguration
 
 logger = logging.getLogger(__name__)
@@ -544,12 +542,12 @@ class QiskitRuntimeService:
         min_num_qubits: int | None = None,
         instance: str | None = None,
         dynamic_circuits: bool | None = None,
-        filters: Callable[[ibm_backend.IBMBackend], bool] | None = None,
+        filters: Callable[[IBMBackend], bool] | None = None,
         *,
         use_fractional_gates: bool | None = False,
         calibration_id: str | None = None,
         **kwargs: Any,
-    ) -> list[ibm_backend.IBMBackend]:
+    ) -> list[IBMBackend]:
         """Return all backends accessible via this account, subject to optional filtering.
 
         Args:
@@ -781,7 +779,7 @@ class QiskitRuntimeService:
             return None
 
         if config:
-            return ibm_backend.IBMBackend(
+            return IBMBackend(
                 instance=instance,
                 configuration=config,
                 service=self,
@@ -1287,7 +1285,7 @@ class QiskitRuntimeService:
             else:
                 backend = None
         except QiskitBackendNotFoundError:
-            backend = ibm_backend.IBMRetiredBackend.from_name(
+            backend = IBMRetiredBackend.from_name(
                 backend_name=raw_data["backend"],
                 api=None,
             )
@@ -1309,10 +1307,10 @@ class QiskitRuntimeService:
         self,
         min_num_qubits: int | None = None,
         instance: str | None = None,
-        filters: Callable[[ibm_backend.IBMBackend], bool] | None = None,
+        filters: Callable[[IBMBackend], bool] | None = None,
         use_fractional_gates: bool | None = False,
         **kwargs: Any,
-    ) -> ibm_backend.IBMBackend:
+    ) -> IBMBackend:
         """Return the least busy available backend.
 
         Args:

--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -38,10 +38,9 @@ from .exceptions import (
 if TYPE_CHECKING:
     from qiskit.providers.backend import Backend
 
-    from qiskit_ibm_runtime import qiskit_runtime_service
-
     from .api.clients import RuntimeClient
     from .decoders.result_decoder import ResultDecoder
+    from .qiskit_runtime_service import QiskitRuntimeService
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +84,7 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
         api_client: RuntimeClient,
         job_id: str,
         program_id: str,
-        service: qiskit_runtime_service.QiskitRuntimeService,
+        service: QiskitRuntimeService,
         creation_date: str | None = None,
         result_decoder: type[ResultDecoder] | Sequence[type[ResultDecoder]] | None = None,
         image: str | None = "",

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -20,11 +20,10 @@ from typing import TYPE_CHECKING
 from qiskit.primitives.base import BaseSamplerV2
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 
-from qiskit_ibm_runtime.utils.deprecation import issue_deprecation_msg
-
 from .base_primitive import BasePrimitiveV2
 from .options import SamplerOptions
 from .utils import validate_classical_registers
+from .utils.deprecation import issue_deprecation_msg
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -19,12 +19,11 @@ from typing import TYPE_CHECKING, Any
 
 from qiskit.providers.backend import BackendV2
 
-from qiskit_ibm_runtime import QiskitRuntimeService
-
 from .api.exceptions import RequestsApiError
 from .exceptions import IBMInputValueError, IBMRuntimeError
 from .fake_provider.local_service import QiskitRuntimeLocalService
 from .ibm_backend import IBMBackend
+from .qiskit_runtime_service import QiskitRuntimeService
 from .utils.converters import hms_to_seconds
 from .utils.default_session import set_cm_session
 

--- a/qiskit_ibm_runtime/transpiler/passes/basis/fold_rzz_angle.py
+++ b/qiskit_ibm_runtime/transpiler/passes/basis/fold_rzz_angle.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from qiskit.primitives.containers.estimator_pub import EstimatorPubLike
     from qiskit.primitives.containers.sampler_pub import SamplerPubLike
 
-    from qiskit_ibm_runtime.base_primitive import BasePrimitiveV2
+    from ....base_primitive import BasePrimitiveV2
 
 
 class FoldRzzAngle(TransformationPass):

--- a/qiskit_ibm_runtime/transpiler/passes/basis/fold_rzz_angle.py
+++ b/qiskit_ibm_runtime/transpiler/passes/basis/fold_rzz_angle.py
@@ -34,7 +34,8 @@ from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 from qiskit.transpiler.basepasses import TransformationPass
 
-from qiskit_ibm_runtime import EstimatorV2, SamplerV2
+from ....estimator import EstimatorV2
+from ....sampler import SamplerV2
 
 if TYPE_CHECKING:
     from qiskit.circuit import Qubit

--- a/qiskit_ibm_runtime/transpiler/plugin.py
+++ b/qiskit_ibm_runtime/transpiler/plugin.py
@@ -23,7 +23,7 @@ from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
 from qiskit.version import __version__ as _terra_version_string
 
-from qiskit_ibm_runtime.transpiler.passes.basis import ConvertIdToDelay, FoldRzzAngle
+from .passes.basis import ConvertIdToDelay, FoldRzzAngle
 
 if TYPE_CHECKING:
     from qiskit.transpiler.passmanager_config import PassManagerConfig

--- a/qiskit_ibm_runtime/utils/backend_converter.py
+++ b/qiskit_ibm_runtime/utils/backend_converter.py
@@ -35,8 +35,8 @@ from qiskit.providers.backend import QubitProperties
 from qiskit.transpiler.passes.utils.wrap_angles import WrapAngles
 from qiskit.transpiler.target import InstructionProperties, Target
 
-from qiskit_ibm_runtime.models.exceptions import BackendPropertyError
-from qiskit_ibm_runtime.utils.utils import is_fractional_gate
+from ..models.exceptions import BackendPropertyError
+from ..utils.utils import is_fractional_gate
 
 if TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit

--- a/qiskit_ibm_runtime/utils/backend_converter.py
+++ b/qiskit_ibm_runtime/utils/backend_converter.py
@@ -41,7 +41,7 @@ from ..utils.utils import is_fractional_gate
 if TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit
 
-    from qiskit_ibm_runtime.models import BackendConfiguration, BackendProperties
+    from ..models import BackendConfiguration, BackendProperties
 
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ are supported by a given backend, one can inspect ``backend.supported_operations
 
 def rzz_wrapper(angles: list[float], qubits: list[Qubit]) -> DAGCircuit:
     """A wrapper to instruct the transpiler how to fold out-of-bounds Rzz angles."""
-    from qiskit_ibm_runtime.transpiler.passes.basis.fold_rzz_angle import FoldRzzAngle
+    from ..transpiler.passes.basis.fold_rzz_angle import FoldRzzAngle
 
     fold_rzz = FoldRzzAngle()
     angle = float(angles[0])

--- a/qiskit_ibm_runtime/utils/converters.py
+++ b/qiskit_ibm_runtime/utils/converters.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from dateutil import parser, tz
 
-from qiskit_ibm_runtime.exceptions import IBMInputValueError
+from ..exceptions import IBMInputValueError
 
 
 def utc_to_local(utc_dt: datetime | str) -> datetime:

--- a/qiskit_ibm_runtime/utils/estimator_pub_result.py
+++ b/qiskit_ibm_runtime/utils/estimator_pub_result.py
@@ -14,7 +14,7 @@
 
 import warnings
 
-from qiskit_ibm_runtime.results import EstimatorPubResult  # noqa: F401
+from ..results import EstimatorPubResult  # noqa: F401
 
 warnings.warn(
     "The `EstimatorPubResult` class has been moved to the `qiskit_ibm_runtime.results` package as "

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -14,7 +14,7 @@
 
 import warnings
 
-from qiskit_ibm_runtime.json import (  # noqa: F401
+from ..json import (  # noqa: F401
     CURRENT_NOISE_LEARNER_MODULE,
     LEGACY_NOISE_LEARNER_MODULE,
     SERVICE_MAX_SUPPORTED_QPY_VERSION,

--- a/qiskit_ibm_runtime/utils/noise_learner_result.py
+++ b/qiskit_ibm_runtime/utils/noise_learner_result.py
@@ -14,11 +14,7 @@
 
 import warnings
 
-from qiskit_ibm_runtime.results import (  # noqa: F401
-    LayerError,
-    NoiseLearnerResult,
-    PauliLindbladError,
-)
+from ..results import LayerError, NoiseLearnerResult, PauliLindbladError  # noqa: F401
 
 warnings.warn(
     "The `NoiseLearnerResult`, `LayerError` and `PauliLindbladError` classes has been moved to the "

--- a/qiskit_ibm_runtime/utils/validations.py
+++ b/qiskit_ibm_runtime/utils/validations.py
@@ -20,8 +20,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from qiskit_ibm_runtime.exceptions import IBMInputValueError
-from qiskit_ibm_runtime.utils.utils import are_circuits_dynamic, is_isa_circuit, is_valid_rzz_pub
+from ..exceptions import IBMInputValueError
+from ..utils.utils import are_circuits_dynamic, is_isa_circuit, is_valid_rzz_pub
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/test/unit/executor/test_executor.py
+++ b/test/unit/executor/test_executor.py
@@ -22,9 +22,9 @@ from qiskit_ibm_runtime.options_models.environment_options import EnvironmentOpt
 from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
-from test.utils import get_mocked_backend, get_mocked_session
 
 from ...ibm_test_case import IBMTestCase
+from ...utils import get_mocked_backend, get_mocked_session
 
 
 class TestExecutorOptions(IBMTestCase):

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -24,9 +24,9 @@ from qiskit_ibm_runtime.options_models.environment_options import EnvironmentOpt
 from qiskit_ibm_runtime.options_models.estimator_options import EstimatorOptions
 from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
-from test.utils import get_mocked_backend
 
 from ...ibm_test_case import IBMTestCase
+from ...utils import get_mocked_backend
 
 
 class TestEstimatorOptions(unittest.TestCase):

--- a/test/unit/executor_sampler/test_sampler_v2_options.py
+++ b/test/unit/executor_sampler/test_sampler_v2_options.py
@@ -20,9 +20,9 @@ from qiskit_ibm_runtime.executor_sampler import SamplerV2
 from qiskit_ibm_runtime.options_models.environment_options import SamplerEnvironmentOptions
 from qiskit_ibm_runtime.options_models.execution_options import SamplerExecutionOptions
 from qiskit_ibm_runtime.options_models.sampler_options import SamplerOptions
-from test.utils import get_mocked_backend
 
 from ...ibm_test_case import IBMTestCase
+from ...utils import get_mocked_backend
 
 
 class TestSamplerOptionsToExecutorOptions(unittest.TestCase):

--- a/test/unit/executor_sampler/test_simulator_options.py
+++ b/test/unit/executor_sampler/test_simulator_options.py
@@ -22,7 +22,8 @@ from qiskit.transpiler import CouplingMap
 from qiskit_ibm_runtime.executor_sampler import SamplerV2
 from qiskit_ibm_runtime.options_models.sampler_options import SamplerOptions
 from qiskit_ibm_runtime.options_models.simulator_options import SimulatorOptions
-from test.utils import get_mocked_backend
+
+from ...utils import get_mocked_backend
 
 
 @ddt

--- a/test/unit/noise_learner_v3/test_noise_learner_v3.py
+++ b/test/unit/noise_learner_v3/test_noise_learner_v3.py
@@ -23,9 +23,9 @@ from qiskit_ibm_runtime.options_models import (
     NoiseLearnerV3Options,
     PostSelectionOptions,
 )
-from test.utils import get_mocked_backend, get_mocked_session
 
 from ...ibm_test_case import IBMTestCase
+from ...utils import get_mocked_backend, get_mocked_session
 
 
 class TestNoiseLearnerV3Options(IBMTestCase):

--- a/test/unit/test_calibrator.py
+++ b/test/unit/test_calibrator.py
@@ -17,9 +17,9 @@ from unittest.mock import patch
 from qiskit_ibm_runtime.calibrator import Calibrator
 from qiskit_ibm_runtime.options_models.calibrator_options import CalibratorOptions
 from qiskit_ibm_runtime.options_models.environment_options import EnvironmentOptions
-from test.utils import get_mocked_backend, get_mocked_session
 
 from ..ibm_test_case import IBMTestCase
+from ..utils import get_mocked_backend, get_mocked_session
 
 
 class TestCalibratorOptions(IBMTestCase):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We have a mixture of absolute and relative imports in the codebase. This PR:
* converts to relative imports in `qiskit_ibm_runtime/`
* converts to relative imports in `test/` (these should stay relative, as `test` is not a proper package and can cause conflicts with other packages that might be named `test`)

### Details and comments

I could not find a way to enforce it using `ruff`. Personally, I am more in favor of absolute imports - but changes would be more intrusive and for historical reasons this PR aims for relative imports.

Fixes N/A

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
