### PR TITLE
Add validation for measure_noise_learning against measure_mitigation at construction  

### DIFF
--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -81,7 +81,7 @@ class ResilienceOptions(BaseOptionsModel):
     def _validate_measure_noise_learning(self) -> ResilienceOptions:
         """Reject a configured measure_noise_learning if measure_mitigation isn't enabled."""
         learning_is_default = self.measure_noise_learning == MeasureNoiseLearningOptions()
-        if not self.measure_mitigation and not learning_is_default:
+        if self.measure_mitigation is False and not learning_is_default:
             raise ValueError(
                 "'measure_noise_learning' options are set, but 'measure_mitigation' is not set to "
                 "True."

--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from pydantic import InstanceOf
+from pydantic import InstanceOf, model_validator
 from qiskit.quantum_info import PauliLindbladMap
 
 from .base import BaseOptionsModel
@@ -76,3 +76,14 @@ class ResilienceOptions(BaseOptionsModel):
     describe the noise characteristics of that layer. The dict contains layers from all PUBs. This
     is required when using PEC mitigation, or ZNE with PEA amplifier.
     """
+
+    @model_validator(mode="after")
+    def _validate_measure_noise_learning(self) -> ResilienceOptions:
+        """Reject a configured measure_noise_learning if measure_mitigation isn't enabled."""
+        learning_is_default = self.measure_noise_learning == MeasureNoiseLearningOptions()
+        if not self.measure_mitigation and not learning_is_default:
+            raise ValueError(
+                "'measure_noise_learning' options are set, but 'measure_mitigation' is not set to "
+                "True."
+            )
+        return self

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -524,6 +524,16 @@ class TestFinalizeOptions(IBMTestCase):
         self.assertFalse(finalized_options.resilience.measure_mitigation)
         self.assertTrue(finalized_options.resilience.zne_mitigation)
 
+    def test_measure_noise_learning_customized_with_mitigation_unset(self):
+        """Test customized mnl is accepted when measure_mitigation finalizes to True."""
+        estimator = EstimatorV2(self.backend)
+        estimator.options.resilience_level = 1
+        estimator.options.resilience.measure_noise_learning.num_randomizations = 64
+
+        finalized_options = estimator.finalize_options()
+        self.assertTrue(finalized_options.resilience.measure_mitigation)
+        self.assertEqual(finalized_options.resilience.measure_noise_learning.num_randomizations, 64)
+
     @data(0, 1, 2)
     def test_forced_values(self, resilience_level):
         """Test that finalize force-set certain values."""

--- a/test/unit/options_models/test_resilience.py
+++ b/test/unit/options_models/test_resilience.py
@@ -73,31 +73,3 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         """Invalid noise_model_mapping values raise ValidationError."""
         with self.assertRaisesRegex(ValidationError, "noise_model_mapping"):
             ResilienceOptions(noise_model_mapping=value)
-
-    @data(None, False)
-    def test_measure_noise_learning_requires_measure_mitigation(self, measure_mitigation):
-        """Setting measure_noise_learning without enabling measure_mitigation raises (DR-R4a)."""
-        with self.assertRaisesRegex(ValidationError, "measure_noise_learning"):
-            ResilienceOptions(
-                measure_mitigation=measure_mitigation,
-                measure_noise_learning={"num_randomizations": 64},
-            )
-
-    def test_measure_noise_learning_allowed_with_measure_mitigation(self):
-        """measure_noise_learning is accepted once measure_mitigation is True."""
-        opts = ResilienceOptions(
-            measure_mitigation=True, measure_noise_learning={"num_randomizations": 64}
-        )
-        self.assertEqual(opts.measure_noise_learning.num_randomizations, 64)
-
-    def test_measure_noise_learning_default_allowed_regardless_of_mitigation(self):
-        """Leaving measure_noise_learning at its default never trips the validator."""
-        opts = ResilienceOptions(measure_mitigation=False)
-        self.assertEqual(opts.measure_noise_learning.num_randomizations, "auto")
-
-    def test_measure_noise_learning_disallowed_on_mutation(self):
-        """The check also fires on assignment, since validate_assignment is enabled."""
-        opts = ResilienceOptions(measure_mitigation=True)
-        opts.measure_noise_learning.num_randomizations = 64
-        with self.assertRaisesRegex(ValidationError, "measure_noise_learning"):
-            opts.measure_mitigation = False

--- a/test/unit/options_models/test_resilience.py
+++ b/test/unit/options_models/test_resilience.py
@@ -41,7 +41,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
     def test_set_all_options(self):
         """All fields accept explicit non-default values."""
         opts = ResilienceOptions(
-            measure_mitigation=False,
+            measure_mitigation=True,
             measure_noise_learning={"num_randomizations": 64},
             pec_mitigation=True,
             pec={"max_overhead": 50, "noise_gain": 0.5},
@@ -52,7 +52,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
                 "layer_1": PauliLindbladMap.identity(num_qubits=1),
             },
         )
-        self.assertFalse(opts.measure_mitigation)
+        self.assertTrue(opts.measure_mitigation)
         self.assertEqual(opts.measure_noise_learning.num_randomizations, 64)
         self.assertTrue(opts.pec_mitigation)
         self.assertEqual(opts.pec.max_overhead, 50)
@@ -73,3 +73,31 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         """Invalid noise_model_mapping values raise ValidationError."""
         with self.assertRaisesRegex(ValidationError, "noise_model_mapping"):
             ResilienceOptions(noise_model_mapping=value)
+
+    @data(None, False)
+    def test_measure_noise_learning_requires_measure_mitigation(self, measure_mitigation):
+        """Setting measure_noise_learning without enabling measure_mitigation raises (DR-R4a)."""
+        with self.assertRaisesRegex(ValidationError, "measure_noise_learning"):
+            ResilienceOptions(
+                measure_mitigation=measure_mitigation,
+                measure_noise_learning={"num_randomizations": 64},
+            )
+
+    def test_measure_noise_learning_allowed_with_measure_mitigation(self):
+        """measure_noise_learning is accepted once measure_mitigation is True."""
+        opts = ResilienceOptions(
+            measure_mitigation=True, measure_noise_learning={"num_randomizations": 64}
+        )
+        self.assertEqual(opts.measure_noise_learning.num_randomizations, 64)
+
+    def test_measure_noise_learning_default_allowed_regardless_of_mitigation(self):
+        """Leaving measure_noise_learning at its default never trips the validator."""
+        opts = ResilienceOptions(measure_mitigation=False)
+        self.assertEqual(opts.measure_noise_learning.num_randomizations, "auto")
+
+    def test_measure_noise_learning_disallowed_on_mutation(self):
+        """The check also fires on assignment, since validate_assignment is enabled."""
+        opts = ResilienceOptions(measure_mitigation=True)
+        opts.measure_noise_learning.num_randomizations = 64
+        with self.assertRaisesRegex(ValidationError, "measure_noise_learning"):
+            opts.measure_mitigation = False


### PR DESCRIPTION
### Summary
Adds options validator to the new options model that was present in the legacy options.

Fixes #3115 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
