### PR TITLE
Replace mock backends with fake backends in some tests for executor-based primitives

### DIFF
--- a/test/unit/executor_estimator/test_estimator_v2_options.py
+++ b/test/unit/executor_estimator/test_estimator_v2_options.py
@@ -15,6 +15,7 @@
 from pydantic import ValidationError
 
 from qiskit_ibm_runtime.executor_estimator.estimator import EstimatorV2
+from qiskit_ibm_runtime.fake_provider import FakeBrisbane
 from qiskit_ibm_runtime.options_models.dynamical_decoupling_options import (
     DynamicalDecouplingOptions,
 )
@@ -24,7 +25,6 @@ from qiskit_ibm_runtime.options_models.execution_options import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor_options import ExecutorOptions
 
 from ...ibm_test_case import IBMTestCase
-from ...utils import get_mocked_backend
 
 
 class TestEstimatorOptions(IBMTestCase):
@@ -94,14 +94,14 @@ class TestEstimatorUsingOptions(IBMTestCase):
 
     def test_default_options(self):
         """Test that default options are set when none are provided."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator = EstimatorV2(mode=FakeBrisbane())
         self.assertIsInstance(estimator.options, EstimatorOptions)
         self.assertEqual(estimator.options, EstimatorOptions())
 
     def test_options_from_instance(self):
         """Test constructing with an EstimatorOptions instance."""
         opts = EstimatorOptions(execution=ExecutionOptions(init_qubits=False))
-        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts)
+        estimator = EstimatorV2(mode=FakeBrisbane(), options=opts)
         self.assertIs(estimator.options, opts)
         self.assertFalse(estimator.options.execution.init_qubits)
 
@@ -111,7 +111,7 @@ class TestEstimatorUsingOptions(IBMTestCase):
             "execution": {"init_qubits": False, "rep_delay": 0.5},
             "environment": {"log_level": "DEBUG", "job_tags": ["tag1"]},
         }
-        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts_dict)
+        estimator = EstimatorV2(mode=FakeBrisbane(), options=opts_dict)
         self.assertFalse(estimator.options.execution.init_qubits)
         self.assertEqual(estimator.options.execution.rep_delay, 0.5)
         self.assertEqual(estimator.options.environment.log_level, "DEBUG")
@@ -119,9 +119,7 @@ class TestEstimatorUsingOptions(IBMTestCase):
 
     def test_options_from_partial_dict(self):
         """Test constructing with a nested dict when only specifying some of the options."""
-        estimator = EstimatorV2(
-            mode=get_mocked_backend(), options={"execution": {"init_qubits": False}}
-        )
+        estimator = EstimatorV2(mode=FakeBrisbane(), options={"execution": {"init_qubits": False}})
         self.assertFalse(estimator.options.execution.init_qubits)
         self.assertIsNone(estimator.options.execution.rep_delay)
         self.assertEqual(estimator.options.environment, EnvironmentOptions())
@@ -129,32 +127,32 @@ class TestEstimatorUsingOptions(IBMTestCase):
     def test_options_constructor_invalid_type(self):
         """Test that an invalid options type raises TypeError."""
         with self.assertRaisesRegex(TypeError, "Expected EstimatorOptions or dict"):
-            EstimatorV2(mode=get_mocked_backend(), options="invalid")
+            EstimatorV2(mode=FakeBrisbane(), options="invalid")
 
     def test_setter_with_instance(self):
         """Test setting options via the setter with an EstimatorOptions instance."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator = EstimatorV2(mode=FakeBrisbane())
         new_opts = EstimatorOptions(execution=ExecutionOptions(init_qubits=False))
         estimator.options = new_opts
         self.assertIs(estimator.options, new_opts)
 
     def test_setter_with_dict(self):
         """Test setting options via the setter with a dict."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator = EstimatorV2(mode=FakeBrisbane())
         estimator.options = {"execution": {"init_qubits": False}}
         self.assertIsInstance(estimator.options, EstimatorOptions)
         self.assertFalse(estimator.options.execution.init_qubits)
 
     def test_setter_invalid_type(self):
         """Test that setting options with an invalid type raises TypeError."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator = EstimatorV2(mode=FakeBrisbane())
         with self.assertRaisesRegex(TypeError, "Expected EstimatorOptions or dict"):
             estimator.options = 42
 
     def test_setter_replaces_options(self):
         """Test that the setter replaces (not updates) the options."""
         estimator = EstimatorV2(
-            mode=get_mocked_backend(), options={"environment": {"log_level": "DEBUG"}}
+            mode=FakeBrisbane(), options={"environment": {"log_level": "DEBUG"}}
         )
         estimator.options = {"execution": {"init_qubits": False}}
         # environment should be back to defaults since we replaced, not updated
