### PR TITLE
Fix wrapper estimator docs and imports

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/__init__.py
+++ b/qiskit_ibm_runtime/executor_estimator/__init__.py
@@ -11,3 +11,5 @@
 # that they have been altered from the originals.
 
 """Executor-based EstimatorV2"""
+
+from .estimator import EstimatorV2

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -124,7 +124,7 @@ class EstimatorV2(BaseEstimatorV2):
 
         options: Estimator options.
             See
-            :class:`~qiskit_ibm_runtime.options_models.estimator_options.EstimatorOptions`
+            :class:`~qiskit_ibm_runtime.options_models.estimator.EstimatorOptions`
             for all available options.
     """
 

--- a/qiskit_ibm_runtime/options_models/estimator.py
+++ b/qiskit_ibm_runtime/options_models/estimator.py
@@ -57,10 +57,7 @@ class EstimatorOptions(BaseOptionsModel):
     """Execution options."""
 
     twirling: TwirlingOptions = TwirlingOptions()
-    """Twirling options.
-
-    Currently only ``enable_measure=False`` is supported.
-    """
+    """Twirling options."""
 
     dynamical_decoupling: DynamicalDecouplingOptions = DynamicalDecouplingOptions()
     """Dynamical decoupling options."""


### PR DESCRIPTION
### Summary
Small docs fixes and adjusts import so that it can be reached with `from qiskit_ibm_runtime.executor_estimator import EstimatorV2` instead of the previous `from qiskit_ibm_runtime.executor_estimator.estimator import EstimatorV2`. This is consistent with the docs and the wrapper sampler.
### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude
