### PR TITLE
Pop measurement flips before applying them in the wrapper estimator post processing

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -211,7 +211,7 @@ def _process_expectation_values(
 
     # Apply measurement flips if present
     if "measurement_flips._meas" in item_result:
-        data ^= item_result["measurement_flips._meas"]
+        data ^= item_result.pop("measurement_flips._meas")
 
     # Build efficient lookup: param_ndindex -> list of (measurement_basis, config_idx)
     # This allows us to find all available measurement bases for a given parameter
@@ -336,7 +336,7 @@ def _process_expectation_values_pec(
 
     # Apply measurement flips if present
     if "measurement_flips._meas" in item_result:
-        data ^= item_result["measurement_flips._meas"]
+        data ^= item_result.pop("measurement_flips._meas")
 
     # extract pec signs if present
     pec_signs = item_result.get("pauli_signs", None)
@@ -591,7 +591,7 @@ def _process_expectation_values_pea(
 
     # Apply measurement flips if present
     if "measurement_flips._meas" in item_result:
-        data ^= item_result["measurement_flips._meas"]
+        data ^= item_result.pop("measurement_flips._meas")
 
     if isinstance(extrapolated_noise_factors, (float, int)):
         extrapolated_noise_factors = [extrapolated_noise_factors]


### PR DESCRIPTION
### Summary
Applying the measurement flips during wrapper estimator post processing mutates the data but keeps the measurement flips. This is a little unsafe, and also memory inefficient. This PRs mimics the pattern used in the wrapper sampler where measurement flips are popped.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.