### PR TITLE
Move tests for ``compute_samplex_arguments`` to the appropriate test file

### DIFF
--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -18,12 +18,11 @@ import numpy as np
 from ddt import data, ddt, unpack
 from qiskit import QuantumCircuit
 from qiskit.circuit import ClassicalRegister, Parameter
-from qiskit.primitives.containers.estimator_pub import EstimatorPub, ObservablesArray
+from qiskit.primitives.containers import EstimatorPub, ObservablesArray
 from qiskit.quantum_info import SparsePauliOp
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.prepare import prepare
-from qiskit_ibm_runtime.executor_estimator.utils import compute_samplex_arguments
 from qiskit_ibm_runtime.options_models.measure_noise_learning import MeasureNoiseLearningOptions
 from qiskit_ibm_runtime.options_models.twirling import TwirlingOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
@@ -454,94 +453,3 @@ class TestPrepareFunction(IBMTestCase):
             (48,),
             "Expected TREX item shape (48,) for num_randomizations=48",
         )
-
-
-@ddt
-class TestComputeSamplexArguments(IBMTestCase):
-    """Tests for ``compute_samplex_arguments``."""
-
-    @data([(2, 2), (2, 2)], [(2, 2, 1), (2, 2)], [(2, 2), (2, 2, 1)], [(), (2, 2, 1)])
-    @unpack
-    def test_shapes_returned_arrays(self, param_shape, obs_shape):
-        """Test the shapes of the returned params and change basis arrays."""
-        circuit = QuantumCircuit(3)
-        if param_shape:
-            for idx in range(7):
-                circuit.rz(Parameter(f"th_{idx}"), 0)
-        circuit.cx(0, 1)
-        circuit.measure_all()
-
-        pub_like = (
-            circuit,
-            ObservablesArray(["ZZZ", "XXX", "YYY", "IYI"]).reshape(obs_shape),
-            np.random.random(param_shape + (circuit.num_parameters,)),
-        )
-        pub = EstimatorPub.coerce(pub_like)
-
-        flat_parameter_values, change_basis, param_basis_pairs = compute_samplex_arguments(pub)
-        num_basis = len(param_basis_pairs)
-
-        self.assertEqual(flat_parameter_values.ndim, 2)
-        self.assertEqual(flat_parameter_values.shape, (num_basis, pub.circuit.num_parameters))
-
-        self.assertEqual(change_basis.ndim, 2)
-        self.assertEqual(change_basis.shape, (num_basis, pub.circuit.num_qubits))
-
-    @data(
-        [
-            (2, 2),
-            (2, 2),
-            [
-                ((0, 0), "ZZZ"),
-                ((0, 1), "XXX"),
-                ((1, 0), "YYY"),
-                ((1, 1), "IYI"),
-            ],
-        ],
-        [
-            (2, 2),
-            (2, 2, 1),
-            [
-                ((0, 0), "ZZZ"),
-                ((0, 0), "YYY"),
-                ((0, 1), "ZZZ"),
-                ((0, 1), "YYY"),
-                ((1, 0), "XXX"),
-                ((1, 0), "IYI"),
-                ((1, 1), "XXX"),
-                ((1, 1), "IYI"),
-            ],
-        ],
-        [
-            (2, 2, 1),
-            (2, 2),
-            [
-                ((0, 0, 0), "ZZZ"),
-                ((0, 0, 0), "XXX"),
-                ((0, 1, 0), "YYY"),
-                ((1, 0, 0), "ZZZ"),
-                ((1, 0, 0), "XXX"),
-                ((1, 1, 0), "YYY"),
-            ],
-        ],
-        [(), (2, 2), [((), "ZZZ"), ((), "XXX"), ((), "YYY")]],
-    )
-    @unpack
-    def test_param_basis_pairs(self, param_shape, obs_shape, expected_pairs):
-        """Test the shapes of the returned ``param_basis_pairs`` list."""
-        circuit = QuantumCircuit(3)
-        if param_shape:
-            for idx in range(7):
-                circuit.rz(Parameter(f"th_{idx}"), 0)
-        circuit.cx(0, 1)
-        circuit.measure_all()
-
-        pub_like = (
-            circuit,
-            ObservablesArray(["ZZZ", "XXX", "YYY", "IYI"]).reshape(obs_shape),
-            np.random.random(param_shape + (circuit.num_parameters,)),
-        )
-        pub = EstimatorPub.coerce(pub_like)
-
-        _, _, param_basis_pairs = compute_samplex_arguments(pub)
-        self.assertListEqual(param_basis_pairs, expected_pairs, msg=param_basis_pairs)

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -13,10 +13,10 @@
 """Unit tests for EstimatorV2 helper functions."""
 
 import numpy as np
