### PR TITLE
Run lowest versions test only in main repo

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Run benchmarks
         run: make benchmark
   unit-tests-lowest-versions:
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'Qiskit'
     name: Run unit tests with lowest versions - python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
### Summary

While looking at the minimal version tests in the recent issue, noticed that they are being run in the forks - which can cause a number of daily notifications for developers in their forks, as well as consume some actions time unnecessarily. This updates the job in the workflow so it is only run for the main fork, same as the others jobs in that workflow.

### Details and comments

Related to #3081

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.

