### PR TITLE
[pre-commit] Specify mypy version to ensure consistency on different developer setups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,9 @@ repos:
         name: mypy
         entry: mypy
         pass_filenames: false
-        language: system
+        language: python
         require_serial: true
+        additional_dependencies: ["mypy==2.3.0"]
       - id: verify-headers
         name: Verify copyright headers
         entry: tools/verify_headers.py


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
On my system (fedora 44) pre-commits were constantly failing on `main` with
```
qiskit_ibm_runtime/sim_executor/insert_noise_pass.py:94: error: Statement is unreachable  [unreachable]
qiskit_ibm_runtime/executor_estimator/zne/extrapolation.py:255: error: Statement is unreachable  [unreachable]
```
Talked with @diego-plan9 and we suspect by default `pre-commit` will use the system `mypy` installation which for me is an old version `1.18`.
One way to circumvent this is to work inside an active `.venv` with the dependencies from this package installed.
However It will not work with `uv` based workflows and is confusing for new contributors.

By specifying `mypy` as a python dependency we can force `pre-commit` of setting up an appropriate environment automatically independent of system installation.

This way we use a consistent mypy version across all developer setups.

### Details and comments

Fixes #

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
