### PR TITLE
Add AerExecutor from qiskit-noise-learning

### DIFF
--- a/qiskit_ibm_runtime/aer_executor/__init__.py
+++ b/qiskit_ibm_runtime/aer_executor/__init__.py
@@ -1,0 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Aer-based local executor for QuantumProgram objects."""
+
+from .aer_executor import AerExecutor, AerRuntimeJob

--- a/qiskit_ibm_runtime/aer_executor/aer_executor.py
+++ b/qiskit_ibm_runtime/aer_executor/aer_executor.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
+from qiskit.optionals import HAS_AER
+
 from .run_quantum_program import run_quantum_program
 
 if TYPE_CHECKING:
@@ -25,13 +27,6 @@ if TYPE_CHECKING:
 
     from ..quantum_program import QuantumProgram
     from ..results import QuantumProgramResult
-
-try:
-    from qiskit_aer import AerSimulator
-
-    HAS_QISKIT_AER = True
-except ImportError:
-    HAS_QISKIT_AER = False
 
 
 class AerRuntimeJob:
@@ -57,6 +52,14 @@ class AerRuntimeJob:
         angle_decimals: int = 5,
         warn_absent: bool = True,
     ):
+        if not HAS_AER:
+            raise ValueError(
+                "Cannot initialize object of type 'AerExecutor' since 'qiskit-aer' is not "
+                "installed. Install 'qiskit-aer' and try again."
+            )
+
+        from qiskit_aer import AerSimulator
+
         if not isinstance(qasm_simulator, AerSimulator):
             raise ValueError("``qasm_simulator`` needs to be an ``AerSimulator`` object.")
 
@@ -133,11 +136,13 @@ class AerExecutor:
         angle_decimals: int = 5,
         warn_absent: bool = True,
     ):
-        if not HAS_QISKIT_AER:
+        if not HAS_AER:
             raise ValueError(
                 "Cannot initialize object of type 'AerExecutor' since 'qiskit-aer' is not "
                 "installed. Install 'qiskit-aer' and try again."
             )
+
+        from qiskit_aer import AerSimulator
 
         if not isinstance(qasm_simulator, AerSimulator):
             raise ValueError("``qasm_simulator`` needs to be an ``AerSimulator`` object.")

--- a/qiskit_ibm_runtime/aer_executor/aer_executor.py
+++ b/qiskit_ibm_runtime/aer_executor/aer_executor.py
@@ -12,14 +12,19 @@
 
 """AerExecutor and AerRuntimeJob: local simulation executor for QuantumProgram objects."""
 
+from __future__ import annotations
+
 import uuid
+from typing import TYPE_CHECKING
 
-from qiskit.providers import BackendV2  # noqa: TC002
-from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
-
-from ..quantum_program import QuantumProgram  # noqa: TC001
-from ..results import QuantumProgramResult  # noqa: TC001
 from .run_quantum_program import run_quantum_program
+
+if TYPE_CHECKING:
+    from qiskit.providers import BackendV2
+    from qiskit.quantum_info import PauliLindbladMap
+
+    from ..quantum_program import QuantumProgram
+    from ..results import QuantumProgramResult
 
 try:
     from qiskit_aer import AerSimulator

--- a/qiskit_ibm_runtime/aer_executor/aer_executor.py
+++ b/qiskit_ibm_runtime/aer_executor/aer_executor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
-from qiskit.optionals import HAS_AER
+from qiskit.utils.optionals import HAS_AER
 
 from .run_quantum_program import run_quantum_program
 

--- a/qiskit_ibm_runtime/aer_executor/aer_executor.py
+++ b/qiskit_ibm_runtime/aer_executor/aer_executor.py
@@ -21,6 +21,13 @@ from ..quantum_program import QuantumProgram  # noqa: TC001
 from ..results import QuantumProgramResult  # noqa: TC001
 from .run_quantum_program import run_quantum_program
 
+try:
+    from qiskit_aer import AerSimulator
+
+    HAS_QISKIT_AER = True
+except ImportError:
+    HAS_QISKIT_AER = False
+
 
 class AerRuntimeJob:
     """Job object returned by :meth:`AerExecutor.run`.
@@ -45,10 +52,8 @@ class AerRuntimeJob:
         angle_decimals: int = 5,
         warn_absent: bool = True,
     ):
-        from qiskit_aer import AerSampler
-
-        if not isinstance(qasm_simulator, AerSampler):
-            raise ValueError("``qasm_simulator`` needs to be an ``AerSampler`` object.")
+        if not isinstance(qasm_simulator, AerSimulator):
+            raise ValueError("``qasm_simulator`` needs to be an ``AerSimulator`` object.")
 
         self._qasm_simulator = qasm_simulator
         self._program = program
@@ -123,10 +128,14 @@ class AerExecutor:
         angle_decimals: int = 5,
         warn_absent: bool = True,
     ):
-        from qiskit_aer import AerSampler
+        if not HAS_QISKIT_AER:
+            raise ValueError(
+                "Cannot initialize object of type 'AerExecutor' since 'qiskit-aer' is not "
+                "installed. Install 'qiskit-aer' and try again."
+            )
 
-        if not isinstance(qasm_simulator, AerSampler):
-            raise ValueError("``qasm_simulator`` needs to be an ``AerSampler`` object.")
+        if not isinstance(qasm_simulator, AerSimulator):
+            raise ValueError("``qasm_simulator`` needs to be an ``AerSimulator`` object.")
 
         self._qasm_simulator = qasm_simulator
         self._noise_dict = noise_dict

