### PR TITLE
Adjust to service rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Qiskit Runtime IBM Client
+
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-ibm-runtime.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/ci.yml/badge.svg)](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/ci.yml)
 [![](https://img.shields.io/github/release/Qiskit/qiskit-ibm-runtime.svg?style=popout-square)](https://github.com/Qiskit/qiskit-ibm-runtime/releases)
@@ -9,10 +10,10 @@
 
 **Qiskit** is an open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives.
 
-**Qiskit IBM Runtime** is a new environment offered by IBM Quantum that streamlines quantum computations and provides optimal
+**IBM Quantum Compute** (formerly Qiskit Runtime) is a new environment offered by IBM Quantum that streamlines quantum computations and provides optimal
 implementations of the Qiskit primitives `sampler` and `estimator` for IBM Quantum hardware. It is designed to use additional classical compute resources to execute quantum circuits with more efficiency on quantum processors, by including near-time computations such as error suppression and error mitigation. Examples of error suppression include dynamical decoupling, noise-aware compilation, error mitigation including readout mitigation, zero-noise extrapolation (ZNE), and probabilistic error cancellation (PEC).
 
-This module provides the interface to access the Qiskit Runtime service on IBM Quantum Platform.
+This module provides the interface to access the IBM Quantum Compute service on IBM Quantum Platform.
 
 ## Installation
 
@@ -31,13 +32,7 @@ pip install qiskit-ibm-runtime[performance,visualization]
 
 ## Account setup
 
-### Qiskit Runtime service on IBM Quantum Platform
-
-| :warning: After the sunset of IBM Quantum Platform Classic the `ibm_quantum` channel option is no longer supported. The `ibm_cloud` and `ibm_quantum_platform` channels are now the only valid channels. See the [migration guide.](https://quantum.cloud.ibm.com/docs/migration-guides/classic-iqp-to-cloud-iqp) for more information.
-|:---------------------------|
-
-
-### Qiskit Runtime service on the new IBM Quantum Platform (IBM Cloud)
+### IBM Quantum Compute service on IBM Quantum Platform
 
 You will need your IBM Quantum Platform API token to authenticate with the runtime service:
 
@@ -46,7 +41,7 @@ You will need your IBM Quantum Platform API token to authenticate with the runti
 2. Copy (and optionally regenerate) your API token from your
    [IBM Cloud account page].
 
-The runtime service is now part of the IBM Quantum Services on IBM Cloud. To use this service, you'll
+The IBM Quantum Compute service is now part of the IBM Quantum Services on IBM Cloud. To use this service, you'll
 need to create an IBM Cloud account and a quantum service instance.
 [This guide](https://quantum.cloud.ibm.com/docs/migration-guides/classic-iqp-to-cloud-iqp)
 contains step-by-step instructions, including how to find your
@@ -58,8 +53,8 @@ IBM Cloud API key and Cloud Resource Name (CRN), which you will need for authent
 Once you have the account credentials, you can save them on disk, so you won't have to input
 them each time. The credentials are saved in the `$HOME/.qiskit/qiskit-ibm.json` file, where `$HOME` is your home directory.
 
-| :warning: Account credentials are saved in plain text, so only do so if you are using a trusted device. |
-|:---------------------------|
+> [!WARNING]
+> Account credentials are saved in plain text, so only do so if you are using a trusted device.
 
  ```python
 from qiskit_ibm_runtime import QiskitRuntimeService
@@ -119,7 +114,7 @@ Primitives accept vectorized inputs, where single circuits can be grouped with a
 
 The [primitive interfaces](https://quantum.cloud.ibm.com/docs/api/qiskit/primitives) are defined in Qiskit.
 
-The IBM Runtime service offers these primitives with additional features, such as built-in error suppression and mitigation.
+The IBM Quantum Compute service offers these primitives with additional features, such as built-in error suppression and mitigation.
 
 There are several different options you can specify when calling the primitives. See [Primitive options](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/options) for more information.
 
@@ -214,7 +209,7 @@ This code batches together 50 parameters to be executed in a single job. If a us
 
 ## Session
 
-In many algorithms and applications, an Estimator needs to be called iteratively without incurring queuing delays on each iteration. To solve this, the IBM Runtime service provides a **Session**. A session starts when the first job within the session is started, and subsequent jobs within the session are prioritized by the scheduler.
+In many algorithms and applications, an Estimator needs to be called iteratively without incurring queuing delays on each iteration. To solve this, the IBM Quantum Compute service provides a **Session**. A session starts when the first job within the session is started, and subsequent jobs within the session are prioritized by the scheduler.
 
 You can use the [`qiskit_ibm_runtime.Session`](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/session.py) class to start a
 session. Consider the same example above and try to find the optimal `theta`. The following example uses the [golden search method](https://en.wikipedia.org/wiki/Golden-section_search) to iteratively find the optimal theta that maximizes the observable.
@@ -352,7 +347,7 @@ export USAGE_DATA_OPT_OUT=True
 
 ## Contribution guidelines
 
-If you'd like to contribute to qiskit-ibm-runtime, please take a look at our
+If you'd like to contribute to `qiskit-ibm-runtime`, please take a look at our
 [contribution guidelines]. This project adheres to Qiskit's [code of conduct].
 By participating, you are expected to uphold to this code.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Qiskit Runtime IBM Client
+# IBM Quantum Compute (formerly Qiskit Runtime) client
 
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-ibm-runtime.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/ci.yml/badge.svg)](https://github.com/Qiskit/qiskit-ibm-runtime/actions/workflows/ci.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ convention = "google"
 [project]
 name = "qiskit-ibm-runtime"
 dynamic = [ "version" ]
-description = "IBM Quantum client for Qiskit Runtime."
+description = "IBM Quantum client for IBM Quantum Compute (formerly Qiskit Runtime)."
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [
     {name = "Qiskit Development Team", email="qiskit@us.ibm.com"},

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -200,7 +200,10 @@ Classes
 
 import logging
 
-from .qiskit_runtime_service import QiskitRuntimeService
+from .qiskit_runtime_service import (
+    QiskitRuntimeService,
+    QiskitRuntimeService as IBMQuantumComputeService,
+)
 from .ibm_backend import IBMBackend
 from .runtime_job_v2 import RuntimeJobV2
 from .runtime_options import RuntimeOptions

--- a/qiskit_ibm_runtime/__init__.py
+++ b/qiskit_ibm_runtime/__init__.py
@@ -11,27 +11,27 @@
 # that they have been altered from the originals.
 
 """
-==========================================
-Qiskit Runtime (:mod:`qiskit_ibm_runtime`)
-==========================================
+================================================================================
+IBM Quantum Compute (formerly Qiskit Runtime) Client (:mod:`qiskit_ibm_runtime`)
+================================================================================
 
 .. currentmodule:: qiskit_ibm_runtime
 
-Modules related to Qiskit Runtime IBM Client.
+Modules related to IBM Quantum Compute (formerly Qiskit Runtime) Client.
 
-Qiskit Runtime is a new architecture that
+IBM Quantum Compute (formerly Qiskit Runtime) is a new architecture that
 streamlines computations requiring many iterations. These experiments will
 execute significantly faster within its improved hybrid quantum/classical process.
 
 Primitives and sessions
 =======================
 
-Qiskit Runtime has two predefined primitives: ``Sampler`` and ``Estimator``.
+IBM Quantum Compute has two predefined primitives: ``Sampler`` and ``Estimator``.
 These primitives provide a simplified interface for performing foundational quantum
 computing tasks while also accounting for the latest developments in
 quantum hardware and software.
 
-Qiskit Runtime also has the concept of a session. Jobs submitted within a session are
+IBM Quantum Compute also has the concept of a session. Jobs submitted within a session are
 prioritized by the scheduler. A session
 allows you to make iterative calls to the quantum computer more efficiently.
 
@@ -137,17 +137,17 @@ Supplementary Information
 Account initialization
 -------------------------
 
-You need to initialize your account before you can start using the Qiskit Runtime service.
+You need to initialize your account before you can start using the IBM Quantum Compute service.
 This is done by initializing a :class:`QiskitRuntimeService` instance with your
 account credentials. If you don't want to pass in the credentials each time, you
 can use the :meth:`QiskitRuntimeService.save_account` method to save the credentials
 on disk.
 
-Qiskit Runtime is available on IBM Cloud, and you can specify the channel with
+IBM Quantum Compute is available on IBM Cloud, and you can specify the channel with
 ``channel="ibm_cloud"`` or ``channel="ibm_quantum_platform"``.
 
-Runtime Jobs
-------------
+IBM Quantum Compute Jobs
+------------------------
 
 When you use the ``run()`` method of the :class:`Sampler` or :class:`Estimator`
 to invoke the primitive, a

--- a/qiskit_ibm_runtime/accounts/__init__.py
+++ b/qiskit_ibm_runtime/accounts/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Account management functionality related to the IBM Runtime Services."""
+"""Account management functionality related to the IBM Quantum Compute service."""
 
 from .account import Account, AccountType, ChannelType, PlanType, RegionType
 from .exceptions import (

--- a/qiskit_ibm_runtime/api/client_parameters.py
+++ b/qiskit_ibm_runtime/api/client_parameters.py
@@ -72,7 +72,7 @@ class ClientParameters:
         )
 
     def get_runtime_api_base_url(self) -> str:
-        """Returns the Runtime API base url."""
+        """Returns the IBM Quantum Compute API base url."""
         return self.url_resolver(self.url, self.instance, self.private_endpoint, self.channel)
 
     def connection_parameters(self) -> dict[str, Any]:

--- a/qiskit_ibm_runtime/api/clients/__init__.py
+++ b/qiskit_ibm_runtime/api/clients/__init__.py
@@ -10,6 +10,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""IBM Quantum API clients."""
+"""IBM Quantum Compute API clients."""
 
 from .runtime import RuntimeClient

--- a/qiskit_ibm_runtime/api/clients/runtime.py
+++ b/qiskit_ibm_runtime/api/clients/runtime.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Client for accessing IBM Quantum runtime service."""
+"""Client for accessing IBM Quantum Compute service."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class RuntimeClient(BaseBackendClient):
-    """Client for accessing runtime service.
+    """Client for accessing IBM Quantum Compute service.
 
     Args:
         params: Connection parameters.
@@ -72,12 +72,12 @@ class RuntimeClient(BaseBackendClient):
             program_id: Program ID.
             backend_name: Name of the backend to run the program.
             params: Parameters to use.
-            image: The runtime image to use.
+            image: The IBM Quantum Compute image to use.
             log_level: Log level to use.
-            session_id: Job ID of the first job in a runtime session.
+            session_id: Job ID of the first job in a IBM Quantum Compute session.
             job_tags: Tags to be assigned to the job.
             max_execution_time: Maximum execution time in seconds.
-            start_session: Set to True to explicitly start a runtime session. Defaults to False.
+            start_session: Set to True to explicitly start a IBM Quantum Compute session.
             session_time: Length of session in seconds.
             private: Marks job as private.
             calibration_id: The calibration id to use with the program execution
@@ -111,7 +111,7 @@ class RuntimeClient(BaseBackendClient):
             JSON response.
         """
         response = self._api.program_job(job_id).get(exclude_params=exclude_params)
-        logger.debug("Runtime job get response: %s", response)
+        logger.debug("IBM Quantum Compute job get response: %s", response)
         return response
 
     def jobs_get(
@@ -137,7 +137,7 @@ class RuntimeClient(BaseBackendClient):
                 returns 'DONE', 'CANCELLED' and 'ERROR' jobs if False.
             program_id: Filter by Program ID.
             job_tags: Filter by tags assigned to jobs. Matched jobs are associated with all tags.
-            session_id: Job ID of the first job in a runtime session.
+            session_id: Job ID of the first job in a IBM Quantum Compute session.
             created_after: Filter by the given start date, in local time. This is used to
                 find jobs whose creation dates are after (greater than or equal to) this
                 local date/time.
@@ -178,7 +178,7 @@ class RuntimeClient(BaseBackendClient):
         """Cancel a job.
 
         Args:
-            job_id: Runtime job ID.
+            job_id: IBM Quantum Compute job ID.
         """
         self._api.program_job(job_id).cancel()
 
@@ -186,7 +186,7 @@ class RuntimeClient(BaseBackendClient):
         """Delete a job.
 
         Args:
-            job_id: Runtime job ID.
+            job_id: IBM Quantum Compute job ID.
         """
         self._api.program_job(job_id).delete()
 

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Runtime REST adapter."""
+"""IBM Quantum Compute REST adapter."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class Runtime(RestAdapterBase):
-    """Rest adapter for Runtime base endpoints."""
+    """Rest adapter for IBM Quantum Compute base endpoints."""
 
     URL_MAP = {
         "jobs": "/jobs",
@@ -83,12 +83,12 @@ class Runtime(RestAdapterBase):
             program_id: Program ID.
             backend_name: Name of the backend.
             params: Program parameters.
-            image: Runtime image.
+            image: IBM Quantum Compute image.
             log_level: Log level to use.
-            session_id: ID of the first job in a runtime session.
+            session_id: ID of the first job in a IBM Quantum Compute session.
             job_tags: Tags to be assigned to the job.
             max_execution_time: Maximum execution time in seconds.
-            start_session: Set to True to explicitly start a runtime session. Defaults to False.
+            start_session: Set to True to explicitly start a IBM Quantum Compute session.
             session_time: Length of session in seconds.
             private: Marks job as private.
             calibration_id: The calibration id to use with the program execution
@@ -156,7 +156,7 @@ class Runtime(RestAdapterBase):
                 returns 'DONE', 'CANCELLED' and 'ERROR' jobs if False.
             program_id: Filter by Program ID.
             job_tags: Filter by tags assigned to jobs. Matched jobs are associated with all tags.
-            session_id: Job ID of the first job in a runtime session.
+            session_id: Job ID of the first job in a IBM Quantum Compute session.
             created_after: Filter by the given start date, in local time. This is used to
                 find jobs whose creation dates are after (greater than or equal to) this
                 local date/time.

--- a/qiskit_ibm_runtime/api/rest/runtime_session.py
+++ b/qiskit_ibm_runtime/api/rest/runtime_session.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Runtime Session REST adapter."""
+"""IBM Quantum Compute Session REST adapter."""
 
 from __future__ import annotations
 
@@ -29,7 +29,7 @@ class RuntimeSession(RestAdapterBase):
 
     Args:
         session: RetrySession to be used in the adapter.
-        session_id: Job ID of the first job in a runtime session.
+        session_id: Job ID of the first job in a IBM Quantum Compute session.
         url_prefix: Prefix to use in the URL.
     """
 

--- a/qiskit_ibm_runtime/base_primitive.py
+++ b/qiskit_ibm_runtime/base_primitive.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Base class for Qiskit Runtime primitives."""
+"""Base class for IBM Quantum Compute primitives."""
 
 from __future__ import annotations
 

--- a/qiskit_ibm_runtime/base_runtime_job.py
+++ b/qiskit_ibm_runtime/base_runtime_job.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Base runtime job class."""
+"""Base IBM Quantum Compute job class."""
 
 from __future__ import annotations
 
@@ -48,7 +48,7 @@ API_TO_JOB_ERROR_MESSAGE = {
 
 
 class BaseRuntimeJob(ABC):
-    """Base Runtime Job class.
+    """Base IBM Quantum Compute Job class.
 
     Args:
         backend: The backend instance used to run this job.
@@ -60,9 +60,9 @@ class BaseRuntimeJob(ABC):
             of such subclasses. If more than one decoder is specified, they will be called in
             chain, with the output of the ``n-th`` decoder as the input of the ``n+1-th``
             decoder. If not specified, the default ``ResultDecoder`` is used.
-        image: Runtime image used for this job: image_name:tag.
-        service: Runtime service.
-        session_id: Job ID of the first job in a runtime session.
+        image: IBM Quantum Compute image used for this job: image_name:tag.
+        service: IBM Quantum Compute (formerly Qiskit Runtime) service.
+        session_id: Job ID of the first job in a IBM Quantum Compute session.
         tags: Tags assigned to the job.
         version: Primitive version.
         private: Marks job as private.
@@ -234,7 +234,7 @@ class BaseRuntimeJob(ABC):
         """Set status.
 
         Args:
-            job_response: Job response from runtime API.
+            job_response: Job response from IBM Quantum Compute API.
 
         Raises:
             IBMError: If an unknown status is returned from the server.
@@ -257,7 +257,7 @@ class BaseRuntimeJob(ABC):
         """Set error message if the job failed.
 
         Args:
-            job_response: Job response from runtime API.
+            job_response: Job response from IBM Quantum Compute API.
         """
         if self._status == self.ERROR:
             self._error_message = self._error_msg_from_job_response(job_response)
@@ -273,7 +273,7 @@ class BaseRuntimeJob(ABC):
         """Returns the error message from an API response.
 
         Args:
-            response: Job response from the runtime API.
+            response: Job response from the IBM Quantum Compute API.
 
         Returns:
             Error message.
@@ -311,10 +311,10 @@ class BaseRuntimeJob(ABC):
 
     @property
     def image(self) -> str:
-        """Return the runtime image used for the job.
+        """Return the IBM Quantum Compute image used for the job.
 
         Returns:
-            The runtime image ``image_name:tag`` or ``""`` if the default image is used.
+            The IBM Quantum Compute image ``image_name:tag`` or ``""`` if the default image is used.
         """
         return self._image
 

--- a/qiskit_ibm_runtime/batch.py
+++ b/qiskit_ibm_runtime/batch.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Qiskit Runtime batch mode."""
+"""IBM Quantum Compute batch mode."""
 
 from __future__ import annotations
 
@@ -43,8 +43,8 @@ class Batch(Session):
     Batch mode can shorten processing time if all jobs are provided at the outset.
     If you want to submit iterative jobs, use ``session`` mode instead.
 
-    You can open a Qiskit Runtime batch by using this ``Batch`` class, then submit jobs
-    to one or more primitives.
+    You can open a IBM Quantum Compute (formerly Qiskit Runtime) batch by using this ``Batch``
+    class, then submit jobs to one or more primitives.
 
     For example::
 
@@ -88,7 +88,7 @@ class Batch(Session):
         backend: Instance of ``Backend`` class.
 
         max_time:
-            Maximum amount of time a runtime session can be open before being
+            Maximum amount of time a IBM Quantum Compute session can be open before being
             forcibly closed. Can be specified as seconds (int) or a string like "2h 30m 40s".
             This value must be less than the
             `system imposed maximum

--- a/qiskit_ibm_runtime/decoders/result_decoder.py
+++ b/qiskit_ibm_runtime/decoders/result_decoder.py
@@ -19,10 +19,10 @@ from ..json import RuntimeDecoder
 
 
 class ResultDecoder:
-    """Runtime job result decoder.
+    """IBM Quantum Compute job result decoder.
 
     You can subclass this class and overwrite the :meth:`decode` method to create a custom result
-    decoder for the results of your runtime program. For example::
+    decoder for the results of your IBM Quantum Compute program. For example::
 
         class MyResultDecoder(ResultDecoder):
 

--- a/qiskit_ibm_runtime/decoders/runner.py
+++ b/qiskit_ibm_runtime/decoders/runner.py
@@ -19,9 +19,9 @@ from .result_decoder import ResultDecoder
 
 
 class RunnerResultDecoder(ResultDecoder):
-    """Result class for Qiskit Runtime program circuit-runner."""
+    """Result class for IBM Quantum Compute program circuit-runner."""
 
     @classmethod
     def decode(cls, data: str) -> RunnerResult:
-        """Decoding for results from Qiskit runtime jobs."""
+        """Decoding for results from IBM Quantum Compute jobs."""
         return RunnerResult.from_dict(super().decode(data))

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -45,10 +45,10 @@ class Estimator:
 
 
 class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2):
-    r"""Class for interacting with Qiskit Runtime Estimator primitive service.
+    r"""Class for interacting with IBM Quantum Compute Estimator primitive service.
 
-    Qiskit Runtime Estimator primitive service estimates expectation values of quantum circuits and
-    observables.
+    IBM Quantum Compute (formerly Qiskit Runtime) Estimator primitive service estimates expectation
+    values of quantum circuits and observables.
 
     The :meth:`run` can be used to submit circuits, observables, and parameters
     to the Estimator primitive.
@@ -104,7 +104,7 @@ class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2)
             * A :class:`Batch` if you are using batch execution mode.
 
             Refer to the
-            `Qiskit Runtime documentation
+            `IBM Quantum Compute documentation
             <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`_
             for more information about the ``Execution modes``.
 

--- a/qiskit_ibm_runtime/estimator.py
+++ b/qiskit_ibm_runtime/estimator.py
@@ -45,9 +45,9 @@ class Estimator:
 
 
 class EstimatorV2(BasePrimitiveV2[EstimatorOptions], Estimator, BaseEstimatorV2):
-    r"""Class for interacting with IBM Quantum Compute Estimator primitive service.
+    r"""EstimatorV2 primitive for IBM Quantum Compute (formerly Qiskit Runtime).
 
-    IBM Quantum Compute (formerly Qiskit Runtime) Estimator primitive service estimates expectation
+    IBM Quantum Compute Estimator primitive service estimates expectation
     values of quantum circuits and observables.
 
     The :meth:`run` can be used to submit circuits, observables, and parameters

--- a/qiskit_ibm_runtime/exceptions.py
+++ b/qiskit_ibm_runtime/exceptions.py
@@ -10,14 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Exceptions related to the IBM Runtime service."""
+"""Exceptions related to the IBM Quantum Compute service."""
 
 from qiskit.exceptions import QiskitError
 from qiskit.providers.exceptions import JobError, JobTimeoutError
 
 
 class IBMError(QiskitError):
-    """Base class for errors raised by the runtime service modules."""
+    """Base class for errors raised by the IBM Quantum Compute service modules."""
 
     pass
 
@@ -71,7 +71,7 @@ class IBMApiError(IBMError):
 
 
 class IBMRuntimeError(IBMError):
-    """Base class for errors raised by the runtime service modules."""
+    """Base class for errors raised by the IBM Quantum Compute service modules."""
 
     pass
 
@@ -83,7 +83,7 @@ class RuntimeProgramNotFound(IBMRuntimeError):
 
 
 class RuntimeJobFailureError(JobError):
-    """Error raised when a runtime job failed."""
+    """Error raised when a IBM Quantum Compute job failed."""
 
     pass
 

--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -63,7 +63,7 @@ class Executor:
             * A :class:`Batch` if you are using batch execution mode.
 
             Refer to the
-            `Qiskit Runtime documentation
+            `IBM Quantum Compute documentation
             <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`_
             for more information about the ``Execution modes``.
 

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -80,7 +80,7 @@ Fields:
 
 
 class EstimatorV2(BaseEstimatorV2):
-    """Executor-based EstimatorV2 primitive for Qiskit Runtime.
+    """Executor-based EstimatorV2 primitive for IBM Quantum Compute (formerly Qiskit Runtime).
 
     This is an implementation of EstimatorV2 built on top of the Executor primitive,
     enabling transparent client-side processing with faster feedback loops and greater
@@ -119,7 +119,7 @@ class EstimatorV2(BaseEstimatorV2):
             * A :class:`~qiskit_ibm_runtime.Session` if you are using session execution mode.
             * A :class:`~qiskit_ibm_runtime.Batch` if you are using batch execution mode.
 
-            Refer to the `Qiskit Runtime documentation
+            Refer to the `IBM Quantum Compute documentation
             <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`_
             for more information about execution modes.
 
@@ -191,7 +191,7 @@ class EstimatorV2(BaseEstimatorV2):
         )
 
     def finalize_options(self) -> EstimatorOptions:
-        """Construct and finalize the runtime estimator options.
+        """Construct and finalize the Estimator options.
 
         This method combines the configured resilience level with the user-provided option
         to produce the final :class:`~.EstimatorOptions` instance used inside a call to
@@ -249,7 +249,7 @@ class EstimatorV2(BaseEstimatorV2):
         to executor inputs can be resource intensive and cause a delay between invoking the function
         and the ``job`` being submitted. In order to check the progress of the call, it is
         recommended to setup logging (with an ``INFO`` level) - see
-        `Qiskit Runtime documentation
+        `IBM Quantum Compute documentation
         <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-service#logging>`_
         for more information.
 

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 class SamplerV2(BaseSamplerV2):
-    """Executor-based Sampler primitive for Qiskit Runtime.
+    """Executor-based Sampler primitive for IBM Quantum Compute (formerly Qiskit Runtime).
 
     This is an implementation of SamplerV2 built on top of the Executor primitive,
     enabling transparent client-side processing with faster feedback loops and greater
@@ -88,7 +88,7 @@ class SamplerV2(BaseSamplerV2):
             * A :class:`~qiskit_ibm_runtime.Session` if you are using session execution mode.
             * A :class:`~qiskit_ibm_runtime.Batch` if you are using batch execution mode.
 
-            Refer to the `Qiskit Runtime documentation
+            Refer to the `IBM Quantum Compute documentation
             <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`_
             for more information about execution modes.
 
@@ -140,7 +140,7 @@ class SamplerV2(BaseSamplerV2):
         to executor inputs can be resource intensive can be resource intensive and cause a delay
         between invoking the function and the ``job`` being submitted. In order to check the
         progress of the call, it is recommended to setup logging (with an ``INFO`` level) - see
-        `Qiskit Runtime documentation
+        `IBM Quantum Compute documentation
         <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/runtime-service#logging>`_
         for more information.
 

--- a/qiskit_ibm_runtime/fake_provider/local_service.py
+++ b/qiskit_ibm_runtime/fake_provider/local_service.py
@@ -157,7 +157,7 @@ class QiskitRuntimeLocalService:
         Args:
             program_id: Program ID.
             inputs: Program input parameters. These input values are passed
-                to the runtime program.
+                to the IBM Quantum Compute program.
             options: Runtime options that control the execution environment.
             calibration_id: The calibration id to use with the program execution
 

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -45,15 +45,15 @@ QASM3RUNNERPROGRAMID = "qasm3-runner"
 
 
 class IBMBackend(Backend):
-    """Backend class interfacing with an IBM Quantum backend.
+    """Backend class interfacing with an IBM Quantum Compute backend.
 
     Note:
         * You should not instantiate the ``IBMBackend`` class directly. Instead, use
           the methods provided by an :class:`QiskitRuntimeService` instance to retrieve and handle
           backends.
 
-    This class represents an IBM Quantum backend. Its attributes and methods provide
-    information about the backend. For example, the :meth:`status()` method
+    This class represents an IBM Quantum Compute (formerly Qiskit Runtime) backend. Its attributes
+    and methods provide information about the backend. For example, the :meth:`status()` method
     returns a :class:`BackendStatus<~.providers.models.BackendStatus>` instance.
     The instance contains the ``operational`` and ``pending_jobs`` attributes, which state whether
     the backend is operational and also the number of jobs in the server queue for the backend,
@@ -335,7 +335,7 @@ class IBMBackend(Backend):
 
         Raises:
             TypeError: If an input argument is not of the correct type.
-            NotImplementedError: If `datetime` is specified when cloud runtime is used.
+            NotImplementedError: If `datetime` is specified when IBM Quantum Compute is used.
         """
         if self._configuration.simulator:
             # Simulators do not have backend properties.

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -45,14 +45,14 @@ QASM3RUNNERPROGRAMID = "qasm3-runner"
 
 
 class IBMBackend(Backend):
-    """Backend class interfacing with an IBM Quantum Compute backend.
+    """Backend class interfacing with an IBM Quantum Compute (formerly Qiskit Runtime) backend.
 
     Note:
         * You should not instantiate the ``IBMBackend`` class directly. Instead, use
           the methods provided by an :class:`QiskitRuntimeService` instance to retrieve and handle
           backends.
 
-    This class represents an IBM Quantum Compute (formerly Qiskit Runtime) backend. Its attributes
+    This class represents an IBM Quantum Compute backend. Its attributes
     and methods provide information about the backend. For example, the :meth:`status()` method
     returns a :class:`BackendStatus<~.providers.models.BackendStatus>` instance.
     The instance contains the ``operational`` and ``pending_jobs`` attributes, which state whether

--- a/qiskit_ibm_runtime/json.py
+++ b/qiskit_ibm_runtime/json.py
@@ -237,7 +237,7 @@ def _cast_strings_keys_to_int(obj: dict) -> dict:
 
 
 class RuntimeEncoder(json.JSONEncoder):
-    """JSON Encoder used by runtime service."""
+    """JSON Encoder used by IBM Quantum Compute service."""
 
     def default(self, obj: Any) -> Any:
         """Return a serializable object for ``obj``."""
@@ -430,7 +430,7 @@ class RuntimeEncoder(json.JSONEncoder):
 
 
 class RuntimeDecoder(json.JSONDecoder):
-    """JSON Decoder used by runtime service."""
+    """JSON Decoder used by IBM Quantum Compute service."""
 
     def __init__(self, *args: Any, **kwargs: Any):
         if "encoding" in kwargs:

--- a/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/noise_learner_v3.py
@@ -55,7 +55,8 @@ class NoiseLearnerV3:
             * A :class:`Batch` if you are using batch execution mode.
 
             Refer to the
-            `Qiskit Runtime documentation <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`__
+            `IBM Quantum Compute (formerly Qiskit Runtime) documentation
+            <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`__
             for more information about the execution modes.
 
         options: The desired options.

--- a/qiskit_ibm_runtime/options/__init__.py
+++ b/qiskit_ibm_runtime/options/__init__.py
@@ -17,7 +17,7 @@ Primitive options (:mod:`qiskit_ibm_runtime.options`)
 
 .. currentmodule:: qiskit_ibm_runtime.options
 
-Options that can be passed to the Qiskit Runtime primitives.
+Options that can be passed to the IBM Quantum Compute (formerly Qiskit Runtime) primitives.
 
 V2 Primitives
 =============

--- a/qiskit_ibm_runtime/options/twirling_options.py
+++ b/qiskit_ibm_runtime/options/twirling_options.py
@@ -64,9 +64,9 @@ class TwirlingOptions:
     .. note::
       The ``shots`` value specified in a PUB or in the ``run()`` method is considered part of the
       primitive execution interface and therefore is always obeyed. ``default_shots``, on the other
-      hand, is considered a Qiskit Runtime specific option. Therefore, the product of
-      ``num_randomizations`` and ``shots_per_randomization`` takes precedence over
-      ``default_shots``.
+      hand, is considered a IBM Quantum Compute (formerly Qiskit Runtime) specific option.
+      Therefore, the product of ``num_randomizations`` and ``shots_per_randomization`` takes
+      precedence over ``default_shots``.
     """
 
     shots_per_randomization: UnsetType | int | Literal["auto"] = Unset
@@ -84,9 +84,9 @@ class TwirlingOptions:
     .. note::
       The ``shots`` value specified in a PUB or in the ``run()`` method is considered part of the
       primitive execution interface and therefore is always obeyed. ``default_shots``, on the other
-      hand, is considered a Qiskit Runtime specific option. Therefore, the product of
-      ``num_randomizations`` and ``shots_per_randomization`` takes precedence over
-      ``default_shots``.
+      hand, is considered a IBM Quantum Compute (formerly Qiskit Runtime) specific option.
+      Therefore, the product of ``num_randomizations`` and ``shots_per_randomization`` takes
+      precedence over ``default_shots``.
     """
 
     strategy: UnsetType | TwirlingStrategyType = Unset

--- a/qiskit_ibm_runtime/options_models/environment.py
+++ b/qiskit_ibm_runtime/options_models/environment.py
@@ -71,7 +71,7 @@ class EnvironmentOptions:
         ]
         | None
     ) = None
-    """Runtime image used for this job."""
+    """IBM Quantum Compute (formerly Qiskit Runtime) image used for this job."""
 
 
 @dataclass(config=PRIMITIVES_CONFIG)

--- a/qiskit_ibm_runtime/options_models/estimator.py
+++ b/qiskit_ibm_runtime/options_models/estimator.py
@@ -113,7 +113,7 @@ class EstimatorOptions:
         zero bias.
 
     Refer to the
-    `Configure error mitigation for Qiskit Runtime
+    `Configure error mitigation for IBM Quantum Compute (formerly Qiskit Runtime)
     <https://quantum.cloud.ibm.com/docs/guides/configure-error-mitigation>`_ guide
     for more information about the error mitigation methods used at each level.
     """

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -55,7 +55,7 @@ SERVICE_NAME = "runtime"
 
 
 class QiskitRuntimeService:
-    """Class for interacting with the Qiskit Runtime service.
+    """Class for interacting with the IBM Quantum Compute (formerly Qiskit Runtime) service.
 
     Recommended uses:
 
@@ -130,7 +130,7 @@ class QiskitRuntimeService:
             path as ``ibm_quantum_platform``, the recommended value is `ibm_quantum_platform``.
             If ``local`` is selected, the local testing mode will be used, and
             primitive queries will run on a local simulator. For more details, check the
-            `Qiskit Runtime local testing mode
+            `IBM Quantum Compute local testing mode
             <https://quantum.cloud.ibm.com/docs/guides/local-testing-mode>`_  documentation.
             For non-local modes, the channel is used to resolve the default API URL value.
             ``ibm_cloud`` was the identifier for the legacy IBM Cloud platform, and
@@ -164,7 +164,7 @@ class QiskitRuntimeService:
             authentication)
         verify: Whether to verify the server's TLS certificate.
         private_endpoint: Connect to private API URL.
-        url_resolver: Function used to resolve the runtime URL. If not
+        url_resolver: Function used to resolve the IBM Quantum Compute URL. If not
             provided, a default resolver will be used to access different service endpoints.
         region: Set a region preference for automatic instance selection.
             This argument is **ignored** if an ``instance`` is specified.
@@ -995,15 +995,15 @@ class QiskitRuntimeService:
         Args:
             program_id: Program ID.
             inputs: Program input parameters. These input values are passed
-                to the runtime program.
+                to the IBM Quantum Compute program.
             options: Runtime options that control the execution environment.
             result_decoder: A :class:`ResultDecoder` subclass used to decode job results, or a list
                 of such subclasses. If more than one decoder is specified, they will be called in
                 chain, with the output of the ``n-th`` decoder as the input of the ``n+1-th``
                 decoder. If not specified, a program-specific decoder or the default
                 ``ResultDecoder`` is used.
-            session_id: Job ID of the first job in a runtime session.
-            start_session: Set to True to explicitly start a runtime session. Defaults to False.
+            session_id: Job ID of the first job in a IBM Quantum Compute session.
+            start_session: Set to True to explicitly start a IBM Quantum Compute session.
             calibration_id: The calibration id to use for the IBM backend.
 
         Returns:
@@ -1084,13 +1084,13 @@ class QiskitRuntimeService:
         )
 
     def job(self, job_id: str) -> RuntimeJobV2:
