### PR TITLE
Use mirror circuit for Estimator through Executor Integration test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,12 +254,12 @@ performance = [
 # Developer extras.
 
 style = [
-    "mypy==1.19.0",
+    "mypy==2.3.0",
     "pre-commit>=4",
 ]
 
 style_local = [
-    "mypy==1.19.0",
+    "mypy==2.3.0",
     "ruff~=0.14.10",
 ]
 

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -27,7 +27,8 @@ if TYPE_CHECKING:
     from qiskit.transpiler import StagedPassManager
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
-from qiskit_ibm_runtime import EstimatorV2 as EstimatorV2ThroughExecutor
+from qiskit_ibm_runtime import EstimatorV2
+from test.utils import make_mirror_circuit_with_phases
 
 from ..ibm_test_case import IBMIntegrationTestCase
 
@@ -45,7 +46,7 @@ def create_bell_isa_circuit_with_single_rz_on_q0(
 
 
 @ddt
-class TestEstimatorThroughExecutor(IBMIntegrationTestCase):
+class TestEstimator(IBMIntegrationTestCase):
     """An integration test, testing EstimatorV2 implemented through Executor."""
 
     estimator_variant: type[BaseEstimatorV2] | None = None
@@ -55,7 +56,9 @@ class TestEstimatorThroughExecutor(IBMIntegrationTestCase):
         super().setUp()
         self.backend = self.service.backend(self.dependencies.qpu)
 
-        self.pm = generate_preset_pass_manager(optimization_level=1, target=self.backend.target)
+        self.preset_pass_manager = generate_preset_pass_manager(
+            optimization_level=1, target=self.backend.target
+        )
 
     def test_estimator_works_for_basic_circuit_with_no_options(self):
         """Runs a simple parametric circuit with multiple observables to make sure the basics work.
@@ -64,26 +67,33 @@ class TestEstimatorThroughExecutor(IBMIntegrationTestCase):
         - Job completes without exceptions
         - Correct expectation value shapes
         """
-        isa_circuit = create_bell_isa_circuit_with_single_rz_on_q0(self.pm)
+        circuit = make_mirror_circuit_with_phases(self.backend)
+        isa_circuit = self.preset_pass_manager.run(circuit)
 
         zz_with_offset = SparsePauliOp.from_list([("ZZ", 1.0), ("II", 9.0)]).apply_layout(
             isa_circuit.layout
         )
-        # q0_phase = 0 -> 10.0 q0_phase = pi -> 10
 
         xx_with_offset = SparsePauliOp.from_list([("XX", 1.0), ("II", 3.0)]).apply_layout(
             isa_circuit.layout
         )
-        # q0_phase = 0 -> 4.0 q0_phase = pi -> 2.0
 
-        estimator = EstimatorV2ThroughExecutor(self.backend)
+        estimator = EstimatorV2(self.backend)
 
         job = estimator.run(
             pubs=[
                 # Map all parameter sets to all observables
-                (isa_circuit, [[zz_with_offset], [xx_with_offset]], [[0], [np.pi]]),
+                (
+                    isa_circuit,
+                    [[zz_with_offset], [xx_with_offset]],
+                    [[0, np.pi / 4], [np.pi, 5 * np.pi / 4]],
+                ),
                 # Map each parameter set to one observable:
-                (isa_circuit, [zz_with_offset, xx_with_offset], [[0], [np.pi]]),
+                (
+                    isa_circuit,
+                    [zz_with_offset, xx_with_offset],
+                    [[0, np.pi / 4], [np.pi, 5 * np.pi / 4]],
+                ),
             ]
         )
 

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -14,35 +14,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 from ddt import ddt
-from qiskit import QuantumCircuit
-from qiskit.circuit import Parameter
 from qiskit.primitives.base import BaseEstimatorV2  # noqa: TC002
 from qiskit.quantum_info import SparsePauliOp
-
-if TYPE_CHECKING:
-    from qiskit.transpiler import StagedPassManager
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from qiskit_ibm_runtime import EstimatorV2
 from test.utils import make_mirror_circuit_with_phases
 
 from ..ibm_test_case import IBMIntegrationTestCase
-
-
-def create_bell_isa_circuit_with_single_rz_on_q0(
-    preset_pass_manager: StagedPassManager,
-) -> QuantumCircuit:
-    """Create a Bell circuit with a single RZ parameter on q0, transpiled to ISA."""
-    circuit = QuantumCircuit(2, name="Bell with single parameter")
-    circuit.h(0)
-    circuit.cx(0, 1)
-    circuit.rz(Parameter("q0_phase"), 0)
-
-    return preset_pass_manager.run(circuit)
 
 
 @ddt


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We decided to try to use the same example circuit "mirror circuit" for all tests if possible.
This PR changes the custom bell circuit in estimator through executor integration test to use the mirror circuit.

Also I change the import alias / naming to only `EstimatorV2` instead of `EstimatorV2ThroughExecutor`

### Details and comments

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
