### PR TITLE
`aer_executor` minimal version fix - using `get_qubit_sparse_pauli_list_copy`

### DIFF
--- a/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/aer_executor/insert_noise_pass.py
@@ -132,7 +132,7 @@ class InsertNoisePass(TransformationPass):
             return None
 
         pauli_lindblad_error = PauliLindbladError(
-            generators=pauli_lindblad_map.generators().to_pauli_list(),
+            generators=pauli_lindblad_map.get_qubit_sparse_pauli_list_copy().to_pauli_list(),
             rates=self._noise_scale * pauli_lindblad_map.rates,
         )
 


### PR DESCRIPTION
### Summary
Minimal version tests are failing with a `'qiskit.quantum_info.PauliLindbladMap' object has no attribute 'generators'` error. This comes from the fact that `generators` is a convenience introduced in `qiskit >2.4.0` for `get_qubit_sparse_pauli_list_copy`. 

### Details and comments

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