-        """Retrieve a runtime job.
+        """Retrieve a IBM Quantum Compute job.
 
         Args:
             job_id: Job ID.
 
         Returns:
-            Runtime job retrieved.
+            IBM Quantum Compute job retrieved.
 
         Raises:
             RuntimeJobNotFound: If the job doesn't exist.
@@ -1130,7 +1130,7 @@ class QiskitRuntimeService:
         created_before: datetime | None = None,
         descending: bool = True,
     ) -> list[RuntimeJobV2]:
-        """Retrieve all runtime jobs, subject to optional filtering.
+        """Retrieve all IBM Quantum Compute jobs, subject to optional filtering.
 
         Args:
             limit: Number of jobs to retrieve. ``None`` means no limit.
@@ -1154,7 +1154,7 @@ class QiskitRuntimeService:
                 creation date (i.e. newest first) until the limit is reached.
 
         Returns:
-            A list of runtime jobs.
+            A list of IBM Quantum Compute jobs.
 
         Raises:
             IBMInputValueError: If an input value is invalid.
@@ -1210,7 +1210,7 @@ class QiskitRuntimeService:
         return [self._decode_job(job) for job in job_responses]
 
     def delete_job(self, job_id: str) -> None:
-        """Delete a runtime job.
+        """Delete a IBM Quantum Compute job.
 
         Note that this operation cannot be reversed.
 

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -123,6 +123,9 @@ class QiskitRuntimeService:
         it will fall back to the overall default account, defined when calling
         :meth:`.save_account` with ``set_as_default=True``.
 
