### PR TITLE
Rename `SimulatorOptions` to `LegacySimulatorOptions`

### DIFF
--- a/qiskit_ibm_runtime/options/__init__.py
+++ b/qiskit_ibm_runtime/options/__init__.py
@@ -81,7 +81,7 @@ Suboptions
    ExecutionOptionsV2
    SamplerExecutionOptionsV2
    EnvironmentOptions
-   SimulatorOptions
+   LegacySimulatorOptions
 
 """
 
@@ -97,6 +97,6 @@ from .pec_options import PecOptions
 from .resilience_options import ResilienceOptionsV2
 from .sampler_execution_options import SamplerExecutionOptionsV2
 from .sampler_options import SamplerOptions
-from .simulator_options import SimulatorOptions
+from .simulator_options import LegacySimulatorOptions
 from .twirling_options import TwirlingOptions
 from .zne_options import ZneOptions

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -23,7 +23,7 @@ from qiskit.transpiler import CouplingMap
 
 from ..runtime_options import RuntimeOptions
 from .environment_options import EnvironmentOptions
-from .simulator_options import SimulatorOptions
+from .simulator_options import LegacySimulatorOptions
 from .utils import (
     Dict,
     Unset,
@@ -134,7 +134,7 @@ class OptionsV2(BaseOptions):
             :class:`EnvironmentOptions` for all available options.
 
         simulator: Simulator options. See
-            :class:`SimulatorOptions` for all available options.
+            :class:`LegacySimulatorOptions` for all available options.
     """
 
     _VERSION: int = Field(2, frozen=True)
@@ -142,7 +142,7 @@ class OptionsV2(BaseOptions):
     # Options not really related to primitives.
     max_execution_time: UnsetType | int = Unset
     environment: EnvironmentOptions | Dict = Field(default_factory=EnvironmentOptions)
-    simulator: SimulatorOptions | Dict = Field(default_factory=SimulatorOptions)
+    simulator: LegacySimulatorOptions | Dict = Field(default_factory=LegacySimulatorOptions)
 
     def update(self, **kwargs: Any) -> None:
         """Update the options."""

--- a/qiskit_ibm_runtime/options/simulator_options.py
+++ b/qiskit_ibm_runtime/options/simulator_options.py
@@ -28,7 +28,7 @@ class NoiseModel:
 
 
 @primitive_dataclass
-class SimulatorOptions:
+class LegacySimulatorOptions:
     """Simulator options.
 
     For best practice in simulating a backend make sure to pass the

--- a/qiskit_ibm_runtime/options_models/estimator.py
+++ b/qiskit_ibm_runtime/options_models/estimator.py
@@ -21,7 +21,7 @@ from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
 from .resilience import ResilienceOptions
-from .simulator import SimulatorOptions
+from .simulator import LegacySimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -62,7 +62,7 @@ class EstimatorOptions(BaseOptionsModel):
     dynamical_decoupling: DynamicalDecouplingOptions = DynamicalDecouplingOptions()
     """Dynamical decoupling options."""
 
-    simulator: SimulatorOptions = SimulatorOptions()
+    simulator: LegacySimulatorOptions = LegacySimulatorOptions()
     """Simulator options."""
 
     experimental: dict = {}

--- a/qiskit_ibm_runtime/options_models/sampler.py
+++ b/qiskit_ibm_runtime/options_models/sampler.py
@@ -18,7 +18,7 @@ from .base import BaseOptionsModel
 from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import SamplerEnvironmentOptions
 from .execution import SamplerExecutionOptions
-from .simulator import SimulatorOptions
+from .simulator import LegacySimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -37,7 +37,7 @@ class SamplerOptions(BaseOptionsModel):
     twirling: TwirlingOptions = TwirlingOptions()
     """Pauli twirling options."""
 
-    simulator: SimulatorOptions = SimulatorOptions()
+    simulator: LegacySimulatorOptions = LegacySimulatorOptions()
     """Simulator options."""
 
     experimental: dict = {}

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -34,7 +34,7 @@ else:
     noise_model_type: TypeAlias = dict | None  # type: ignore[no-redef, misc]
 
 
-class SimulatorOptions(BaseOptionsModel):
+class LegacySimulatorOptions(BaseOptionsModel):
     """Simulator options.
 
     Used to control local mode simulation.

--- a/test/unit/options_models/test_sampler.py
+++ b/test/unit/options_models/test_sampler.py
@@ -19,14 +19,14 @@ from pydantic import ValidationError
 from qiskit.transpiler import CouplingMap
 
 from qiskit_ibm_runtime.options_models.sampler import SamplerOptions
-from qiskit_ibm_runtime.options_models.simulator import SimulatorOptions
+from qiskit_ibm_runtime.options_models.simulator import LegacySimulatorOptions
 
 from ...ibm_test_case import IBMTestCase
 
 
 @ddt
-class TestSimulatorOptions(IBMTestCase):
-    """Tests for SimulatorOptions in SamplerOptions."""
+class TestLegacySimulatorOptions(IBMTestCase):
+    """Tests for LegacySimulatorOptions in SamplerOptions."""
 
     def test_simulator_options_default(self):
         """Test that simulator options have correct defaults."""
@@ -49,15 +49,15 @@ class TestSimulatorOptions(IBMTestCase):
     def test_coupling_map_invalid_type_raises(self, input):
         """Non-list, non-CouplingMap, non-None value should raise ValidationError."""
         with self.assertRaises(ValidationError):
-            SimulatorOptions(coupling_map=input)
+            LegacySimulatorOptions(coupling_map=input)
 
     def test_noise_model_invalid_type_no_aer_raises(self):
         """Passing a non-dict noise_model raises when Aer is not installed."""
         with patch("qiskit_ibm_runtime.options_models.simulator.optionals.HAS_AER", False):
             with self.assertRaises(ValidationError):
-                SimulatorOptions(noise_model=object())
+                LegacySimulatorOptions(noise_model=object())
 
     def test_noise_model_invalid_type_with_aer_raises(self):
         """A non-dict, non-AerNoiseModel value raises ValidationError."""
         with self.assertRaises(ValidationError):
-            SimulatorOptions(noise_model=12345)
+            LegacySimulatorOptions(noise_model=12345)


### PR DESCRIPTION
### Summary
Renaming `SimulatorOptions` to `LegacySimulatorOptions` in preparation for the new `SimulatorOptions` in `sim_executor`

### Details and comments

Closes #3137 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