--- a/qiskit_ibm_runtime/aer_executor/aer_executor.py
+++ b/qiskit_ibm_runtime/aer_executor/aer_executor.py
@@ -1,0 +1,151 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""AerExecutor and AerRuntimeJob: local simulation executor for QuantumProgram objects."""
+
+import uuid
+
+from qiskit.providers import BackendV2  # noqa: TC002
+from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
+
+from ..quantum_program import QuantumProgram  # noqa: TC001
+from ..results import QuantumProgramResult  # noqa: TC001
+from .run_quantum_program import run_quantum_program
+
+
+class AerRuntimeJob:
+    """Job object returned by :meth:`AerExecutor.run`.
+
+    The program is executed eagerly on construction; the result is available
+    immediately when :meth:`result` is called.
+
+    Args:
+        qasm_simulator: The Aer simulator to run on.
+        program: The quantum program to execute.
+        noise_dict: A map from barrier label refs to Pauli-Lindblad noise maps.
+        angle_decimals: Rounding precision for gate angles (in units of π/2).
+        warn_absent: If ``True`` (default), warn when a tagged barrier has no entry in
+            ``noise_dict``.
+    """
+
+    def __init__(
+        self,
+        qasm_simulator: BackendV2,
+        program: QuantumProgram,
+        noise_dict: dict[str, PauliLindbladMap] | None = None,
+        angle_decimals: int = 5,
+        warn_absent: bool = True,
+    ):
+        from qiskit_aer import AerSampler
+
+        if not isinstance(qasm_simulator, AerSampler):
+            raise ValueError("``qasm_simulator`` needs to be an ``AerSampler`` object.")
+
+        self._qasm_simulator = qasm_simulator
+        self._program = program
+        self._noise_dict = noise_dict
+        self._angle_decimals = angle_decimals
+        self._warn_absent = warn_absent
+        self._job_id: str = str(uuid.uuid4())
+        self.tags: list[str] = []  # interface compatibility with real Executor
+
+        self._result = run_quantum_program(
+            qasm_simulator=self._qasm_simulator,
+            program=self._program,
+            noise_dict=self._noise_dict,
+            angle_decimals=self._angle_decimals,
+            warn_absent=self._warn_absent,
+        )
+
+    def job_id(self) -> str:
+        """Return the unique job ID."""
+        return self._job_id
+
+    def result(self, *_, **__) -> QuantumProgramResult:  # type: ignore[no-untyped-def]
+        """Return the result of the program execution."""
+        return self._result
+
+
+class AerExecutor:
+    """Local Aer-based executor mimicking the IBM Runtime executor interface.
+
+    Runs a :class:`~qiskit_ibm_runtime.QuantumProgram` eagerly on construction of the
+    returned job — the result is available immediately when :meth:`AerRuntimeJob.result`
+    is called.
+
+    **Noise injection**
+
+    When ``noise_dict`` is provided, Pauli-Lindblad noise is injected into circuits at
+    tagged barriers via :class:`~.InsertNoisePass`.  Samplomatic inserts three barriers
+    around each boxed gate — left (``L``), middle (``M``), and right (``R``) — with
+    labels of the form ``<pos><idx>@tag=<tag>`` (e.g. ``R0@tag=r0``).  By default,
+    noise is injected at the ``R`` (right) barriers, i.e. *after* the gate.  Use
+    ``noise_after=False`` on :class:`InsertNoisePass` to target ``M`` barriers instead
+    (noise *before* the gate).
+
+    The ``noise_dict`` format is:
+
+    - **Keys** — layer name tags (strings, e.g. ``"r0"``, ``"my_tag"``).  Each key must match
+      the ``ref`` of a ``Tag`` annotation used when building the ``QuantumProgram``.
+      A warning is emitted (if ``warn_absent=True``) when a tagged barrier's tag is absent
+      from the dict; the barrier is left as-is (no noise inserted for that layer).
+    - **Values** — :class:`~qiskit.quantum_info.PauliLindbladMap` instances describing
+      the Pauli-Lindblad noise channel for that gate.  The map's ``num_qubits`` must
+      equal the number of qubits on the corresponding barrier in the circuit.
+    - **Qubit indexing** — indices inside the map are *local* to the barrier's qubit
+      set, independent of global circuit qubit numbering.
+
+    Args:
+        qasm_simulator: The Aer simulator to run programs on.
+        noise_dict: A map from barrier label refs to Pauli-Lindblad noise maps.  Pass
+            ``None`` (default) to run without noise injection.
+        angle_decimals: Gate angles are rounded to the nearest multiple of π/2 at this
+            decimal precision before simulation.  This prevents floating-point drift from
+            preventing Clifford-method simulation when angles are nominally Clifford.
+        warn_absent: If ``True`` (default), emit a warning when a tagged barrier's tag is
+            not found in ``noise_dict``.  Set to ``False`` when partial coverage of tags is
+            intentional.
+    """
+
+    def __init__(
+        self,
+        qasm_simulator: BackendV2,
+        noise_dict: dict[str, PauliLindbladMap] | None = None,
+        angle_decimals: int = 5,
+        warn_absent: bool = True,
+    ):
+        from qiskit_aer import AerSampler
+
+        if not isinstance(qasm_simulator, AerSampler):
+            raise ValueError("``qasm_simulator`` needs to be an ``AerSampler`` object.")
+
+        self._qasm_simulator = qasm_simulator
+        self._noise_dict = noise_dict
+        self._angle_decimals = angle_decimals
+        self._warn_absent = warn_absent
+
+    def run(self, program: QuantumProgram) -> AerRuntimeJob:
+        """Run a quantum program and return a completed job.
+
+        Args:
+            program: The quantum program to execute.
+
+        Returns:
+            A job whose result is immediately available.
+        """
+        return AerRuntimeJob(
+            qasm_simulator=self._qasm_simulator,
+            program=program,
+            noise_dict=self._noise_dict,
+            angle_decimals=self._angle_decimals,
+            warn_absent=self._warn_absent,
+        )

--- a/qiskit_ibm_runtime/aer_executor/broadcast_sample.py
+++ b/qiskit_ibm_runtime/aer_executor/broadcast_sample.py
@@ -1,0 +1,79 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utilities for sampling from a Samplex over broadcast and randomization axes."""
+
+from math import prod
+
+import numpy as np
+from samplomatic.samplex import Samplex  # noqa: TC002
+from samplomatic.tensor_interface import TensorInterface  # noqa: TC002
+
+
+def broadcast_sample(
+    samplex: Samplex,
+    samplex_arguments: TensorInterface,
+    shape: tuple[int, ...],
+    rng: np.random.Generator,
+) -> dict[str, np.ndarray]:
+    """Sample from a samplex, iterating over broadcast axes in ``samplex_arguments``.
+
+    Axes where ``samplex_arguments`` has size > 1 (after right-aligning with
+    ``shape``) are **broadcast** axes (e.g. a parameter sweep); the remaining
+    axes are **randomization** axes.  For each slice along the broadcast axes
+    the function calls ``samplex.sample()`` with scalar (non-broadcastable)
+    arguments and the appropriate ``num_randomizations``, then assembles the
+    results into arrays of shape ``(*shape, *intrinsic)``.
+
+
+    Args:
+        samplex: The samplex to sample from.
+        samplex_arguments: The broadcastable array inputs to the samplex.
+        shape: The total shape.
+        rng: A randomness generator.
+
+    Returns:
+        Broadcasted samples from the samplex.
+    """
+    ndim = len(shape)
+    padded_shape = (1,) * (ndim - samplex_arguments.ndim) + samplex_arguments.shape
+
+    broadcast_axes = [idx for idx in range(ndim) if padded_shape[idx] > 1]
+    randomization_axes = [idx for idx in range(ndim) if padded_shape[idx] <= 1]
+
+    num_randomizations = prod(shape[i] for i in randomization_axes)
+    rand_shape = tuple(shape[i] for i in randomization_axes)
+    broadcast_shape = tuple(shape[i] for i in broadcast_axes)
+
+    output: dict[str, np.ndarray] = {}
+    for bc_idx in np.ndindex(broadcast_shape):
+        bc_iter = iter(bc_idx)
+        slice_idxs = tuple(next(bc_iter) if dim > 1 else 0 for dim in samplex_arguments.shape)
+
+        sample_result = samplex.sample(
+            samplex_arguments[slice_idxs],
+            num_randomizations=num_randomizations,
+            rng=rng,
+        )
+
+        if not output:
+            for key, val in dict(sample_result).items():
+                intrinsic_shape = val.shape[1:]
+                output[key] = np.empty((*shape, *intrinsic_shape), dtype=val.dtype)
+
+        bc_iter = iter(bc_idx)
+        out_idx = tuple(next(bc_iter) if dim > 1 else slice(None) for dim in padded_shape)
+
+        for key, val in dict(sample_result).items():
+            output[key][out_idx] = val.reshape(*rand_shape, *val.shape[1:])
+
+    return output

--- a/qiskit_ibm_runtime/aer_executor/broadcast_sample.py
+++ b/qiskit_ibm_runtime/aer_executor/broadcast_sample.py
@@ -12,11 +12,16 @@
 
 """Utilities for sampling from a Samplex over broadcast and randomization axes."""
 
+from __future__ import annotations
+
 from math import prod
+from typing import TYPE_CHECKING
 
 import numpy as np
