### PR TITLE
Clear `QuantumCircuit.metadata` in wrapper sampler

### DIFF
--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from samplomatic import build
@@ -108,7 +107,7 @@ def prepare(
             else:
                 param_values = None
 
-            circuit = deepcopy(pub.circuit)
+            circuit = pub.circuit.copy()
             circuit.metadata = {}  # clear the metadata as it's now passthrough data
             items.append(
                 CircuitItem(

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -107,8 +107,10 @@ def prepare(
             else:
                 param_values = None
 
-            circuit = pub.circuit.copy()
-            circuit.metadata = {}  # clear the metadata as it's now passthrough data
+            circuit = pub.circuit
+            if circuit.metadata:
+                circuit = circuit.copy()  # copy the circuit to avoid mutating the original
+                circuit.metadata = {}  # clear the metadata as it is now passthrough data
             items.append(
                 CircuitItem(
                     circuit=circuit,

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from samplomatic import build
@@ -107,9 +108,11 @@ def prepare(
             else:
                 param_values = None
 
+            circuit = deepcopy(pub.circuit)
+            circuit.metadata = {}  # clear the metadata as it's now passthrough data
             items.append(
                 CircuitItem(
-                    circuit=pub.circuit,
+                    circuit=circuit,
                     circuit_arguments=param_values,
                 )
             )

--- a/test/unit/executor_sampler/test_sampler.py
+++ b/test/unit/executor_sampler/test_sampler.py
@@ -255,7 +255,7 @@ class TestSamplerV2QuantumProgramIntegrity(IBMTestCase):
 
     @patch("qiskit_ibm_runtime.executor_sampler.sampler.Executor.run")
     def test_circuit_preservation(self, mock_run):
-        """Test that circuits are preserved exactly in QuantumProgram."""
+        """Test that circuits are preserved in QuantumProgram with empty metadata."""
         mock_run.return_value = MagicMock()
 
         # Create a circuit with specific structure
@@ -266,14 +266,22 @@ class TestSamplerV2QuantumProgramIntegrity(IBMTestCase):
         circuit.barrier()
         circuit.measure([0, 1, 2], [0, 1, 2])
 
+        # add some metadata
+        metadata = {"foo": True, "bar": np.int64(1)}
+        circuit.metadata = metadata
+
         sampler = SamplerV2(mode=self.backend)
         sampler.run([circuit], shots=1024)
 
         quantum_program = mock_run.call_args[0][0]
         item = quantum_program.items[0]
 
-        # Verify circuit is the same object
-        self.assertIs(item.circuit, circuit)
+        # Verify circuit is equivalent and metadata is cleared on the copy
+        self.assertEqual(item.circuit, circuit)
+        self.assertEqual(item.circuit.metadata, {})
+
+        # Verify that the original circuit is not mutated
+        self.assertEqual(circuit.metadata, metadata)
 
         # Verify circuit structure is preserved
         self.assertEqual(item.circuit.num_qubits, 3)


### PR DESCRIPTION
### Summary

Currently, the wrapper sampler converts circuit metadata into passthrough data when calling `prepare`. However, said metadata is not cleared on the`QuantumCircuit` instances that are submitted to the `Executor`. Because of this, an example such as:
```
circuit = QuantumCircuit(backend.num_qubits)
circuit.metadata['np_type'] = np.int64(4)

for q in range(circuit.num_qubits):
    circuit.x(qubit=q)
circuit.measure_all()

pm = generate_preset_pass_manager(backend=backend, optimization_level=0)
isa_circuit = pm.run(circuit)

sampler = SamplerV2(backend)
job = sampler.run([circuit])
job.job_id()
```
will error with `TypeError: Object of type int64 is not JSON serializable` when encoding a circuit into QPY. The proposed solution in this PR is to make a copy of each circuit (to avoid mutating the user's original circuits) and clear the metadata when submitting.

### Details and comments

Fixes #3063

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
