### PR TITLE
Remove `MeasureNoiseLearningOptions.shots_per_randomization` attribute in executor-based estimator

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -218,13 +218,6 @@ def prepare_pec(
 
     # Add TREX calibration circuit
     if measure_noise_learning is not None:
-        if (
-            isinstance(measure_noise_learning.shots_per_randomization, int)
-            and measure_noise_learning.shots_per_randomization != shots_per_randomization
-        ):
-            raise IBMInputValueError(
-                "shots_per_randomization must be the same for twirling and measure_noise_learning"
-            )
         trex_num_randomizations = resolve_trex_num_randomizations(
             measure_noise_learning, twirling_num_randomizations
         )

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 
 from samplomatic import build
 
-from ..exceptions import IBMInputValueError
 from ..executor.calculate_twirling_shots import calculate_twirling_shots
 from ..quantum_program import QuantumProgram
 from ..quantum_program.quantum_program import SamplexItem
@@ -157,13 +156,6 @@ def prepare(
 
     # Add TREX calibration circuit
     if measure_noise_learning is not None:
-        if (
-            isinstance(measure_noise_learning.shots_per_randomization, int)
-            and measure_noise_learning.shots_per_randomization != shots_per_randomization
-        ):
-            raise IBMInputValueError(
-                "shots_per_randomization must be the same for twirling and measure_noise_learning"
-            )
         trex_num_randomizations = resolve_trex_num_randomizations(
             measure_noise_learning, num_randomizations
         )

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -193,13 +193,6 @@ def prepare_pea(
 
     # Add TREX calibration circuit
     if measure_noise_learning is not None:
-        if (
-            isinstance(measure_noise_learning.shots_per_randomization, int)
-            and measure_noise_learning.shots_per_randomization != shots_per_randomization
-        ):
-            raise IBMInputValueError(
-                "shots_per_randomization must be the same for twirling and measure_noise_learning"
-            )
         trex_num_randomizations = resolve_trex_num_randomizations(
             measure_noise_learning, num_randomizations
         )

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -196,13 +196,6 @@ def prepare_zne(
 
     # Add TREX calibration circuit
     if measure_noise_learning is not None:
-        if (
-            isinstance(measure_noise_learning.shots_per_randomization, int)
-            and measure_noise_learning.shots_per_randomization != shots_per_randomization
-        ):
-            raise IBMInputValueError(
-                "shots_per_randomization must be the same for twirling and measure_noise_learning"
-            )
         trex_num_randomizations = resolve_trex_num_randomizations(
             measure_noise_learning, num_randomizations
         )

--- a/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
+++ b/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
@@ -33,6 +33,6 @@ class MeasureNoiseLearningOptions:
     num_randomizations: int | Literal["auto"] = "auto"
     """The number of random circuits to draw for the measurement learning experiment.
 
-    If "auto", the calibration uses the same number of randomizations
+    If ``"auto"``, the calibration uses the same number of randomizations
     as specified in the estimator's twirling options.
     """

--- a/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
+++ b/qiskit_ibm_runtime/options_models/measure_noise_learning_options.py
@@ -36,9 +36,3 @@ class MeasureNoiseLearningOptions:
     If "auto", the calibration uses the same number of randomizations
     as specified in the estimator's twirling options.
     """
-
-    shots_per_randomization: int | Literal["auto"] = "auto"
-    """The number of shots to use for the learning experiment per random circuit.
-
-    If "auto", the value will be chosen automatically based on the input PUBs.
-    """

--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -43,7 +43,6 @@ class TestEstimatorOptions(unittest.TestCase):
         self.assertIsInstance(options.environment, EnvironmentOptions)
         self.assertIsNone(options.resilience.measure_mitigation)
         self.assertEqual(options.resilience.measure_noise_learning.num_randomizations, "auto")
-        self.assertEqual(options.resilience.measure_noise_learning.shots_per_randomization, "auto")
 
     def test_set_default_precision(self):
         """Test setting default_precision."""

--- a/test/unit/executor_estimator/test_resilience_options.py
+++ b/test/unit/executor_estimator/test_resilience_options.py
@@ -29,7 +29,6 @@ class TestResilienceOptionsDefaults(unittest.TestCase):
         opts = ResilienceOptions()
         self.assertIsNone(opts.measure_mitigation)
         self.assertEqual(opts.measure_noise_learning.num_randomizations, "auto")
-        self.assertEqual(opts.measure_noise_learning.shots_per_randomization, "auto")
         self.assertFalse(opts.pec_mitigation)
         self.assertEqual(opts.pec.max_overhead, 100)
         self.assertEqual(opts.pec.noise_gain, "auto")
@@ -46,7 +45,7 @@ class TestResilienceOptionsDefaults(unittest.TestCase):
         }
         opts = ResilienceOptions(
             measure_mitigation=False,
-            measure_noise_learning={"num_randomizations": 64, "shots_per_randomization": 1024},
+            measure_noise_learning={"num_randomizations": 64},
             pec_mitigation=True,
             pec={"max_overhead": 50, "noise_gain": 0.5},
             zne_mitigation=True,
@@ -55,7 +54,6 @@ class TestResilienceOptionsDefaults(unittest.TestCase):
         )
         self.assertFalse(opts.measure_mitigation)
         self.assertEqual(opts.measure_noise_learning.num_randomizations, 64)
-        self.assertEqual(opts.measure_noise_learning.shots_per_randomization, 1024)
         self.assertTrue(opts.pec_mitigation)
         self.assertEqual(opts.pec.max_overhead, 50)
         self.assertEqual(opts.pec.noise_gain, 0.5)


### PR DESCRIPTION
### Summary
In the Executor-based Estimator, every TREX circuit is executed with the same number of shots as every other item in the program. This PR removes the ability to specify `MeasureNoiseLearningOptions.shots_per_randomization`, which is currently ignored after PR #3035, and had probably been forgotten

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