-from samplomatic.samplex import Samplex  # noqa: TC002
-from samplomatic.tensor_interface import TensorInterface  # noqa: TC002
+
+if TYPE_CHECKING:
+    from samplomatic.samplex import Samplex
+    from samplomatic.tensor_interface import TensorInterface
 
 
 def broadcast_sample(

--- a/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
@@ -1,0 +1,133 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Transpiler pass that inserts Pauli-Lindblad noise after labeled barriers."""
+
+import re
+import warnings
+from collections.abc import Callable  # noqa: TC003
+from functools import partial
+
+from qiskit.circuit import QuantumCircuit, Qubit  # noqa: TC002
+from qiskit.converters import circuit_to_dag
+from qiskit.dagcircuit import DAGCircuit, DAGOpNode  # noqa: TC002
+from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
+from qiskit.transpiler import TransformationPass
+from qiskit_aer.noise import PauliLindbladError
+
+
+def _find_qubit(dag: DAGCircuit, qubit: Qubit) -> int:
+    return dag.find_bit(qubit).index
+
+
+class InsertNoisePass(TransformationPass):
+    """Transpiler pass that inserts Pauli-Lindblad noise channels after (or before) tagged barriers.
+
+    Barriers whose labels match the pattern ``<pos><idx>@tag=<tag>`` are replaced with a
+    sub-circuit consisting of the original barrier followed (or preceded) by a
+    :class:`~qiskit_aer.noise.PauliLindbladError` looked up from ``noise_dict`` by ``<tag>``.
+
+    Args:
+        noise_dict: Map from gate-name tags to Pauli-Lindblad noise maps.  Pass ``None`` to
+            perform a no-op (no noise is inserted).
+        noise_after: If ``True`` (default), insert noise after the barrier; otherwise before.
+        noise_scale: Multiplicative scale factor applied to all noise rates.
+        warn_absent: If ``True`` (default), emit a warning when a tagged barrier's tag is not
+            found in ``noise_dict``.  Set to ``False`` to suppress these warnings.
+    """
+
+    def __init__(
+        self,
+        noise_dict: dict[str, PauliLindbladMap] | None,
+        noise_after: bool = True,
+        noise_scale: float = 1.0,
+        warn_absent: bool = True,
+    ):
+        self._noise_dict = noise_dict or {}
+        self._noise_after = noise_after
+        self._noise_scale = noise_scale
+        self._warn_absent = warn_absent
+
+        self._pattern = re.compile(r"^(?P<pos>[A-Za-z])(?P<idx>\d+)(.*?)tag=(?P<tag>.+)(.*?)")
+
+        super().__init__()
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Run the pass."""
+        if not self._noise_dict:
+            return dag
+
+        for op_node in reversed(list(dag.topological_op_nodes())):
+            if op_node.name != "barrier":
+                continue
+
+            if _new_subdag := self._new_subdag(op_node, partial(_find_qubit, dag)):
+                dag.substitute_node_with_dag(
+                    node=op_node,
+                    input_dag=_new_subdag,
+                )
+
+        return dag
+
+    def _match_key(self, name: str) -> str | None:
+        if not (match_group := self._pattern.match(name)):
+            return None
+        pos = match_group.group("pos")
+        tag = match_group.group("tag")
+
+        if self._noise_after:
+            if pos != "R":
+                return None
+        else:
+            if pos != "M":
+                return None
+
+        return tag
+
+    def _new_subdag(
+        self, op_node: DAGOpNode, find_qubit: Callable[[Qubit], int]
+    ) -> DAGCircuit | None:
+        # Qiskit has no public API for reading barrier labels; _label is the only option.
+        label = op_node.op._label  # noqa: SLF001
+        if label is None:
+            return None
+        if (noise_key := self._match_key(label)) is None:
+            return None
+
+        pauli_lindblad_map = self._noise_dict.get(noise_key)
+        if pauli_lindblad_map is None:
+            if self._noise_dict and self._warn_absent:
+                warnings.warn(
+                    f"No noise found for tag '{noise_key}'; "
+                    f"available tags: {list(self._noise_dict.keys())}",
+                    stacklevel=2,
+                )
+            return None
+
+        if len(pauli_lindblad_map) == 0:
+            return None
+
+        pauli_lindblad_error = PauliLindbladError(
+            generators=pauli_lindblad_map.generators().to_pauli_list(),
+            rates=self._noise_scale * pauli_lindblad_map.rates,
+        )
+
+        # The PauliLindbladMap's indices are interpreted in ascending physical-qubit order
+        # of the parent DAG, so we apply the resulting error to the local qc.qubits in the
+        # permutation that orders op_node.qargs by their physical index.
+        physical_indices = [find_qubit(q) for q in op_node.qargs]
+        plm_indices = sorted(range(len(physical_indices)), key=physical_indices.__getitem__)
+
+        qc = QuantumCircuit(op_node.num_qubits)
+        qc.append(op_node.op, qc.qubits)
+        qc.append(pauli_lindblad_error, [qc.qubits[i] for i in plm_indices])
+        return circuit_to_dag(qc)

--- a/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
@@ -30,12 +30,8 @@ if TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit, DAGOpNode
     from qiskit.quantum_info import PauliLindbladMap
 
-try:
-    from qiskit_aer.noise import PauliLindbladError
-
-    HAS_QISKIT_AER = True
-except ImportError:
-    HAS_QISKIT_AER = False
+from qiskit.optionals import HAS_AER
+from qiskit_aer.noise import PauliLindbladError
 
 
 def _find_qubit(dag: DAGCircuit, qubit: Qubit) -> int:
@@ -65,10 +61,10 @@ class InsertNoisePass(TransformationPass):
         noise_scale: float = 1.0,
         warn_absent: bool = True,
     ):
-        if not HAS_QISKIT_AER:
+        if not HAS_AER:
             raise ValueError(
-                "Cannot initialize object of type 'InsertNoisePass' since 'qiskit-aer' is not "
-                "installed. Install 'qiskit-aer' and try again."
+                "Cannot import this file since 'qiskit-aer' is not installed. Install 'qiskit-aer' "
+                "and try again."
             )
 
         self._noise_dict = noise_dict or {}

--- a/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
@@ -22,7 +22,13 @@ from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode  # noqa: TC002
 from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
 from qiskit.transpiler import TransformationPass
-from qiskit_aer.noise import PauliLindbladError
+
+try:
+    from qiskit_aer.noise import PauliLindbladError
+
+    HAS_QISKIT_AER = True
+except ImportError:
+    HAS_QISKIT_AER = False
 
 
 def _find_qubit(dag: DAGCircuit, qubit: Qubit) -> int:
@@ -52,6 +58,12 @@ class InsertNoisePass(TransformationPass):
         noise_scale: float = 1.0,
         warn_absent: bool = True,
     ):
+        if not HAS_QISKIT_AER:
+            raise ValueError(
+                "Cannot initialize object of type 'InsertNoisePass' since 'qiskit-aer' is not "
+                "installed. Install 'qiskit-aer' and try again."
+            )
+
         self._noise_dict = noise_dict or {}
         self._noise_after = noise_after
         self._noise_scale = noise_scale

--- a/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
@@ -12,16 +12,23 @@
 
 """Transpiler pass that inserts Pauli-Lindblad noise after labeled barriers."""
 
+from __future__ import annotations
+
 import re
 import warnings
-from collections.abc import Callable  # noqa: TC003
 from functools import partial
+from typing import TYPE_CHECKING
 
-from qiskit.circuit import QuantumCircuit, Qubit  # noqa: TC002
+from qiskit.circuit import QuantumCircuit
 from qiskit.converters import circuit_to_dag
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode  # noqa: TC002
-from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
 from qiskit.transpiler import TransformationPass
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from qiskit.circuit import Qubit
+    from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+    from qiskit.quantum_info import PauliLindbladMap
 
 try:
     from qiskit_aer.noise import PauliLindbladError

--- a/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
@@ -112,7 +112,7 @@ class InsertNoisePass(TransformationPass):
         self, op_node: DAGOpNode, find_qubit: Callable[[Qubit], int]
     ) -> DAGCircuit | None:
         # Qiskit has no public API for reading barrier labels; _label is the only option.
-        label = op_node.op._label  # noqa: SLF001
+        label = op_node.op._label
         if label is None:
             return None
         if (noise_key := self._match_key(label)) is None:

--- a/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit, DAGOpNode
     from qiskit.quantum_info import PauliLindbladMap
 
-from qiskit.optionals import HAS_AER
+from qiskit.utils.optionals import HAS_AER
 from qiskit_aer.noise import PauliLindbladError
 
 

--- a/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
+++ b/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
@@ -20,7 +20,6 @@ from qiskit.primitives.containers.sampler_pub import SamplerPub
 from qiskit.providers import BackendV2  # noqa: TC002
 from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
 from qiskit.transpiler import PassManager
