### PR TITLE
Adding `SimulatorOptions` to `ExecutorOptions`

### DIFF
--- a/qiskit_ibm_runtime/options_models/executor.py
+++ b/qiskit_ibm_runtime/options_models/executor.py
@@ -33,4 +33,8 @@ class ExecutorOptions(BaseOptionsModel):
     """Experimental options that are passed to the executor."""
 
     simulator: SimulatorOptions = SimulatorOptions()
-    """Local mode simulator options."""
+    """Simulator options.
+    
+    These options are used when an executor is initialized with a backend that is a simulator,
+    and they are ignored otherwise.
+    """

--- a/qiskit_ibm_runtime/options_models/executor.py
+++ b/qiskit_ibm_runtime/options_models/executor.py
@@ -34,7 +34,7 @@ class ExecutorOptions(BaseOptionsModel):
 
     simulator: SimulatorOptions = SimulatorOptions()
     """Simulator options.
-    
+
     These options are used when an executor is initialized with a backend that is a simulator,
     and they are ignored otherwise.
     """

--- a/qiskit_ibm_runtime/options_models/executor.py
+++ b/qiskit_ibm_runtime/options_models/executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from .base import BaseOptionsModel
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
+from .simulator import SimulatorOptions
 
 
 class ExecutorOptions(BaseOptionsModel):
@@ -30,3 +31,6 @@ class ExecutorOptions(BaseOptionsModel):
 
     experimental: dict = {}
     """Experimental options that are passed to the executor."""
+
+    simulator: SimulatorOptions = SimulatorOptions()
+    """Local mode simulator options."""

--- a/test/unit/executor/test_executor.py
+++ b/test/unit/executor/test_executor.py
@@ -21,6 +21,7 @@ from qiskit_ibm_runtime.executor import Executor
 from qiskit_ibm_runtime.options_models.environment import EnvironmentOptions
 from qiskit_ibm_runtime.options_models.execution import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor import ExecutorOptions
+from qiskit_ibm_runtime.options_models.simulator import SimulatorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 
 from ...ibm_test_case import IBMTestCase
@@ -35,6 +36,7 @@ class TestExecutorOptions(IBMTestCase):
         executor = Executor(mode=get_mocked_backend())
         self.assertIsInstance(executor.options, ExecutorOptions)
         self.assertEqual(executor.options, ExecutorOptions())
+        self.assertEqual(executor.options.simulator, SimulatorOptions())
 
     def test_options_from_instance(self):
         """Test constructing with an ExecutorOptions instance."""


### PR DESCRIPTION
### Summary
Adding `SimulatorOptions` to `ExecutorOptions` as a `simulator` attribute

### Details and comments

Closes #3110 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
