### PR TITLE
Reject NaN RZZ angles during primitive validation

### DIFF
--- a/qiskit_ibm_runtime/utils/utils.py
+++ b/qiskit_ibm_runtime/utils/utils.py
@@ -165,7 +165,7 @@ def _is_valid_rzz_pub_helper(circuit: QuantumCircuit) -> str | set[Parameter]:
             angle = instruction.operation.params[0]
             if isinstance(angle, ParameterExpression):
                 angle_params.add(angle)
-            elif angle < 0.0 or angle > np.pi / 2 + 1e-10:
+            elif np.isnan(angle) or angle < 0.0 or angle > np.pi / 2 + 1e-10:
                 return (
                     "The instruction rzz is supported only for angles in the "
                     f"range [0, pi/2], but an angle ({angle}) outside of this "
@@ -218,8 +218,8 @@ def is_valid_rzz_pub(pub: EstimatorPub | SamplerPub) -> str:
         projected_arr = arr[:, col_indices]
 
         for row in projected_arr:
-            angle = float(param_exp.bind(dict(zip(param_exp.parameters, row))))
-            if angle < 0.0 or angle > np.pi / 2 + 1e-10:
+            angle = float(param_exp.bind_all(dict(zip(param_exp.parameters, row))))
+            if np.isnan(angle) or angle < 0.0 or angle > np.pi / 2 + 1e-10:
                 vals_msg = ", ".join(
                     [f"{param_name}={param_val}" for param_name, param_val in zip(param_names, row)]
                 )

--- a/release-notes/unreleased/2452.bug.rst
+++ b/release-notes/unreleased/2452.bug.rst
@@ -1,0 +1,3 @@
+Reject fixed and parameterized ``RZZ`` angles that evaluate to ``NaN`` during
+primitive input validation, instead of accepting the value or leaking a raw
+Qiskit binding error.

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -299,7 +299,7 @@ class TestSamplerV2(IBMTestCase):
             with self.assertRaises(IBMInputValueError):
                 SamplerV2(backend).run(pubs=[circ])
 
-    @data(-1, 1, 2)
+    @data(-1, 1, 2, np.nan)
     def test_rzz_fixed_angle_validation(self, angle):
         """Test exception when rzz gate is used with an angle outside the range [0, pi/2]."""
         backend = FakeFractionalBackend()
@@ -314,7 +314,7 @@ class TestSamplerV2(IBMTestCase):
             with self.assertRaisesRegex(IBMInputValueError, f"{angle}"):
                 SamplerV2(backend).run(pubs=[circ])
 
-    @data(-1, 1, 2)
+    @data(-1, 1, 2, np.nan)
     def test_rzz_parametrized_angle_validation(self, angle):
         """Test rzz gate with parameter outside range.
 
@@ -333,6 +333,17 @@ class TestSamplerV2(IBMTestCase):
         else:
             with self.assertRaisesRegex(IBMInputValueError, f"p={angle}"):
                 SamplerV2(backend).run(pubs=[(circ, [angle])])
+
+    def test_rzz_parametrized_angle_allows_eliminated_nan(self):
+        """Test that a NaN parameter is allowed when it is eliminated from the RZZ angle."""
+        backend = FakeFractionalBackend()
+        param = Parameter("p")
+
+        circ = QuantumCircuit(2)
+        circ.rzz(0 * param + 1, 0, 1)
+        circ.measure_all()
+
+        SamplerV2(backend).run(pubs=[(circ, [np.nan])])
 
     @data([1.0, 2.0], [1.0, 0.0])
     @unpack


### PR DESCRIPTION
### Summary

Reject fixed and parameterized `RZZ` angles whose evaluated value is `NaN`. This keeps invalid input inside the existing `IBMInputValueError` validation path instead of accepting a fixed NaN or leaking a raw Qiskit binding error.

### Details and comments

- evaluate parameter expressions with `bind_all` before validating the resulting angle
- preserve valid expressions where a NaN-valued parameter is algebraically eliminated
- extend fixed and parameterized RZZ regression coverage, including the eliminated-NaN case
- add the required Towncrier bug-fix fragment

Validation:

- `python -m pytest -q test/unit/test_sampler.py`: 43 passed, 3 subtests passed
- `ruff check` on touched Python files: passed
- `ruff format --check` on touched Python files: passed
- `mypy --no-incremental` on touched Python files: passed
- `git diff --check`: passed
- additional automated code review: no findings after the eliminated-parameter revision

## Why this matters

NaN gate angles should fail fast at validation time with a clear error, not propagate into backend execution or produce undefined results on real hardware.

## Related

Fixes #2452

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used OpenAI Codex to help write this PR description.
- [x] I used OpenAI Codex to generate or modify code and tests.