### PR TITLE
`SimExecutor`: support `BackendV2` from `AerSimulator`

### DIFF
--- a/qiskit_ibm_runtime/sim_executor/run_quantum_program.py
+++ b/qiskit_ibm_runtime/sim_executor/run_quantum_program.py
@@ -22,6 +22,7 @@ from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 from qiskit.transpiler import PassManager
 from qiskit.utils.optionals import HAS_AER
+from qiskit_aer import AerSimulator
 
 from ..quantum_program import CircuitItem, SamplexItem
 from ..results import QuantumProgramResult
@@ -29,8 +30,8 @@ from .broadcast_sample import broadcast_sample
 from .insert_noise_pass import InsertNoisePass
 
 if TYPE_CHECKING:
+    from qiskit.providers import BackendV2
     from qiskit.quantum_info import PauliLindbladMap
-    from qiskit_aer import AerSimulator
 
     from ..quantum_program import QuantumProgram
 
@@ -49,7 +50,7 @@ def _round_to_clifford(values: np.ndarray, decimals: int) -> np.ndarray:
 
 @HAS_AER.require_in_call
 def run_quantum_program(
-    qasm_simulator: AerSimulator,
+    backend: BackendV2,
     program: QuantumProgram,
     noise_dict: dict[str, PauliLindbladMap] | None = None,
     angle_decimals: int = 5,
@@ -58,7 +59,7 @@ def run_quantum_program(
     """Run a quantum program on a simulator.
 
     Args:
-        qasm_simulator: The simulator to use.
+        backend: The backend to simulate.
         program: The program to run.
         noise_dict: A map from barrier label refs to noise maps.
         angle_decimals: Gate angles are rounded to the nearest multiple of π/2 at this
@@ -69,8 +70,10 @@ def run_quantum_program(
         Results of simulation.
     """
     # Generate a sampler
-    backend = deepcopy(qasm_simulator)
-    backend.set_max_qubits(10000)
+    if isinstance(backend, AerSimulator):
+        backend = deepcopy(backend)
+        backend.set_max_qubits(10000)
+
     aer_sampler = AerSamplerV2.from_backend(backend)
 
     rng = np.random.default_rng(aer_sampler.seed)

--- a/qiskit_ibm_runtime/sim_executor/sim_executor.py
+++ b/qiskit_ibm_runtime/sim_executor/sim_executor.py
@@ -22,8 +22,8 @@ from qiskit.utils.optionals import HAS_AER
 from .run_quantum_program import run_quantum_program
 
 if TYPE_CHECKING:
+    from qiskit.providers import BackendV2
     from qiskit.quantum_info import PauliLindbladMap
-    from qiskit_aer import AerSimulator
 
     from ..quantum_program import QuantumProgram
     from ..results import QuantumProgramResult
@@ -37,7 +37,7 @@ class SimRuntimeJob:
     immediately when :meth:`result` is called.
 
     Args:
-        backend: The Aer simulator to run on.
+        backend: The backend to simulate.
         program: The quantum program to execute.
         noise_dict: A map from barrier label refs to Pauli-Lindblad noise maps.
         angle_decimals: Rounding precision for gate angles (in units of π/2).
@@ -47,7 +47,7 @@ class SimRuntimeJob:
 
     def __init__(
         self,
-        backend: AerSimulator,
+        backend: BackendV2,
         program: QuantumProgram,
         noise_dict: dict[str, PauliLindbladMap] | None = None,
         angle_decimals: int = 5,
@@ -71,7 +71,7 @@ class SimRuntimeJob:
         """Return the result of the program execution."""
         if self._result is None:
             self._result = run_quantum_program(
-                qasm_simulator=self._backend,
+                backend=self._backend,
                 program=self._program,
                 noise_dict=self._noise_dict,
                 angle_decimals=self._angle_decimals,
@@ -111,7 +111,7 @@ class SimExecutor:
       set, independent of global circuit qubit numbering.
 
     Args:
-        backend: The Aer simulator to run programs on.
+        backend: The backend to simulate.
         noise_dict: A map from barrier label refs to Pauli-Lindblad noise maps.  Pass
             ``None`` (default) to run without noise injection.
         angle_decimals: Gate angles are rounded to the nearest multiple of π/2 at this
@@ -124,7 +124,7 @@ class SimExecutor:
 
     def __init__(
         self,
-        backend: AerSimulator,
+        backend: BackendV2,
         noise_dict: dict[str, PauliLindbladMap] | None = None,
         angle_decimals: int = 5,
         warn_absent: bool = True,


### PR DESCRIPTION
### Summary
Rather than restricting the backend to `AerSimulator` in `sim_executor` we can support any `BackendV2` thanks to `AerSamplerV2.from_backend`. This gives us more flexibility with choosing a backend to simulate.

### Details and comments

Part of #3129

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
