### PR TITLE
Fix typos in some functions and constants in wrapper primitives

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -214,16 +214,16 @@ class EstimatorV2(BaseEstimatorV2):
         finalized_options = deepcopy(self.options)
 
         # Begin by initializing options based on resilience level
-        defults = RESILIENCE_LEVEL_DEFAULTS[finalized_options.resilience_level]
+        defaults = RESILIENCE_LEVEL_DEFAULTS[finalized_options.resilience_level]
 
         if finalized_options.twirling.enable_gates is None:
-            finalized_options.twirling.enable_gates = defults["enable_gates"]
+            finalized_options.twirling.enable_gates = defaults["enable_gates"]
         if finalized_options.twirling.enable_measure is None:
-            finalized_options.twirling.enable_measure = defults["enable_measure"]
+            finalized_options.twirling.enable_measure = defaults["enable_measure"]
         if finalized_options.resilience.measure_mitigation is None:
-            finalized_options.resilience.measure_mitigation = defults["measure_mitigation"]
+            finalized_options.resilience.measure_mitigation = defaults["measure_mitigation"]
         if finalized_options.resilience.zne_mitigation is None:
-            finalized_options.resilience.zne_mitigation = defults["zne_mitigation"]
+            finalized_options.resilience.zne_mitigation = defaults["zne_mitigation"]
 
         # Force-set some values based on mitigation
         if finalized_options.resilience.measure_mitigation is True:

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -27,7 +27,7 @@ from .utils import (
     extract_shots_from_pubs,
     validate_meas_type_twirling,
     validate_no_boxes,
-    validate_twirling_option_fileds_are_not_none,
+    validate_twirling_option_fields_are_not_none,
 )
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ def prepare(
             (when twirling is disabled), if shots are not properly specified, or if
             measurement twirling is enabled with a non-classified ``meas_type``.
     """
-    validate_twirling_option_fileds_are_not_none(options.twirling)
+    validate_twirling_option_fields_are_not_none(options.twirling)
     validate_meas_type_twirling(options.execution.meas_type, options.twirling.enable_measure)
 
     # Extract and validate shots from pubs

--- a/qiskit_ibm_runtime/executor_sampler/utils.py
+++ b/qiskit_ibm_runtime/executor_sampler/utils.py
@@ -68,7 +68,7 @@ def validate_meas_type_twirling(meas_type: str | None, enable_measure: bool | No
         )
 
 
-def validate_twirling_option_fileds_are_not_none(options: TwirlingOptions) -> None:
+def validate_twirling_option_fields_are_not_none(options: TwirlingOptions) -> None:
     """Validate that twirling options fields are not ``None``.
 
     Args:


### PR DESCRIPTION
### Summary
This PR fixes some typos in function and constant names in the wrapper primitives.

- [X] I didn't use LLM tooling, or only used it privately.