-from qiskit_aer.primitives import SamplerV2 as AerSamplerV2
 
 from ..quantum_program import (
     CircuitItem,
@@ -30,6 +29,14 @@ from ..quantum_program import (
 from ..results import QuantumProgramResult
 from .broadcast_sample import broadcast_sample
 from .insert_noise_pass import InsertNoisePass
+
+try:
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.primitives import SamplerV2 as AerSamplerV2
+
+    HAS_QISKIT_AER = True
+except ImportError:
+    HAS_QISKIT_AER = False
 
 
 def _round_to_clifford(values: np.ndarray, decimals: int) -> np.ndarray:
@@ -61,10 +68,14 @@ def run_quantum_program(
     Returns:
         Results of simulation.
     """
-    from qiskit_aer import AerSampler
+    if not HAS_QISKIT_AER:
+        raise ValueError(
+            "The function 'run_quantum_program' cannot be run since 'qiskit-aer' is not "
+            "installed. Install 'qiskit-aer' and try again."
+        )
 
-    if not isinstance(qasm_simulator, AerSampler):
-        raise ValueError("``qasm_simulator`` needs to be an ``AerSampler`` object.")
+    if not isinstance(qasm_simulator, AerSimulator):
+        raise ValueError("``qasm_simulator`` needs to be an ``AerSimulator`` object.")
 
     # Generate a sampler
     backend = deepcopy(qasm_simulator)

--- a/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
+++ b/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
@@ -12,23 +12,26 @@
 
 """Functions for running a QuantumProgram on a local Aer simulator."""
 
+from __future__ import annotations
+
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import numpy as np
 from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.sampler_pub import SamplerPub
-from qiskit.providers import BackendV2  # noqa: TC002
-from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
 from qiskit.transpiler import PassManager
 
-from ..quantum_program import (
-    CircuitItem,
-    QuantumProgram,  # noqa: TC001
-    SamplexItem,
-)
+from ..quantum_program import CircuitItem, SamplexItem
 from ..results import QuantumProgramResult
 from .broadcast_sample import broadcast_sample
 from .insert_noise_pass import InsertNoisePass
+
+if TYPE_CHECKING:
+    from qiskit.providers import BackendV2
+    from qiskit.quantum_info import PauliLindbladMap
+
+    from ..quantum_program import QuantumProgram
 
 try:
     from qiskit_aer import AerSimulator

--- a/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
+++ b/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
@@ -1,0 +1,148 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Functions for running a QuantumProgram on a local Aer simulator."""
+
+from copy import deepcopy
+
+import numpy as np
+from qiskit.primitives.containers.bindings_array import BindingsArray
+from qiskit.primitives.containers.sampler_pub import SamplerPub
+from qiskit.providers import BackendV2  # noqa: TC002
+from qiskit.quantum_info import PauliLindbladMap  # noqa: TC002
+from qiskit.transpiler import PassManager
+from qiskit_aer.primitives import SamplerV2 as AerSamplerV2
+
+from ..quantum_program import (
+    CircuitItem,
+    QuantumProgram,  # noqa: TC001
+    SamplexItem,
+)
+from ..results import QuantumProgramResult
+from .broadcast_sample import broadcast_sample
+from .insert_noise_pass import InsertNoisePass
+
+
+def _round_to_clifford(values: np.ndarray, decimals: int) -> np.ndarray:
+    """Round angles to the nearest multiple of π/2 at ``decimals`` decimal places.
+
+    This prevents floating-point drift from disqualifying nominally-Clifford circuits
+    from the stabilizer simulation method.
+    """
+    return np.round(values / (np.pi / 2), decimals=decimals) * (np.pi / 2)
+
+
+def run_quantum_program(
+    qasm_simulator: BackendV2,
+    program: QuantumProgram,
+    noise_dict: dict[str, PauliLindbladMap] | None = None,
+    angle_decimals: int = 5,
+    warn_absent: bool = True,
+) -> QuantumProgramResult:
+    """Run a quantum program on a simulator.
+
+    Args:
+        qasm_simulator: The simulator to use.
+        program: The program to run.
+        noise_dict: A map from barrier label refs to noise maps.
+        angle_decimals: Gate angles are rounded to the nearest multiple of π/2 at this
+            decimal precision before simulation.  See :func:`AerExecutor` for details.
+        warn_absent: Passed to :class:`InsertNoisePass`; see :class:`AerExecutor`.
+
+    Returns:
+        Results of simulation.
+    """
+    from qiskit_aer import AerSampler
+
+    if not isinstance(qasm_simulator, AerSampler):
+        raise ValueError("``qasm_simulator`` needs to be an ``AerSampler`` object.")
+
+    # Generate a sampler
+    backend = deepcopy(qasm_simulator)
+    backend.set_max_qubits(10000)
+    aer_sampler = AerSamplerV2.from_backend(backend)
+
+    # _seed is private but is the only way to obtain the sampler's RNG seed for reproducibility.
+    rng = np.random.default_rng(aer_sampler._seed)  # noqa: SLF001
+
+    result_list = []
+    metadata_list = []
+
+    for prog_item in program.items:
+        if noise_dict is not None:
+            circuit = PassManager(
+                [InsertNoisePass(noise_dict=noise_dict, warn_absent=warn_absent)]
+            ).run(prog_item.circuit)
+        else:
+            circuit = prog_item.circuit
+
+        if isinstance(prog_item, CircuitItem):
+            if prog_item.circuit_arguments is not None:
+                bindings_array = BindingsArray(
+                    {tuple(prog_item.circuit.parameters): prog_item.circuit_arguments}
+                )
+                for k, v in bindings_array._data.items():  # noqa: SLF001
+                    bindings_array._data[k] = _round_to_clifford(v, angle_decimals)  # noqa: SLF001
+            else:
+                bindings_array = None
+            sampler_res = aer_sampler.run(
+                [
+                    SamplerPub(
+                        circuit=circuit,
+                        parameter_values=bindings_array,
+                        shots=program.shots,
+                    )  # type: ignore
+                ]
+            ).result()
+            metadata_list.append(sampler_res[0].metadata)
+            bit_array = sampler_res[0].data
+            data = {key: ba.to_bool_array(order="little") for key, ba in dict(bit_array).items()}
+            result_list.append(data)
+
+        elif isinstance(prog_item, SamplexItem):
+            samplex_data = broadcast_sample(
+                prog_item.samplex,
+                prog_item.samplex_arguments,
+                prog_item.shape,
+                rng,
+            )
+            bindings_array = BindingsArray(
+                {tuple(prog_item.circuit.parameters): samplex_data.pop("parameter_values")}
+            )
+            for k, v in bindings_array._data.items():  # noqa: SLF001
+                bindings_array._data[k] = _round_to_clifford(v, angle_decimals)  # noqa: SLF001
+            sampler_res = aer_sampler.run(
+                [
+                    SamplerPub(
+                        circuit=circuit,
+                        parameter_values=bindings_array,
+                        shots=program.shots,
+                    )  # type: ignore
+                ]
+            ).result()
+            metadata_list.append(sampler_res[0].metadata)
+            bit_array = sampler_res[0].data
+            bool_arrays = {
+                key: ba.to_bool_array(order="little") for key, ba in dict(bit_array).items()
+            }
+            data = {**samplex_data, **bool_arrays}
+            result_list.append(data)
+
+        else:
+            raise TypeError(f"Unsupported QuantumProgramItem type: {type(prog_item)}")
+
+    return QuantumProgramResult(
+        data=result_list,
+        # metadata=dict(enumerate(metadata_list)),
+        metadata=None,  # TODO: Figure this out
+        passthrough_data=program.passthrough_data,
+    )

--- a/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
+++ b/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
@@ -21,6 +21,7 @@ import numpy as np
 from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 from qiskit.transpiler import PassManager
+from qiskit.utils.optionals import HAS_AER
 
 from ..quantum_program import CircuitItem, SamplexItem
 from ..results import QuantumProgramResult
@@ -32,14 +33,6 @@ if TYPE_CHECKING:
     from qiskit.quantum_info import PauliLindbladMap
 
     from ..quantum_program import QuantumProgram
-
-try:
-    from qiskit_aer import AerSimulator
-    from qiskit_aer.primitives import SamplerV2 as AerSamplerV2
-
-    HAS_QISKIT_AER = True
-except ImportError:
-    HAS_QISKIT_AER = False
 
 
 def _round_to_clifford(values: np.ndarray, decimals: int) -> np.ndarray:
@@ -71,11 +64,14 @@ def run_quantum_program(
     Returns:
         Results of simulation.
     """
-    if not HAS_QISKIT_AER:
+    if not HAS_AER:
         raise ValueError(
             "The function 'run_quantum_program' cannot be run since 'qiskit-aer' is not "
             "installed. Install 'qiskit-aer' and try again."
         )
+
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.primitives import SamplerV2 as AerSamplerV2
 
     if not isinstance(qasm_simulator, AerSimulator):
         raise ValueError("``qasm_simulator`` needs to be an ``AerSimulator`` object.")

--- a/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
+++ b/qiskit_ibm_runtime/aer_executor/run_quantum_program.py
@@ -82,7 +82,7 @@ def run_quantum_program(
     aer_sampler = AerSamplerV2.from_backend(backend)
 
     # _seed is private but is the only way to obtain the sampler's RNG seed for reproducibility.
-    rng = np.random.default_rng(aer_sampler._seed)  # noqa: SLF001
+    rng = np.random.default_rng(aer_sampler._seed)
 
     result_list = []
     metadata_list = []
@@ -100,8 +100,8 @@ def run_quantum_program(
                 bindings_array = BindingsArray(
                     {tuple(prog_item.circuit.parameters): prog_item.circuit_arguments}
                 )
-                for k, v in bindings_array._data.items():  # noqa: SLF001
-                    bindings_array._data[k] = _round_to_clifford(v, angle_decimals)  # noqa: SLF001
+                for k, v in bindings_array._data.items():
+                    bindings_array._data[k] = _round_to_clifford(v, angle_decimals)
             else:
                 bindings_array = None
             sampler_res = aer_sampler.run(
@@ -128,8 +128,8 @@ def run_quantum_program(
             bindings_array = BindingsArray(
                 {tuple(prog_item.circuit.parameters): samplex_data.pop("parameter_values")}
             )
-            for k, v in bindings_array._data.items():  # noqa: SLF001
-                bindings_array._data[k] = _round_to_clifford(v, angle_decimals)  # noqa: SLF001
+            for k, v in bindings_array._data.items():
+                bindings_array._data[k] = _round_to_clifford(v, angle_decimals)
             sampler_res = aer_sampler.run(
                 [
                     SamplerPub(

--- a/test/unit/aer_executor/__init__.py
+++ b/test/unit/aer_executor/__init__.py
@@ -1,0 +1,13 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for AerExecutor."""

--- a/test/unit/aer_executor/test_aer_executor_clifford.py
+++ b/test/unit/aer_executor/test_aer_executor_clifford.py
@@ -249,7 +249,7 @@ class TestAerExecutor(IBMTestCase):
         item_data = result[0]
 
         # Result shape: (4, shots, 2)
-        self.assertEqual(["c"].shape, (4, shots, 2))
+        self.assertEqual(item_data["c"].shape, (4, shots, 2))
 
         # phi=0, theta=0 → |00⟩
         self.assertTrue((item_data["c"][0] == [False, False]).all())

--- a/test/unit/aer_executor/test_aer_executor_clifford.py
+++ b/test/unit/aer_executor/test_aer_executor_clifford.py
@@ -1,0 +1,350 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test AerExecutor with a Clifford circuit on the stabilizer simulator."""
+
+import numpy as np
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.transpiler import generate_preset_pass_manager
+from qiskit_aer import AerSimulator
+from samplomatic.builders.build import build
+from samplomatic.transpiler import generate_boxing_pass_manager
+
+from qiskit_ibm_runtime.aer_executor import AerExecutor
+from qiskit_ibm_runtime.fake_provider.backends.fez import FakeFez
+from qiskit_ibm_runtime.quantum_program import QuantumProgram
+
+from ...ibm_test_case import IBMTestCase
+
+
+class TestAerExecutor(IBMTestCase):
+    """Tests for AerExecutor."""
+
+    def assert_correct(
+        self, expected: dict[str, np.ndarray], executor_results: dict[str, np.ndarray]
+    ) -> None:
+        """Assert that executor results match the expected bit arrays after flip correction.
+
+        Bit arrays use LSB-first ordering: ``data[..., 0]`` corresponds to classical
+        register bit 0.
+
+        Args:
+            expected: A map from classical register names to boolean arrays of shape
+                ``(num_bits,)`` giving the expected deterministic outcome.
+            executor_results: A map from register names to boolean arrays of shape
+                ``(num_randomizations, num_shots, num_bits)``, and optionally
+                ``measurement_flips.<name>`` arrays that broadcast over the shots axis.
+
+        Raises:
+            AssertionError: If not every expected key is present in the results.
+            AssertionError: If any result array is not 3-d bool with the correct last axis.
+            AssertionError: If corrected data does not exactly match the expected outcome.
+        """
+        for name, expected_bits in expected.items():
+            self.assertTrue(
+                name in executor_results,
+                f"Classical register '{name}' not found in executor results",
+            )
+
+            arr = executor_results[name]
+            self.assertEqual(
+                arr.dtype, bool, f"Expected '{name}' to have dtype bool, got '{arr.dtype}'."
+            )
+            self.assertEqual(arr.ndim, 3, f"Expected 3-d array for '{name}', got shape {arr.shape}")
+            self.assertEqual(
+                arr.shape[2],
+                len(expected_bits),
+                f"Expected {len(expected_bits)} bits for '{name}', got {arr.shape[2]}",
+            )
+
+            corrected = arr
+            if (flips := executor_results.get(f"measurement_flips.{name}")) is not None:
+                corrected = arr ^ flips
+
+            self.assertTrue(
+                (corrected == expected_bits).all(),
+                f"Corrected data for '{name}' does not match expected outcome {expected_bits}",
+            )
+
+    def test_clifford_circuit_item(self):
+        """Test using the stabilizer simulation method via a CircuitItem."""
+        # Build a simple 3-qubit Clifford circuit (GHZ state preparation + measurement)
+        qc = QuantumCircuit(3, 3)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.measure([0, 1, 2], [0, 1, 2])
+
+        # Transpile to FakeFez using a non-trivial layout: physical qubits [17, 18, 19]
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(),
+            initial_layout=[17, 18, 19],
+            optimization_level=0,
+        )
+        transpiled = pm.run(qc)
+
+        # Build a QuantumProgram with the transpiled circuit (no free parameters)
+        program = QuantumProgram(shots=1024)
+        program.append_circuit_item(transpiled)
+
+        # Run via AerExecutor
+        executor = AerExecutor(AerSimulator(method="stabilizer"))
+        job = executor.run(program)
+        result = job.result()
+
+        # The result should have one item
+        self.assertEqual(len(result), 1)
+
+        # There should be a classical register key in the result data
+        item_data = result[0]
+        self.assertGreater(len(item_data), 0)
+
+        # Each measurement outcome array should have shape (shots, num_clbits)
+        for key, arr in item_data.items():
+            self.assertEqual(
+                arr.shape[0], 1024, f"Expected 1024 shots, got {arr.shape[0]} for register '{key}'"
+            )
+
+        # For a GHZ state, only '000' and '111' outcomes are possible.
+        # Verify that all shots are either all-zeros or all-ones across the 3 bits.
+        for key, arr in item_data.items():
+            for shot in arr:
+                self.assertTrue(
+                    all(shot == 0) or all(shot == 1),
+                    f"Unexpected measurement outcome {shot}—GHZ state should only yield 000 or 111",
+                )
+
+    def test_clifford_samplex_item(self):
+        """Test using the stabilizer simulation method via a SamplexItem."""
+        num_randomizations = 8
+        shots = 256
+
+        # Build a simple 2-qubit CX circuit (|00⟩ → |00⟩ deterministically)
+        qc = QuantumCircuit(2, 2)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+
+        # Transpile and box in one pass manager
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(),
+            initial_layout=[17, 27],
+            optimization_level=0,
+        )
+        pm.post_scheduling = generate_boxing_pass_manager()
+        transpiled = pm.run(qc)
+        template_circuit, samplex = build(transpiled)
+
+        # Build a QuantumProgram using a SamplexItem
+        program = QuantumProgram(shots=shots)
+        program.append_samplex_item(
+            template_circuit,
+            samplex=samplex,
+            shape=(num_randomizations,),
+        )
+
+        # Run via AerExecutor
+        executor = AerExecutor(AerSimulator(method="stabilizer"))
+        job = executor.run(program)
+        result = job.result()
+
+        self.assertEqual(len(result), 1)
+        item_data = result[0]
+
+        # CX|00⟩ = |00⟩
+        self.assert_correct({"c": np.array([False, False])}, item_data)
+
+    def test_circuit_item_with_circuit_arguments(self):
+        """Run a parameterized CircuitItem by supplying circuit_arguments directly.
+
+        Uses RX(theta) bitflips (theta ∈ {0, π}) on two qubits to produce four
+        deterministic outcomes, verifying that circuit_arguments are bound correctly
+        in the CircuitItem branch of run_quantum_program.
+        """
+        shots = 128
+
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        qc = QuantumCircuit(2, 2)
+        qc.rx(theta, 0)
+        qc.rx(phi, 1)
+        qc.measure([0, 1], [0, 1])
+
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(),
+            initial_layout=[17, 27],
+            optimization_level=0,
+        )
+        transpiled = pm.run(qc)
+
+        # circuit.parameters sorts alphabetically: [phi, theta]
+        # shape (4, 2): 4 sweep configurations, 2 parameters each
+        circuit_arguments = np.array(
+            [[0.0, 0.0], [np.pi, 0.0], [0.0, np.pi], [np.pi, np.pi]], dtype=float
+        )
+        program = QuantumProgram(shots=shots)
+        program.append_circuit_item(transpiled, circuit_arguments=circuit_arguments)
+
+        executor = AerExecutor(AerSimulator(method="stabilizer"))
+        result = executor.run(program).result()
+
+        self.assertEqual(len(result), 1)
+        item_data = result[0]
+
+        # Result shape: (4, shots, 2)
+        self.assertEqual(item_data["c"].shape, (4, shots, 2))
+
+        # phi=0, theta=0 → |00⟩
+        self.assertTrue((item_data["c"][0] == [False, False]).all())
+        # phi=π, theta=0 → |01⟩ (phi acts on q1, LSB-first: bit1=True)
+        self.assertTrue((item_data["c"][1] == [False, True]).all())
+        # phi=0, theta=π → |10⟩ (theta acts on q0, LSB-first: bit0=True)
+        self.assertTrue((item_data["c"][2] == [True, False]).all())
+        # phi=π, theta=π → |11⟩
+        self.assertTrue((item_data["c"][3] == [True, True]).all())
+
+    def test_samplex_item_with_parameter_sweep(self):
+        """Run a parameterized CircuitItem by supplying circuit_arguments directly.
+
+        Uses RX(theta) bitflips (theta ∈ {0, π}) on two qubits to produce four
+        deterministic outcomes, verifying that circuit_arguments are bound correctly
+        in the CircuitItem branch of run_quantum_program.
+        """
+        shots = 128
+
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        qc = QuantumCircuit(2, 2)
+        qc.rx(theta, 0)
+        qc.rx(phi, 1)
+        qc.measure([0, 1], [0, 1])
+
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(),
+            initial_layout=[17, 27],
+            optimization_level=0,
+        )
+        transpiled = pm.run(qc)
+
+        # circuit.parameters sorts alphabetically: [phi, theta]
+        # shape (4, 2): 4 sweep configurations, 2 parameters each
+        circuit_arguments = np.array(
+            [[0.0, 0.0], [np.pi, 0.0], [0.0, np.pi], [np.pi, np.pi]], dtype=float
+        )
+        program = QuantumProgram(shots=shots)
+        program.append_circuit_item(transpiled, circuit_arguments=circuit_arguments)
+
+        executor = AerExecutor(AerSimulator(method="stabilizer"), angle_decimals=5)
+        result = executor.run(program).result()
+
+        self.assertEqual(len(result), 1)
+        item_data = result[0]
+
+        # Result shape: (4, shots, 2)
+        self.assertEqual(["c"].shape, (4, shots, 2))
+
+        # phi=0, theta=0 → |00⟩
+        self.assertTrue((item_data["c"][0] == [False, False]).all())
+        # phi=π, theta=0 → |01⟩ (phi acts on q1, LSB-first: bit1=True)
+        self.assertTrue((item_data["c"][1] == [False, True]).all())
+        # phi=0, theta=π → |10⟩ (theta acts on q0, LSB-first: bit0=True)
+        self.assertTrue((item_data["c"][2] == [True, False]).all())
+        # phi=π, theta=π → |11⟩
+        self.assertTrue((item_data["c"][3] == [True, True]).all())
+
+    def test_samplex_item_with_broadcast_sweep(self):
+        """Run a Pauli-twirled circuit with a parameter sweep over input bitflips.
+
+        This test verifies that broadcast dimensions in samplex_arguments are handled correctly.
+
+        The circuit applies RX(theta) on qubit 0 before CX and RX(phi) on qubit 1
+        after CX, where theta, phi ∈ {0, π} act as bitflips. This keeps the circuit
+        Clifford for the stabilizer simulator and gives four distinct, deterministic
+        outcomes.
+
+        The shape ``(r0, 2, 2, r1)`` places the two broadcast axes (theta sweep,
+        phi sweep) between two randomization axes, exercising non-adjacent
+        randomization dimensions in ``_broadcast_sample``.
+        """
+        r0 = 3
+        r1 = 4
+        shots = 64
+
+        # Build a 2-qubit circuit: RX(theta) on q0, CX, RX(phi) on q1, then measure
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        qc = QuantumCircuit(2, 2)
+        qc.rx(theta, 0)
+        qc.cx(0, 1)
+        qc.rx(phi, 1)
+        qc.measure([0, 1], [0, 1])
+
+        # Transpile and box in one pass manager
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(),
+            initial_layout=[17, 27],
+            optimization_level=0,
+        )
+        pm.post_scheduling = generate_boxing_pass_manager()
+        transpiled = pm.run(qc)
+        template_circuit, samplex = build(transpiled)
+
+        # Sweep over bitflip values: shape (2, 2, 1, 2) = (theta, phi, r1_placeholder, params)
+        # Extrinsic shape (2, 2, 1) right-aligns with (r0, 2, 2, r1) as padded (1, 2, 2, 1)
+        # circuit.parameters sorts alphabetically: [phi, theta]
+        param_values = np.array(
+            [
+                [[0.0, 0.0], [np.pi, 0.0]],
+                [[0.0, np.pi], [np.pi, np.pi]],
+            ]
+        ).reshape((2, 2, 1, 2))
+        program = QuantumProgram(shots=shots)
+        program.append_samplex_item(
+            template_circuit,
+            samplex=samplex,
+            samplex_arguments={"parameter_values": param_values},
+            shape=(r0, 2, 2, r1),
+        )
+
+        executor = AerExecutor(AerSimulator(method="stabilizer"), angle_decimals=5)
+        job = executor.run(program)
+        result = job.result()
+
+        self.assertEqual(len(result), 1)
+        item_data = result[0]
+
+        # Verify broadcast produced the expected extrinsic shape (r0, 2, 2, r1, ...)
+        for key, arr in item_data.items():
+            self.assertEqual(
+                arr.shape[:4],
+                (r0, 2, 2, r1),
+                f"Expected leading shape {(r0, 2, 2, r1)}, got {arr.shape[:4]} for '{key}'",
+            )
+
+        # Check correctness per sweep value.
+        # Collapse the two randomization axes (r0, r1) into one for assert_correct.
+        def sweep_slice(i, j):
+            return {
+                key: arr[:, i, j, :].reshape(r0 * r1, *arr.shape[4:])
+                for key, arr in item_data.items()
+            }
+
+        # theta=0, phi=0: CX|00⟩ = |00⟩, no flip on q1 → |00⟩
+        self.assert_correct({"c": np.array([False, False])}, sweep_slice(0, 0))
+
+        # theta=0, phi=π: CX|00⟩ = |00⟩, X on q1 → |01⟩
+        self.assert_correct({"c": np.array([False, True])}, sweep_slice(0, 1))
+
+        # theta=π, phi=0: CX|10⟩ = |11⟩, no flip on q1 → |11⟩
+        self.assert_correct({"c": np.array([True, True])}, sweep_slice(1, 0))
+
+        # theta=π, phi=π: CX|10⟩ = |11⟩, X on q1 → |10⟩
+        self.assert_correct({"c": np.array([True, False])}, sweep_slice(1, 1))

--- a/test/unit/aer_executor/test_broadcast_sample.py
+++ b/test/unit/aer_executor/test_broadcast_sample.py
@@ -1,0 +1,150 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for ``broadcast_sample``."""
+
+import numpy as np
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.transpiler import generate_preset_pass_manager
+from samplomatic.builders.build import build
+from samplomatic.transpiler import generate_boxing_pass_manager
+
+from qiskit_ibm_runtime.aer_executor.broadcast_sample import broadcast_sample
+from qiskit_ibm_runtime.fake_provider.backends.fez import FakeFez
+from qiskit_ibm_runtime.quantum_program import QuantumProgram
+
+from ...ibm_test_case import IBMTestCase
+
+
+class TestBroadcastSample(IBMTestCase):
+    """Tests for ``broadcast_sample``."""
+
+    def make_cx_item(self):
+        """Return a SamplexItem for a Pauli-twirled CX circuit (no free parameters)."""
+        qc = QuantumCircuit(2, 2)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(), initial_layout=[17, 27], optimization_level=0
+        )
+        pm.post_scheduling = generate_boxing_pass_manager()
+        transpiled = pm.run(qc)
+        template_circuit, samplex = build(transpiled)
+        program = QuantumProgram(shots=64)
+        program.append_samplex_item(template_circuit, samplex=samplex, shape=(3, 5))
+        return program.items[0]
+
+    def make_param_item_no_broadcast(self):
+        """Return a SamplexItem for a parameterized circuit with no broadcast axes."""
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        qc = QuantumCircuit(2, 2)
+        qc.rx(theta, 0)
+        qc.cx(0, 1)
+        qc.rx(phi, 1)
+        qc.measure([0, 1], [0, 1])
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(), initial_layout=[17, 27], optimization_level=0
+        )
+        pm.post_scheduling = generate_boxing_pass_manager()
+        transpiled = pm.run(qc)
+        template_circuit, samplex = build(transpiled)
+        # No samplex_arguments => shape (4,) is all randomization
+        program = QuantumProgram(shots=64)
+        program.append_samplex_item(template_circuit, samplex=samplex, shape=(4,))
+        return program.items[0]
+
+    def make_param_item_mixed(self):
+        """Return a SamplexItem with mixed broadcast/randomization axes: shape (r0, 2, 2, r1)."""
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        qc = QuantumCircuit(2, 2)
+        qc.rx(theta, 0)
+        qc.cx(0, 1)
+        qc.rx(phi, 1)
+        qc.measure([0, 1], [0, 1])
+        pm = generate_preset_pass_manager(
+            backend=FakeFez(), initial_layout=[17, 27], optimization_level=0
+        )
+        pm.post_scheduling = generate_boxing_pass_manager()
+        transpiled = pm.run(qc)
+        template_circuit, samplex = build(transpiled)
+        # parameters sorted alphabetically: [phi, theta]
+        param_values = np.array(
+            [[[0.0, 0.0], [np.pi, 0.0]], [[0.0, np.pi], [np.pi, np.pi]]]
+        ).reshape((2, 2, 1, 2))
+        program = QuantumProgram(shots=64)
+        program.append_samplex_item(
+            template_circuit,
+            samplex=samplex,
+            samplex_arguments={"parameter_values": param_values},
+            shape=(3, 2, 2, 4),
+        )
+        return program.items[0]
+
+    def test_broadcast_sample_no_broadcast_axes(self):
+        """All axes are randomization axes: output shape matches the requested shape."""
+        item = self.make_cx_item()
+        shape = item.shape  # (3, 5)
+        rng = np.random.default_rng(42)
+
+        result = broadcast_sample(item.samplex, item.samplex_arguments, shape, rng)
+
+        self.assertIsInstance(result, dict)
+        self.assertGreater(len(result), 0)
+        for key, val in result.items():
+            self.assertEqual(
+                val.shape[: len(shape)],
+                shape,
+                f"Expected leading shape {shape} for '{key}', got {val.shape}",
+            )
+
+    def test_broadcast_sample_output_keys(self):
+        """Output contains 'parameter_values' and at least one 'measurement_flips.*' key."""
+        item = self.make_cx_item()
+        rng = np.random.default_rng(0)
+
+        result = broadcast_sample(item.samplex, item.samplex_arguments, item.shape, rng)
+
+        self.assertTrue("parameter_values" in result)
+
+        flip_keys = [k for k in result if k.startswith("measurement_flips.")]
+        self.assertGreater(len(flip_keys), 0)
+
+    def test_broadcast_sample_all_broadcast_axes(self):
+        """Broadcast axes produce the correct leading shape."""
+        item = self.make_param_item_mixed()
+        shape = item.shape  # (3, 2, 2, 4)
+        rng = np.random.default_rng(7)
+
+        result = broadcast_sample(item.samplex, item.samplex_arguments, shape, rng)
+
+        for key, val in result.items():
+            self.assertEqual(
+                val.shape[: len(shape)],
+                shape,
+                f"Expected leading shape {shape} for '{key}', got {val.shape}",
+            )
+
+    def test_broadcast_sample_rng_reproducible(self):
+        """Same RNG seed produces identical results."""
+        item = self.make_cx_item()
+
+        r1 = broadcast_sample(
+            item.samplex, item.samplex_arguments, item.shape, np.random.default_rng(1)
+        )
+        r2 = broadcast_sample(
+            item.samplex, item.samplex_arguments, item.shape, np.random.default_rng(1)
+        )
+
+        for key in r1:
+            np.testing.assert_array_equal(r1[key], r2[key], err_msg=f"Mismatch in '{key}'")

--- a/test/unit/aer_executor/test_insert_noise_pass.py
+++ b/test/unit/aer_executor/test_insert_noise_pass.py
@@ -1,0 +1,145 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for InsertNoisePass."""
+
+import warnings
+
+import numpy as np
+from ddt import data, ddt, unpack
+from qiskit.circuit import Barrier, QuantumCircuit
+from qiskit.quantum_info import DensityMatrix, PauliLindbladMap
+from qiskit.transpiler import PassManager
+from qiskit_aer import AerSimulator
+
+from qiskit_ibm_runtime.aer_executor.insert_noise_pass import InsertNoisePass
+
+from ...ibm_test_case import IBMTestCase
+
+
+def _circuit_with_barrier(n_qubits: int, label: str) -> QuantumCircuit:
+    circuit = QuantumCircuit(n_qubits)
+    circuit.append(Barrier(n_qubits, label=label), list(range(n_qubits)))
+    return circuit
+
+
+def _noise_error_ops(circuit: QuantumCircuit) -> list:
+    # PauliLindbladError is wrapped in QuantumChannelInstruction when going through the DAG.
+    return [instr.operation for instr in circuit.data if instr.operation.name == "quantum_channel"]
+
+
+@ddt
+class TestInsertNoisePass(IBMTestCase):
+    """Tests for InsertNoisePass."""
+
+    @data((True, "R", 1), (True, "M", 0), (False, "R", 0), (False, "M", 1))
+    @unpack
+    def test_noise_after_true_injects_at_r_barriers(
+        self, noise_after, barrier_type, num_noise_error_ops
+    ):
+        """Test `noise_after` for different types of barriers."""
+        inject_noise = InsertNoisePass(
+            noise_dict={"r0": PauliLindbladMap.from_list([("XI", 0.1), ("IX", 0.2)])},
+            noise_after=noise_after,
+        )
+        pm = PassManager([inject_noise])
+        result = pm.run(_circuit_with_barrier(2, label=f"{barrier_type}0@tag=r0"))
+        self.assertEqual(len(_noise_error_ops(result)), num_noise_error_ops)
+
+    def test_noise_scale_multiplies_rates(self):
+        """Test the `noise_scale` argument."""
+        circuit = _circuit_with_barrier(2, "R0@tag=r0")
+        noise_dict = {"r0": PauliLindbladMap.from_list([("XI", 0.1)])}
+
+        pm_1x = PassManager([InsertNoisePass(noise_dict=noise_dict, noise_scale=1.0)])
+        result_1x = pm_1x.run(circuit)
+
+        pm_3x = PassManager([InsertNoisePass(noise_dict=noise_dict, noise_scale=3.0)])
+        result_3x = pm_3x.run(circuit)
+
+        # PauliLindbladError is stored as ._quantum_error inside QuantumChannelInstruction.
+        np.testing.assert_allclose(_noise_error_ops(result_1x)[0]._quantum_error.rates, [0.1])  # noqa: SLF001
+        np.testing.assert_allclose(_noise_error_ops(result_3x)[0]._quantum_error.rates, [0.3])  # noqa: SLF001
+
+    def test_warn_absent(self):
+        """Test the ``warn_absent`` field."""
+        circuit = _circuit_with_barrier(2, "R0@tag=unknown")
+        noise_dict = {"r0": PauliLindbladMap.from_list([("XI", 0.1)])}
+
+        with self.assertWarnsRegex(UserWarning, "No noise found for tag 'unknown'"):
+            PassManager([InsertNoisePass(noise_dict=noise_dict, warn_absent=True)]).run(circuit)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            PassManager([InsertNoisePass(noise_dict=noise_dict, warn_absent=False)]).run(circuit)
+
+    def test_none_noise_dict_is_noop(self):
+        """Test that ``noise_dict=None`` is a noop."""
+        circuit = _circuit_with_barrier(2, "R0@tag=r0")
+        result = PassManager([InsertNoisePass(noise_dict=None)]).run(circuit)
+        self.assertEqual(len(_noise_error_ops(result)), 0)
+
+    def test_missing_tag_leaves_barrier_intact(self):
+        """Test that missing tags leave barriers intect."""
+        circuit = _circuit_with_barrier(2, "R0@tag=unknown")
+        noise_dict = {"r0": PauliLindbladMap.from_list([("XI", 0.1)])}
+
+        pm = PassManager([InsertNoisePass(noise_dict=noise_dict, warn_absent=False)])
+        result = pm.run(circuit)
+
+        self.assertEqual(len(_noise_error_ops(result)), 0)
+        self.assertEqual(result.count_ops().get("barrier", 0), 1)
+
+    def test_noise_qubits_ordered_by_physical_index(self):
+        """Test qubit order."""
+        # Barrier on a non-canonical qubit subset/order: qargs = [2, 0].  After substitution the
+        # PauliLindbladError must land on physical qubits [0, 2] (ascending), not [2, 0].
+        circuit = QuantumCircuit(3)
+        circuit.append(Barrier(2, label="R0@tag=r0"), [2, 0])
+
+        noise_dict = {"r0": PauliLindbladMap.from_list([("XI", 0.1)])}
+        result = PassManager([InsertNoisePass(noise_dict=noise_dict, noise_after=True)]).run(
+            circuit
+        )
+
+        noise_instrs = [instr for instr in result.data if instr.operation.name == "quantum_channel"]
+        self.assertEqual(len(noise_instrs), 1)
+        self.assertEqual([result.find_bit(q).index for q in noise_instrs[0].qubits], [0, 2])
+        # The original barrier should appear exactly once--regression: an earlier fix duplicated it.
+        self.assertEqual(result.count_ops().get("barrier", 0), 1)
+
+    @data("order", [[0, 1, 3], [3, 0, 1], [0, 3, 1]])
+    def test_noise_simulation_applies_rates_to_correct_physical_qubits(self, order):
+        """Test correct physical qubits are selected."""
+        # We want to inject this noise on qubits {0, 1, 3}. We set the barrier qubits to [3, 0, 1]
+        # just to prove that we ignore the barrier qubit order, and instead use the order of the
+        # physical qubits. In this case we should get
+        #   "IIX" rate 0.20 -> X on physical qubit 0
+        #   "IXI" rate 0.10 -> X on physical qubit 1
+        #   "XII" rate 0.05 -> X on physical qubit 3
+        noise_dict = {
+            "r0": PauliLindbladMap.from_list([("IIX", 0.20), ("IXI", 0.10), ("XII", 0.05)])
+        }
+
+        circuit = QuantumCircuit(4)
+        circuit.append(Barrier(3, label="R0@tag=r0"), [3, 0, 1])
+
+        noisy = PassManager([InsertNoisePass(noise_dict=noise_dict, noise_after=True)]).run(circuit)
+        noisy.save_density_matrix()
+
+        result = AerSimulator(method="density_matrix").run(noisy).result()
+        dm = DensityMatrix(result.data(0)["density_matrix"])
+
+        rates_per_physical_qubit = np.array([0.20, 0.10, 0.0, 0.05])
+        expected_p1 = (1 - np.exp(-2 * rates_per_physical_qubit)) / 2
+        actual_p1 = np.array([dm.probabilities([q])[1] for q in range(circuit.num_qubits)])
+        np.testing.assert_allclose(actual_p1, expected_p1, atol=1e-10)

--- a/test/unit/aer_executor/test_noisy.py
+++ b/test/unit/aer_executor/test_noisy.py
@@ -1,0 +1,146 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests."""
+
+from itertools import islice, product
+
+from ddt import data, ddt, unpack
+from qiskit.circuit import QuantumCircuit
+from qiskit.primitives.containers.bit_array import BitArray
+from qiskit.quantum_info import PauliLindbladMap
+from qiskit_aer import AerSimulator
+from samplomatic import Tag, Twirl
+from samplomatic.builders.build import build
+
+from qiskit_ibm_runtime.aer_executor import AerExecutor
+from qiskit_ibm_runtime.fake_provider.backends.fez import FakeFez
+from qiskit_ibm_runtime.quantum_program import QuantumProgram
+
+from ...ibm_test_case import IBMTestCase
+
+
+def _batched(iterable, n, *, strict=False):
+    # _batched('ABCDEFG', 3) → ABC DEF G
+    if n < 1:
+        raise ValueError("n must be at least one")
+    iterator = iter(iterable)
+    while batch := tuple(islice(iterator, n)):
+        if strict and len(batch) != n:
+            raise ValueError("_batched(): incomplete batch")
+        yield batch
+
+
+def _circ_a():
+    num_qubits = 2
+    active_qubits = list(range(num_qubits))
+
+    qc_boxed = QuantumCircuit(num_qubits, num_qubits)
+    with qc_boxed.box(
+        annotations=[
+            Twirl(dressing="left"),
+            Tag(ref="r0"),
+        ]
+    ):  # pyright: ignore[reportGeneralTypeIssues]
+        for edge in _batched(active_qubits, 2):
+            if len(edge) == 2:
+                qc_boxed.cz(*edge)
+
+    with qc_boxed.box(annotations=[Twirl(dressing="right")]):
+        qc_boxed.noop([0, 1])
+    return qc_boxed, active_qubits
+
+
+def _circ_b():
+    fez_backend = FakeFez()
+    coupling_map = fez_backend.coupling_map
+    active_qubits = list(range(fez_backend.num_qubits))
+
+    qc_boxed = QuantumCircuit(fez_backend.num_qubits, fez_backend.num_qubits)
+    with qc_boxed.box(
+        annotations=[
+            Twirl(dressing="left"),
+            Tag(ref="r0"),
+        ]
+    ):  # pyright: ignore[reportGeneralTypeIssues]
+        for edge in _batched(active_qubits, 2):
+            if edge in coupling_map:
+                qc_boxed.cz(*edge)
+            else:
+                qc_boxed.z(edge)
+
+    with qc_boxed.box(annotations=[Twirl(dressing="right")]):
+        qc_boxed.noop(active_qubits)
+
+    return qc_boxed, active_qubits
+
+
+@ddt
+class TestNoisySimulation(IBMTestCase):
+    """Test noisy simulation."""
+
+    @data(*product([True, False], ["a", "b"]))
+    @unpack
+    def test_noisy_simulation(self, noise, case):
+        """Test noisy simulation."""
+        if case == "a":
+            qc_boxed, active_qubits = _circ_a()
+        elif case == "b":
+            qc_boxed, active_qubits = _circ_b()
+        else:
+            raise ValueError("...")
+
+        qc_boxed.measure(active_qubits, active_qubits)
+
+        template_circuit, samplex = build(qc_boxed)
+
+        self.assertGreater(template_circuit.count_ops().get("rz", 0), 0)
+
+        shots_per_twirl = 1024
+        num_twirls = 1
+        num_shots_tot = shots_per_twirl * num_twirls
+
+        # Build a QuantumProgram using a SamplexItem
+        program = QuantumProgram(shots=shots_per_twirl)
+        program.append_samplex_item(
+            template_circuit,
+            samplex=samplex,
+            shape=(num_twirls,),
+        )
+
+        def _xi(i: int, n: int = len(active_qubits)) -> str:
+            ll = ["I"] * n
+            ll[i] = "X"
+            return "".join(reversed(ll))
+
+        if noise:
+            noise_dict = {
+                "r0": PauliLindbladMap.from_list(
+                    [(_xi(i), 1e-1) for i in range(len(active_qubits))]
+                ),
+            }
+        else:
+            noise_dict = None
+
+        # Run via AerExecutor
+        executor = AerExecutor(AerSimulator(method="stabilizer"), noise_dict=noise_dict)
+        job = executor.run(program)
+        result = job.result()
+
+        self.assertEqual(len(result), 1)
+
+        ba_c = BitArray.from_bool_array(result[0]["c"])
+        cts = ba_c.get_counts()
+        if noise:
+            self.assertGreater(num_shots_tot, cts.get("0" * len(active_qubits), 0))
+        else:
+            self.assertEqual(num_shots_tot, cts.get("0" * len(active_qubits), 0))

--- a/test/unit/aer_executor/test_run_quantum_program.py
+++ b/test/unit/aer_executor/test_run_quantum_program.py
@@ -1,0 +1,63 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for run_quantum_program."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit_aer import AerSimulator
+
+from qiskit_ibm_runtime.aer_executor.run_quantum_program import run_quantum_program
+from qiskit_ibm_runtime.quantum_program import QuantumProgram
+
+from ...ibm_test_case import IBMTestCase
+
+
+class TestRunQuantumProgram(IBMTestCase):
+    """Test for running quantum programs."""
+
+    def test_unsupported_item_type_raises_type_error(self):
+        """Test unsupported types."""
+        fake_item = MagicMock()
+        fake_item.circuit = QuantumCircuit(1)
+
+        program = MagicMock()
+        program.items = [fake_item]
+        program.shots = 64
+        program.passthrough_data = None
+
+        with pytest.raises(TypeError, match="Unsupported QuantumProgramItem type"):
+            run_quantum_program(AerSimulator(method="stabilizer"), program)
+
+    def test_angle_rounding_snaps_near_clifford(self):
+        """RZ(π + ε) with a tiny ε should round to π, yielding |1⟩ deterministically.
+
+        H → RZ(π) → H maps |0⟩ → |1⟩. Without rounding, ε would make the angle non-Clifford
+        and the stabilizer simulator would error.
+        """
+        theta = Parameter("theta")
+        qc = QuantumCircuit(1, 1)
+        qc.h(0)
+        qc.rz(theta, 0)
+        qc.h(0)
+        qc.measure(0, 0)
+
+        circuit_arguments = np.array([[np.pi + 1e-10]])  # shape (sweeps=1, params=1)
+        program = QuantumProgram(shots=64)
+        program.append_circuit_item(qc, circuit_arguments=circuit_arguments)
+
+        result = run_quantum_program(AerSimulator(method="stabilizer"), program, angle_decimals=5)
+
+        self.assertTrue((result[0]["c"] == [[True]]).all())

--- a/test/unit/aer_executor/test_run_quantum_program.py
+++ b/test/unit/aer_executor/test_run_quantum_program.py
@@ -15,7 +15,6 @@
 from unittest.mock import MagicMock
 
 import numpy as np
-import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit_aer import AerSimulator
 
@@ -38,7 +37,7 @@ class TestRunQuantumProgram(IBMTestCase):
         program.shots = 64
         program.passthrough_data = None
 
-        with pytest.raises(TypeError, match="Unsupported QuantumProgramItem type"):
+        with self.assertRaisesRegex(TypeError, "Unsupported QuantumProgramItem type"):
             run_quantum_program(AerSimulator(method="stabilizer"), program)
 
     def test_angle_rounding_snaps_near_clifford(self):


### PR DESCRIPTION
### Summary

This PR copy/pastes aer-executor and tests from qiskit-noise-learning ([link](https://github.com/Qiskit/qiskit-noise-learning/tree/main/qiskit_noise_learning/aer_executor)) into qiskit-ibm-runtime.

### Details and comments

A few changes were made to the original files:

- The files have been reformatted in the style required by qiskit-ibm-runtime.
- The [inline.py](https://github.com/Qiskit/qiskit-noise-learning/blob/main/qiskit_noise_learning/aer_executor/inline.py) file was left behind, as per discussions with @samanthavbarron.
- The qiskit-aer dependency is dealt with in the same way as in the [neat.py](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/debug_tools/neat.py) file, namely:
    - Files that need qiskit-aer do not import qiskit-aer, they only try to do so. If they succeed, they set HAS_QISKIT_AER` to `True`, otherwise they set it to `False`.
    - The classes and functions that require qiskit-aer raise an error whenever `HAS_QISKIT_AER` is `False.

This PR does not:

- Add new tests or docstrings.
- Improve logic or fix bugs.

Fixes #3066

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