+    Since ``qiskit-ibm-runtime`` ``0.49``, this class can also be accessed as
+    ``qiskit_ibm_runtime.IBMQuantumComputeService``.
+
     Args:
         channel: String that identifies the service platform. This is
             set to ``ibm_quantum_platform`` by default, but can additionally take ``local``

--- a/qiskit_ibm_runtime/results/runner.py
+++ b/qiskit_ibm_runtime/results/runner.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class RunnerResult(Result):
-    """Result class for Qiskit Runtime program circuit-runner."""
+    """Result class for IBM Quantum Compute (formerly Qiskit Runtime) program circuit-runner."""
 
     def get_quasiprobabilities(
         self, experiment: int | list | None = None

--- a/qiskit_ibm_runtime/runtime_job_v2.py
+++ b/qiskit_ibm_runtime/runtime_job_v2.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Qiskit runtime job."""
+"""IBM Quantum Compute job."""
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ API_TO_JOB_STATUS: dict[str, JobStatus] = {
 
 
 class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob):
-    """Representation of a runtime V2 primitive execution.
+    """Representation of a IBM Quantum Compute (formerly Qiskit Runtime) V2 primitive execution.
 
     Args:
         backend: The backend instance used to run this job.
@@ -67,9 +67,9 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
             of such subclasses. If more than one decoder is specified, they will be called in
             chain, with the output of the ``n-th`` decoder as the input of the ``n+1-th``
             decoder. If not specified, the default ``ResultDecoder`` is used.
-        image: Runtime image used for this job: image_name:tag.
-        service: Runtime service.
-        session_id: Job ID of the first job in a runtime session.
+        image: IBM Quantum Compute image used for this job: image_name:tag.
+        service: IBM Quantum Compute service.
+        session_id: Job ID of the first job in a IBM Quantum Compute session.
         tags: Tags assigned to the job.
         version: Primitive version.
         private: Marks job as private.
@@ -132,7 +132,7 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
                 * For session jobs, the default and the floor value are ``100ms``.
 
         Returns:
-            Runtime job result (post-processed if applicable).
+            IBM Quantum Compute job result (post-processed if applicable).
 
         Raises:
             RuntimeJobFailureError: If the job failed.
@@ -186,7 +186,7 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, JobStatus], BaseRuntimeJob)
         """Returns the job status from an API response.
 
         Args:
-            response: Job response from the runtime API.
+            response: Job response from the IBM Quantum Compute API.
 
         Returns:
             Job status.

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -45,13 +45,13 @@ class Sampler:
 
 
 class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
-    """Class for interacting with Qiskit Runtime Sampler primitive service.
+    """Class for interacting with IBM Quantum Compute Sampler primitive service.
 
     This class supports version 2 of the Sampler interface, which uses different
     input and output formats than version 1.
 
-    Qiskit Runtime Sampler primitive returns the sampled result according to the
-    specified output type. For example, it returns a bitstring for each shot
+    IBM Quantum Compute (formerly Qiskit Runtime) Sampler primitive returns the sampled result
+    according to the specified output type. For example, it returns a bitstring for each shot
     if measurement level 2 (bits) is requested.
 
     The :meth:`run` method can be used to submit circuits and parameters to the Sampler primitive.
@@ -64,7 +64,7 @@ class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
             * A :class:`Batch` if you are using batch execution mode.
 
             Refer to the
-            `Qiskit Runtime documentation
+            `IBM Quantum Compute documentation
             <https://quantum.cloud.ibm.com/docs/guides/execution-modes>`_
             for more information about the ``Execution modes``.
 

--- a/qiskit_ibm_runtime/sampler.py
+++ b/qiskit_ibm_runtime/sampler.py
@@ -45,12 +45,12 @@ class Sampler:
 
 
 class SamplerV2(BasePrimitiveV2[SamplerOptions], Sampler, BaseSamplerV2):
-    """Class for interacting with IBM Quantum Compute Sampler primitive service.
+    """SamplerV2 primitive for IBM Quantum Compute (formerly Qiskit Runtime).
 
     This class supports version 2 of the Sampler interface, which uses different
     input and output formats than version 1.
 
-    IBM Quantum Compute (formerly Qiskit Runtime) Sampler primitive returns the sampled result
+    IBM Quantum Compute Sampler primitive returns the sampled result
     according to the specified output type. For example, it returns a bitstring for each shot
     if measurement level 2 (bits) is requested.
 

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Qiskit Runtime flexible session."""
+"""IBM Quantum Compute flexible session."""
 
 from __future__ import annotations
 
@@ -48,13 +48,13 @@ def _active_session(func):  # type: ignore
 
 
 class Session:
-    """Class for creating a Qiskit Runtime session.
+    """Class for creating a IBM Quantum Compute session.
 
-    A Qiskit Runtime ``session`` allows you to group a collection of iterative calls to
-    the quantum computer. A session is started when the first job within the session
-    is started. Subsequent jobs within the session are prioritized by the scheduler.
+    A IBM Quantum Compute (formerly Qiskit Runtime) ``session`` allows you to group a collection of
+    iterative calls to the quantum computer. A session is started when the first job within the
+    session is started. Subsequent jobs within the session are prioritized by the scheduler.
 
-    You can open a Qiskit Runtime session using this ``Session`` class and submit jobs
+    You can open a IBM Quantum Compute session using this ``Session`` class and submit jobs
     to one or more primitives.
 
     For example::
@@ -88,7 +88,7 @@ class Session:
         backend: Instance of ``Backend`` class.
 
         max_time:
-            Maximum amount of time, a runtime session can be open before being
+            Maximum amount of time, a IBM Quantum Compute session can be open before being
             forcibly closed. Can be specified as seconds (int) or a string like "2h 30m 40s".
             This value must be less than the
             `system imposed maximum
@@ -156,7 +156,7 @@ class Session:
         Args:
             program_id: Program ID.
             inputs: Program input parameters. These input values are passed
-                to the runtime program.
+                to the IBM Quantum Compute program.
             options: Runtime options that control the execution environment.
             result_decoder: A :class:`ResultDecoder` subclass used to decode job results, or a list
                 of such subclasses. If more than one decoder is specified, they will be called in

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -48,9 +48,9 @@ def _active_session(func):  # type: ignore
 
 
 class Session:
-    """Class for creating a IBM Quantum Compute session.
+    """Class for creating a IBM Quantum Compute (formerly Qiskit Runtime) session.
 
-    A IBM Quantum Compute (formerly Qiskit Runtime) ``session`` allows you to group a collection of
+    A IBM Quantum Compute ``session`` allows you to group a collection of
     iterative calls to the quantum computer. A session is started when the first job within the
     session is started. Subsequent jobs within the session are prioritized by the scheduler.
 

--- a/qiskit_ibm_runtime/utils/json.py
+++ b/qiskit_ibm_runtime/utils/json.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Utility functions for the runtime service."""
+"""Utility functions for the IBM Quantum Compute service."""
 
 import warnings
 

--- a/release-notes/unreleased/3070.upgrade.rst
+++ b/release-notes/unreleased/3070.upgrade.rst
@@ -1,0 +1,3 @@
+The Qiskit Runtime service has been renamed to IBM Quantum Compute, and the references to it in
+the documentation has been updated. The :class:`~.QiskitRuntimeService` class is now available
+as ``IBMQuantumComputeService``.

--- a/release-notes/unreleased/3070.upgrade.rst
+++ b/release-notes/unreleased/3070.upgrade.rst
@@ -1,3 +1,3 @@
-The Qiskit Runtime service has been renamed to IBM Quantum Compute, and the references to it in
-the documentation has been updated. The :class:`~.QiskitRuntimeService` class is now available
-as ``IBMQuantumComputeService``.
+The Qiskit Runtime service has been renamed to IBM Quantum Compute service, and the references to
+it in the documentation have been updated. The :class:`~.QiskitRuntimeService` class is now
+available as ``IBMQuantumComputeService``.

--- a/tools/concat_release_notes.py
+++ b/tools/concat_release_notes.py
@@ -42,7 +42,7 @@ def generate_header(output_file: Path) -> None:
     """Write the release note headers to a file."""
     output_file.write_text(
         "=======================================\n\
-Qiskit Runtime IBM Client release notes\n\
+IBM Quantum Compute (formerly Qiskit Runtime) Client release notes\n\
 =======================================\n\
 \n\
 .. towncrier release notes start\n",

--- a/tools/concat_release_notes.py
+++ b/tools/concat_release_notes.py
@@ -41,9 +41,9 @@ def sort_release_notes_paths(release_notes_paths: Path) -> list[Path]:
 def generate_header(output_file: Path) -> None:
     """Write the release note headers to a file."""
     output_file.write_text(
-        "=======================================\n\
+        "==================================================================\n\
 IBM Quantum Compute (formerly Qiskit Runtime) Client release notes\n\
-=======================================\n\
+==================================================================\n\
 \n\
 .. towncrier release notes start\n",
         "utf-8",

--- a/tools/generate_fake_backend_files.py
+++ b/tools/generate_fake_backend_files.py
@@ -12,8 +12,8 @@
 # that they have been altered from the originals.
 """Fetch backend snapshots and generate fake backend package files.
 
-This script connects to IBM Quantum Runtime, fetches the latest configuration and
-properties for one or more backends, and writes the following files under:
+This script connects to IBM Quantum Compute (formerly Qiskit Runtime), fetches the latest
+configuration and properties for one or more backends, and writes the following files under:
 
 ``qiskit_ibm_runtime/fake_provider/backends/<backend_city>/``
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adjust to the renaming of Qiskit Runtime (the service) to IBM Quantum Compute:
* Update documentation
* Re-export `QiskitRuntimeService` as `IBMQuantumComputeService`

### Details and comments

Fixes #3052

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
