### PR TITLE
Fix documentation typos in resilience and ZNE options

### DIFF
--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -32,7 +32,7 @@ class ResilienceOptions(BaseOptionsModel):
     """Whether to enable measurement error mitigation method.
 
     If you enable measurement mitigation, you can fine-tune its noise learning by using
-    :attr:`~measure_noise_learning`. See :class:`.~MeasureNoiseLearningOptions` for all measurement
+    :attr:`~measure_noise_learning`. See :class:`~.MeasureNoiseLearningOptions` for all measurement
     mitigation noise learning options.
 
     If ``measure_mitigation`` is ``None``, it is determined by the according to the resilience
@@ -61,9 +61,9 @@ class ResilienceOptions(BaseOptionsModel):
     If you enable ZNE, you can fine-tune its options by using :attr:`~zne`. See
     :class:`~.ZneOptions` for additional ZNE related options.
 
-    If ``zne_mitigation`` is ``None``, it is determined by the server according to the resilience
-    level: it is ``False`` for resilience levels ``0`` and ``1``, and ``True`` for resilience level
-    ``2``.
+    If ``zne_mitigation`` is left as ``None``, it inherits the default for the configured
+    :attr:`~.EstimatorOptions.resilience_level`: ``False`` for resilience levels ``0`` and ``1``,
+    and ``True`` for resilience level ``2``.
     """
 
     zne: ZneOptions = ZneOptions()

--- a/qiskit_ibm_runtime/options_models/zne.py
+++ b/qiskit_ibm_runtime/options_models/zne.py
@@ -59,8 +59,8 @@ class ZneOptions(BaseOptionsModel):
         1. ``pub_result.data.evs_extrapolated`` and ``pub_result.data.stds_extrapolated``,
             both with shape ``(*shape, num_extrapolators, num_evaluation_points)``, where
             ``num_extrapolators`` is the length of the list of
-            ``options.resilience.zne.extrapolators``, and ``num_evaluation_points`` is the length of
-            the list ``options.resilience.extrapolated_noise_factors``. These values provide
+            ``options.resilience.zne.extrapolator``, and ``num_evaluation_points`` is the length of
+            the list ``options.resilience.zne.extrapolated_noise_factors``. These values provide
             evaluations of every extrapolator at every specified noise extrapolation value.
         2. ``pub_result.data.evs_noise_factors``, ``pub_result.data.stds_noise_factors``, and
            ``ensemble_stds_noise_factors`` all have shape ``(*shape, num_noise_factors)`` where
@@ -117,8 +117,8 @@ class ZneOptions(BaseOptionsModel):
     """ noise_factors: Noise factors to use for noise amplification.
 
     The default depends on the amplifier method - the default for pea is
-    :class:.~PEA_DEFAULT_NOISE_FACTORS` and the default for the other methods
-    is :class:.~ZNE_DEFAULT_NOISE_FACTORS`.
+    :data:`~.PEA_DEFAULT_NOISE_FACTORS` and the default for the other methods
+    is :data:`~.ZNE_DEFAULT_NOISE_FACTORS`.
     """
 
     extrapolator: ExtrapolatorType | Sequence[ExtrapolatorType] = ("exponential", "linear")


### PR DESCRIPTION
### Summary
Used AI tool to find some doc issues with resilience options classes.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Code