-from ddt import data, ddt
+from ddt import data, ddt, unpack
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Parameter
-from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers import EstimatorPub, ObservablesArray
 from qiskit.quantum_info import Pauli, SparsePauliOp
 from samplomatic import Tag
 from samplomatic.transpiler import generate_boxing_pass_manager
@@ -34,6 +34,7 @@ from qiskit_ibm_runtime.executor_estimator.utils import (
 from ...ibm_test_case import IBMTestCase
 
 
+@ddt
 class TestComputeSamplexArguments(IBMTestCase):
     """Tests for compute_samplex_arguments function."""
 
@@ -61,6 +62,92 @@ class TestComputeSamplexArguments(IBMTestCase):
         # A single observable term "Z" -> one measurement basis -> one flattened
         # row, ordered by circuit.parameters (a, b), not by the dict key order (b, a).
         np.testing.assert_array_equal(flat_parameter_values, [[0.1, 0.7]])
+
+    @data([(2, 2), (2, 2)], [(2, 2, 1), (2, 2)], [(2, 2), (2, 2, 1)], [(), (2, 2, 1)])
+    @unpack
+    def test_shapes_returned_arrays(self, param_shape, obs_shape):
+        """Test the shapes of the returned params and change basis arrays."""
+        circuit = QuantumCircuit(3)
+        if param_shape:
+            for idx in range(7):
+                circuit.rz(Parameter(f"th_{idx}"), 0)
+        circuit.cx(0, 1)
+        circuit.measure_all()
+
+        pub_like = (
+            circuit,
+            ObservablesArray(["ZZZ", "XXX", "YYY", "IYI"]).reshape(obs_shape),
+            np.random.random(param_shape + (circuit.num_parameters,)),
+        )
+        pub = EstimatorPub.coerce(pub_like)
+
+        flat_parameter_values, change_basis, param_basis_pairs = compute_samplex_arguments(pub)
+        num_basis = len(param_basis_pairs)
+
+        self.assertEqual(flat_parameter_values.ndim, 2)
+        self.assertEqual(flat_parameter_values.shape, (num_basis, pub.circuit.num_parameters))
+
+        self.assertEqual(change_basis.ndim, 2)
+        self.assertEqual(change_basis.shape, (num_basis, pub.circuit.num_qubits))
+
+    @data(
+        [
+            (2, 2),
+            (2, 2),
+            [
+                ((0, 0), "ZZZ"),
+                ((0, 1), "XXX"),
+                ((1, 0), "YYY"),
+                ((1, 1), "IYI"),
+            ],
+        ],
+        [
+            (2, 2),
+            (2, 2, 1),
+            [
+                ((0, 0), "ZZZ"),
+                ((0, 0), "YYY"),
+                ((0, 1), "ZZZ"),
+                ((0, 1), "YYY"),
+                ((1, 0), "XXX"),
+                ((1, 0), "IYI"),
+                ((1, 1), "XXX"),
+                ((1, 1), "IYI"),
+            ],
+        ],
+        [
+            (2, 2, 1),
+            (2, 2),
+            [
+                ((0, 0, 0), "ZZZ"),
+                ((0, 0, 0), "XXX"),
+                ((0, 1, 0), "YYY"),
+                ((1, 0, 0), "ZZZ"),
+                ((1, 0, 0), "XXX"),
+                ((1, 1, 0), "YYY"),
+            ],
+        ],
+        [(), (2, 2), [((), "ZZZ"), ((), "XXX"), ((), "YYY")]],
+    )
+    @unpack
+    def test_param_basis_pairs(self, param_shape, obs_shape, expected_pairs):
+        """Test the shapes of the returned ``param_basis_pairs`` list."""
+        circuit = QuantumCircuit(3)
+        if param_shape:
+            for idx in range(7):
+                circuit.rz(Parameter(f"th_{idx}"), 0)
+        circuit.cx(0, 1)
+        circuit.measure_all()
+
+        pub_like = (
+            circuit,
+            ObservablesArray(["ZZZ", "XXX", "YYY", "IYI"]).reshape(obs_shape),
+            np.random.random(param_shape + (circuit.num_parameters,)),
+        )
+        pub = EstimatorPub.coerce(pub_like)
+
+        _, _, param_basis_pairs = compute_samplex_arguments(pub)
+        self.assertListEqual(param_basis_pairs, expected_pairs, msg=param_basis_pairs)
 
 
 class TestGetPauliBasis(IBMTestCase):


### PR DESCRIPTION
### Summary
This PR moves tests for `compute_samplex_arguments` from the file for testing the prepare function of estimator to the file for testing util functions for estimator, placing them in an existing `TestComputeSamplexArguments` class

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
