### PR TITLE
Fix conflict around mypy when installing with `[dev]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,12 +254,12 @@ performance = [
 # Developer extras.
 
 style = [
-    "mypy==1.19.0",
+    "mypy==2.3.0",
     "pre-commit>=4",
 ]
 
 style_local = [
-    "mypy==1.19.0",
+    "mypy==2.3.0",
     "ruff~=0.14.10",
 ]
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#3120 introduced new `mypy` version, but we need to use consistent versions in `dev` optional dependencies to avoid conflict.

to reproduce the issue:
```
uv run --extra dev pytest test/integration/test_executor_estimator.py -s 
-v
  × No solution found when resolving dependencies for split (markers:
  │ python_full_version >= '3.14'):
  ╰─▶ Because qiskit-ibm-runtime[dev] depends on mypy==1.19.0
      and qiskit-ibm-runtime[common] depends on mypy==2.3.0,
      we can conclude that qiskit-ibm-runtime[common] and
      qiskit-ibm-runtime[dev] are incompatible.
      And because your project requires qiskit-ibm-runtime[common]
      and qiskit-ibm-runtime[dev], we can conclude that your project's
      requirements are unsatisfiable.
```

### Details and comments

Fixes #

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
