### PR TITLE
Remove duplicated logging in wrapper estimator

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -293,9 +293,6 @@ class EstimatorV2(BaseEstimatorV2):
             logger.info("Running in local simulator mode")
             return self._run_simulator(coerced_pubs, options, shots)
 
-        # Convert pubs to QuantumProgram and map options using the selected prepare function
-        logger.info("Starting pre-processing")
-
         if options.dynamical_decoupling.enable:
             for pub in coerced_pubs:
                 if pub.circuit.has_control_flow_op():


### PR DESCRIPTION
### Summary
`Starting pre-processing` is logged twice.

- [X] I didn't use LLM tooling, or only used it privately.
