### PR TITLE
Change ObservablesArray import for Qiskit 2.3 compatibility

### DIFF
--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -18,8 +18,7 @@ import numpy as np
 from ddt import data, ddt, unpack
 from qiskit import QuantumCircuit
 from qiskit.circuit import ClassicalRegister, Parameter
-from qiskit.primitives.containers import ObservablesArray
-from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers.estimator_pub import EstimatorPub, ObservablesArray
 from qiskit.quantum_info import SparsePauliOp
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -16,8 +16,7 @@ import numpy as np
 from ddt import data, ddt, unpack
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Parameter
-from qiskit.primitives.containers import ObservablesArray
-from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers.estimator_pub import EstimatorPub, ObservablesArray
 from qiskit.quantum_info import Pauli, SparsePauliOp
 from samplomatic import Tag
 from samplomatic.transpiler import generate_boxing_pass_manager


### PR DESCRIPTION
### Summary

Fix a couple of imports that needed https://github.com/Qiskit/qiskit/pull/14348 to be in place, which landed after Qiskit 2.3. In Qiskit 2.3, `ObservablesArray` is not a direct member of `qiskit.primitives.containers`.

### Details and comments

Related to #3081

This prevents the minimal version tests to pass.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
