### PR TITLE
Change `mypy` config to not ignore broken imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ fallback_version = "0.46.1"
 python_version = "3.10"
 packages = ["qiskit_ibm_runtime", "test"]
 namespace_packages = true
-ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unreachable = true
 strict_equality = true
@@ -68,6 +67,24 @@ disable_error_code = "import-untyped"
 module = "test.*"
 disallow_untyped_calls = false
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "ddt",
+    "ibm_cloud_sdk_core.*",
+    "ibm_platform_services.*",
+    "ibm_quantum_schemas.*",
+    "numpy.*",
+    "plotly.*",
+    "pydantic.*",
+    "qiskit_aer.*",
+    "qiskit.*",
+    "requests_ntlm.*",
+    "rustworkx",
+    "samplomatic.*",
+    "urllib3.*",
+]
+ignore_missing_imports = true
 
 [tool.coverage.run]
 source = ["qiskit_ibm_runtime"]

--- a/qiskit_ibm_runtime/calibrator.py
+++ b/qiskit_ibm_runtime/calibrator.py
@@ -26,8 +26,8 @@ from .utils.default_session import get_cm_session
 if TYPE_CHECKING:
     from qiskit.providers import BackendV2
 
-    from ..runtime_job_v2 import RuntimeJobV2
     from .batch import Batch
+    from .runtime_job_v2 import RuntimeJobV2
     from .session import Session
 
 

--- a/qiskit_ibm_runtime/decoders/executor_estimator/trex_utils.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/trex_utils.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from qiskit.quantum_info import Pauli
 
-    from ..results.quantum_program import QuantumProgramItemResult
+    from ...results.quantum_program import QuantumProgramItemResult
 
 import numpy as np
 from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauli

--- a/qiskit_ibm_runtime/utils/default_session.py
+++ b/qiskit_ibm_runtime/utils/default_session.py
@@ -18,7 +18,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .session import Session
+    from ..session import Session
 
 # Default session
 _DEFAULT_SESSION: ContextVar[Session | None] = ContextVar("_DEFAULT_SESSION", default=None)


### PR DESCRIPTION
### Summary
Mypy config is changed to catch broken imports within the repo. Dependencies with no stubs are still ignored in this regard.

Some broken imports were fixed.

Thanks @diego-plan9 

- [X] I didn't use LLM tooling, or only used it privately.