@@ -163,24 +161,24 @@ class TestEstimatorUsingOptions(IBMTestCase):
 
     def test_experimental_options_default_empty(self):
         """Test that experimental options default to empty dict."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator = EstimatorV2(mode=FakeBrisbane())
         self.assertEqual(estimator.options.experimental, {})
 
     def test_experimental_options_from_dict(self):
         """Test constructing with experimental options in dict."""
         opts_dict = {"experimental": {"foo": "bar", "baz": 123}}
-        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts_dict)
+        estimator = EstimatorV2(mode=FakeBrisbane(), options=opts_dict)
         self.assertEqual(estimator.options.experimental, {"foo": "bar", "baz": 123})
 
     def test_experimental_options_from_instance(self):
         """Test constructing with an EstimatorOptions instance with experimental options."""
         opts = EstimatorOptions(experimental={"custom_key": "custom_value"})
-        estimator = EstimatorV2(mode=get_mocked_backend(), options=opts)
+        estimator = EstimatorV2(mode=FakeBrisbane(), options=opts)
         self.assertEqual(estimator.options.experimental, {"custom_key": "custom_value"})
 
     def test_experimental_options_setter(self):
         """Test setting experimental options via the setter."""
-        estimator = EstimatorV2(mode=get_mocked_backend())
+        estimator = EstimatorV2(mode=FakeBrisbane())
         estimator.options = {"experimental": {"test": "value"}}
         self.assertEqual(estimator.options.experimental, {"test": "value"})
 

--- a/test/unit/executor_sampler/test_sampler_v2_options.py
+++ b/test/unit/executor_sampler/test_sampler_v2_options.py
@@ -15,12 +15,12 @@
 from pydantic import ValidationError
 
 from qiskit_ibm_runtime.executor_sampler import SamplerV2
+from qiskit_ibm_runtime.fake_provider import FakeBrisbane
 from qiskit_ibm_runtime.options_models.environment_options import SamplerEnvironmentOptions
 from qiskit_ibm_runtime.options_models.execution_options import SamplerExecutionOptions
 from qiskit_ibm_runtime.options_models.sampler_options import SamplerOptions
 
 from ...ibm_test_case import IBMTestCase
-from ...utils import get_mocked_backend
 
 
 class TestSamplerOptionsToExecutorOptions(IBMTestCase):
@@ -106,14 +106,14 @@ class TestSamplerUsingOptions(IBMTestCase):
 
     def test_default_options(self):
         """Test that default options are set when none are provided."""
-        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler = SamplerV2(mode=FakeBrisbane())
         self.assertIsInstance(sampler.options, SamplerOptions)
         self.assertEqual(sampler.options, SamplerOptions())
 
     def test_options_from_instance(self):
         """Test constructing with an SamplerOptions instance."""
         opts = SamplerOptions(execution=SamplerExecutionOptions(init_qubits=False))
-        sampler = SamplerV2(mode=get_mocked_backend(), options=opts)
+        sampler = SamplerV2(mode=FakeBrisbane(), options=opts)
         self.assertIs(sampler.options, opts)
         self.assertFalse(sampler.options.execution.init_qubits)
 
@@ -123,7 +123,7 @@ class TestSamplerUsingOptions(IBMTestCase):
             "execution": {"init_qubits": False, "rep_delay": 0.5},
             "environment": {"log_level": "DEBUG", "job_tags": ["tag1"]},
         }
-        sampler = SamplerV2(mode=get_mocked_backend(), options=opts_dict)
+        sampler = SamplerV2(mode=FakeBrisbane(), options=opts_dict)
         self.assertFalse(sampler.options.execution.init_qubits)
         self.assertEqual(sampler.options.execution.rep_delay, 0.5)
         self.assertEqual(sampler.options.environment.log_level, "DEBUG")
@@ -131,9 +131,7 @@ class TestSamplerUsingOptions(IBMTestCase):
 
     def test_options_from_partial_dict(self):
         """Test constructing with a nested dict when only specifying some of the options."""
-        sampler = SamplerV2(
-            mode=get_mocked_backend(), options={"execution": {"init_qubits": False}}
-        )
+        sampler = SamplerV2(mode=FakeBrisbane(), options={"execution": {"init_qubits": False}})
         self.assertFalse(sampler.options.execution.init_qubits)
         self.assertIsNone(sampler.options.execution.rep_delay)
         self.assertEqual(sampler.options.environment, SamplerEnvironmentOptions())
@@ -141,33 +139,31 @@ class TestSamplerUsingOptions(IBMTestCase):
     def test_options_constructor_invalid_type(self):
         """Test that an invalid options type raises TypeError."""
         with self.assertRaisesRegex(TypeError, "Expected SamplerOptions or dict"):
-            SamplerV2(mode=get_mocked_backend(), options="invalid")
+            SamplerV2(mode=FakeBrisbane(), options="invalid")
 
     def test_setter_with_instance(self):
         """Test setting options via the setter with an SamplerOptions instance."""
-        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler = SamplerV2(mode=FakeBrisbane())
         new_opts = SamplerOptions(execution=SamplerExecutionOptions(init_qubits=False))
         sampler.options = new_opts
         self.assertIs(sampler.options, new_opts)
 
     def test_setter_with_dict(self):
         """Test setting options via the setter with a dict."""
-        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler = SamplerV2(mode=FakeBrisbane())
         sampler.options = {"execution": {"init_qubits": False}}
         self.assertIsInstance(sampler.options, SamplerOptions)
         self.assertFalse(sampler.options.execution.init_qubits)
 
     def test_setter_invalid_type(self):
         """Test that setting options with an invalid type raises TypeError."""
-        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler = SamplerV2(mode=FakeBrisbane())
         with self.assertRaisesRegex(TypeError, "Expected SamplerOptions or dict"):
             sampler.options = 42
 
     def test_setter_replaces_options(self):
         """Test that the setter replaces (not updates) the options."""
-        sampler = SamplerV2(
-            mode=get_mocked_backend(), options={"environment": {"log_level": "DEBUG"}}
-        )
+        sampler = SamplerV2(mode=FakeBrisbane(), options={"environment": {"log_level": "DEBUG"}})
         sampler.options = {"execution": {"init_qubits": False}}
         # environment should be back to defaults since we replaced, not updated
         self.assertEqual(sampler.options.environment.log_level, "WARNING")
@@ -175,24 +171,24 @@ class TestSamplerUsingOptions(IBMTestCase):
 
     def test_experimental_options_default_empty(self):
         """Test that experimental options default to empty dict."""
-        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler = SamplerV2(mode=FakeBrisbane())
         self.assertEqual(sampler.options.experimental, {})
 
     def test_experimental_options_from_dict(self):
         """Test constructing with experimental options in dict."""
         opts_dict = {"experimental": {"foo": "bar", "baz": 123}}
-        sampler = SamplerV2(mode=get_mocked_backend(), options=opts_dict)
+        sampler = SamplerV2(mode=FakeBrisbane(), options=opts_dict)
         self.assertEqual(sampler.options.experimental, {"foo": "bar", "baz": 123})
 
     def test_experimental_options_from_instance(self):
         """Test constructing with an SamplerOptions instance with experimental options."""
         opts = SamplerOptions(experimental={"custom_key": "custom_value"})
-        sampler = SamplerV2(mode=get_mocked_backend(), options=opts)
+        sampler = SamplerV2(mode=FakeBrisbane(), options=opts)
         self.assertEqual(sampler.options.experimental, {"custom_key": "custom_value"})
 
     def test_experimental_options_setter(self):
         """Test setting experimental options via the setter."""
-        sampler = SamplerV2(mode=get_mocked_backend())
+        sampler = SamplerV2(mode=FakeBrisbane())
         sampler.options = {"experimental": {"test": "value"}}
         self.assertEqual(sampler.options.experimental, {"test": "value"})
 

--- a/test/unit/executor_sampler/test_simulator_options.py
+++ b/test/unit/executor_sampler/test_simulator_options.py
@@ -19,11 +19,11 @@ from pydantic import ValidationError
 from qiskit.transpiler import CouplingMap
 
 from qiskit_ibm_runtime.executor_sampler import SamplerV2
+from qiskit_ibm_runtime.fake_provider import FakeBrisbane
 from qiskit_ibm_runtime.options_models.sampler_options import SamplerOptions
 from qiskit_ibm_runtime.options_models.simulator_options import SimulatorOptions
 
 from ...ibm_test_case import IBMTestCase
-from ...utils import get_mocked_backend
 
 
 @ddt
@@ -79,7 +79,7 @@ class TestSimulatorOptions(IBMTestCase):
                 "coupling_map": [[0, 1], [1, 2]],
             }
         }
-        sampler = SamplerV2(mode=get_mocked_backend(), options=opts_dict)
+        sampler = SamplerV2(mode=FakeBrisbane(), options=opts_dict)
 
         self.assertEqual(sampler.options.simulator.seed_simulator, 123)
         self.assertEqual(sampler.options.simulator.basis_gates, ["h", "cx", "rz"])


### PR DESCRIPTION
### Summary
Now that local mode is supported in both sampler and estimator, we can change some tests so that they instantiate a fake backend rather than mocking one.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
