### PR TITLE
Raise an error when wrapper estimator is run with empty PUBs.

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -265,11 +265,13 @@ class EstimatorV2(BaseEstimatorV2):
 
         Raises:
             ValueError: If backend is not provided.
-            IBMInputValueError: If precision is not properly specified or if unsupported
-                options are detected.
+            IBMInputValueError: If no pubs are provided, if precision is not properly
+                specified, or if unsupported options are detected.
         """
         # Coerce pubs to EstimatorPub objects
         coerced_pubs = [EstimatorPub.coerce(pub, precision) for pub in pubs]
+        if not coerced_pubs:
+            raise IBMInputValueError("No pubs provided. At least one pub is required.")
 
         # Finalize the options dynamically by:
         #   * Generating new options according to the specified resilience level

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -379,6 +379,16 @@ class TestEstimatorV2Run(IBMTestCase):
             estimator.run([pub1, pub2])
         self.assertIn("same precision", str(context.exception))
 
+    def test_run_raises_error_when_no_pubs_provided(self):
+        """Test that run raises IBMInputValueError when called with an empty pub list."""
+        estimator = EstimatorV2(mode=self.backend)
+
+        with self.assertRaisesRegex(IBMInputValueError, "No pubs provided"):
+            estimator.run([])
+
+        # Executor should never be reached
+        self.mock_executor_instance.run.assert_not_called()
+
     def test_run_raises_error_when_pec_enabled_without_noise_model(self):
         """Test that run raises error when PEC is enabled but noise_model_mapping isn't."""
         estimator = EstimatorV2(mode=self.backend)


### PR DESCRIPTION
### Summary
Fixes #3061 

I opted to raise an error instead of returning a failed job (or sending an empty payload to the server for it to fail). This deviates from legacy behavior, but I think it's for the better.

- [X] I didn't use LLM tooling, or only used it privately.