### PR TITLE
Improve the error handling of unsupported metadata types in `Executor.run` 

### DIFF
--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -117,13 +117,21 @@ class Executor:
 
         Returns:
             A job.
+
+        Raises:
+            ValueError: If converters are not found for a given schema version.
+            TypeError: If the program metadata contains an unsupported type.
         """
         try:
             converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[self._SCHEMA_VERSION]
         except KeyError:
             raise ValueError(f"No converters for schema version {self._SCHEMA_VERSION}.")
 
-        params = converter.encoder(program, self.options)
+        try:
+            params = converter.encoder(program, self.options)
+        except TypeError as e:
+            type_name = str(e).split("type ")[-1].split(" is not")[0]
+            raise TypeError(f"Metadata contains a field of unsupported type '{type_name}'.") from e
         runtime_options = asdict(self.options.environment)  # type: ignore[call-overload]
         runtime_options["backend"] = self._backend.name
         runtime_options["instance"] = self._backend._instance

--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -131,7 +131,9 @@ class Executor:
             params = converter.encoder(program, self.options)
         except TypeError as e:
             type_name = str(e).split("type ")[-1].split(" is not")[0]
-            raise TypeError(f"Metadata contains a field of unsupported type '{type_name}'.") from e
+            raise TypeError(
+                f"Program metadata contains a field of unsupported type '{type_name}'."
+            ) from e
         runtime_options = asdict(self.options.environment)  # type: ignore[call-overload]
         runtime_options["backend"] = self._backend.name
         runtime_options["instance"] = self._backend._instance


### PR DESCRIPTION
### Summary

Given an example such as:
```
circuit = QuantumCircuit(100)

for q in range(circuit.num_qubits):
    circuit.x(qubit=q)
circuit.measure_all()

circuit.metadata['np_type'] = np.int64(4)

pm = generate_preset_pass_manager(backend=backend, optimization_level=0)
isa_circuit = pm.run(circuit)

qp = QuantumProgram(shots=10, passthrough_data={"np_type": np.int64(4)})
qp.append_circuit_item(circuit=isa_circuit)

executor: Executor = Executor(mode=backend)
job = executor.run(qp)
```
the error message raised looks like `TypeError: Object of type int64 is not JSON serializable` which is not particularly informative for the user. Here we update that to `TypeError: Program metadata contains a field of unsupported type 'int64'.`

### Details and comments

Closes #3063 stretch goal

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
