### PR TITLE
Deprecate NLV3 post-selection options

### DIFF
--- a/qiskit_ibm_runtime/options_models/post_selection.py
+++ b/qiskit_ibm_runtime/options_models/post_selection.py
@@ -59,7 +59,7 @@ class PostSelectionOptions(BaseOptionsModel):
     @field_validator("enable")
     @classmethod
     def _warn_post_selection(cls, value: bool) -> bool:
-        """Warn that the ``post_selection`` option is deprecated when it is enabled."""
+        """Warn that the post selection options are deprecated."""
         if value:
             issue_deprecation_msg(
                 msg="The 'post_selection' field of NoiseLearnerV3 is deprecated",

--- a/qiskit_ibm_runtime/options_models/post_selection.py
+++ b/qiskit_ibm_runtime/options_models/post_selection.py
@@ -65,6 +65,6 @@ class PostSelectionOptions(BaseOptionsModel):
                 msg="The 'post_selection' field of NoiseLearnerV3 is deprecated",
                 version="0.49.0",
                 remedy="Use 'bit_flip_check' field instead",
-                stacklevel=3,
+                stacklevel=2,
             )
         return value

--- a/qiskit_ibm_runtime/options_models/post_selection.py
+++ b/qiskit_ibm_runtime/options_models/post_selection.py
@@ -12,18 +12,30 @@
 
 """Post selection options."""
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import field_validator
+from pydantic import AfterValidator
 
 from ..utils.deprecation import issue_deprecation_msg
 from .base import BaseOptionsModel
 
 
+def _warn_post_selection(value: bool) -> bool:
+    """Warn that the post selection options are deprecated."""
+    if value:
+        issue_deprecation_msg(
+            msg="The 'post_selection' field of NoiseLearnerV3 is deprecated",
+            version="0.49.0",
+            remedy="Use 'bit_flip_check' field instead",
+            stacklevel=2,
+        )
+    return value
+
+
 class PostSelectionOptions(BaseOptionsModel):
     """Options for post selecting results."""
 
-    enable: bool = False
+    enable: Annotated[bool, AfterValidator(_warn_post_selection)] = False
     """Whether to enable Post Selection when performing learning experiments.
 
     If ``True``, Post Selection is applied to all the learning circuits. In particular, the
@@ -55,16 +67,3 @@ class PostSelectionOptions(BaseOptionsModel):
     See the dosctrings of :class:`.PostSelector` and :meth:`.PostSelector.compute_mask` for more
     details.
     """
-
-    @field_validator("enable")
-    @classmethod
-    def _warn_post_selection(cls, value: bool) -> bool:
-        """Warn that the post selection options are deprecated."""
-        if value:
-            issue_deprecation_msg(
-                msg="The 'post_selection' field of NoiseLearnerV3 is deprecated",
-                version="0.49.0",
-                remedy="Use 'bit_flip_check' field instead",
-                stacklevel=2,
-            )
-        return value

--- a/qiskit_ibm_runtime/options_models/post_selection.py
+++ b/qiskit_ibm_runtime/options_models/post_selection.py
@@ -14,6 +14,9 @@
 
 from typing import Literal
 
+from pydantic import field_validator
+
+from ..utils.deprecation import issue_deprecation_msg
 from .base import BaseOptionsModel
 
 
@@ -52,3 +55,16 @@ class PostSelectionOptions(BaseOptionsModel):
     See the dosctrings of :class:`.PostSelector` and :meth:`.PostSelector.compute_mask` for more
     details.
     """
+
+    @field_validator("enable")
+    @classmethod
+    def _warn_post_selection(cls, value: bool) -> bool:
+        """Warn that the ``post_selection`` option is deprecated when it is enabled."""
+        if value:
+            issue_deprecation_msg(
+                msg="The 'post_selection' field of NoiseLearnerV3 is deprecated",
+                version="0.49.0",
+                remedy="Use 'bit_flip_check' field instead",
+                stacklevel=3,
+            )
+        return value

--- a/release-notes/unreleased/3160.deprecation.rst
+++ b/release-notes/unreleased/3160.deprecation.rst
@@ -1,0 +1,2 @@
+The ``post_selection`` option of :class:`.NoiseLearnerV3` is now deprecated and will be removed in a
+future release.

--- a/test/unit/noise_learner_v3/converters/test_converters_0_1.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_1.py
@@ -48,9 +48,6 @@ class TestConverters(IBMTestCase):
         options.layer_pair_depths = [2, 4, 10]
         options.execution.init_qubits = False
         options.execution.rep_delay = 10**-6
-        options.post_selection.enable = True
-        options.post_selection.strategy = "edge"
-        options.post_selection.x_pulse_type = "xslow"
 
         encoded = noise_learner_v3_inputs_to_0_1(instructions, options)
         decoded = noise_learner_v3_inputs_from_0_1(encoded)

--- a/test/unit/noise_learner_v3/converters/test_converters_0_2.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_2.py
@@ -48,9 +48,6 @@ class TestConverters(IBMTestCase):
         options.layer_pair_depths = [2, 4, 10]
         options.execution.init_qubits = False
         options.execution.rep_delay = 10**-6
-        options.post_selection.enable = True
-        options.post_selection.strategy = "edge"
-        options.post_selection.x_pulse_type = "xslow"
 
         encoded = noise_learner_v3_inputs_to_0_2(instructions, options)
         decoded = noise_learner_v3_inputs_from_0_2(encoded)

--- a/test/unit/noise_learner_v3/converters/test_converters_0_3.py
+++ b/test/unit/noise_learner_v3/converters/test_converters_0_3.py
@@ -48,9 +48,9 @@ class TestConverters(IBMTestCase):
         options.layer_pair_depths = [2, 4, 10]
         options.execution.init_qubits = False
         options.execution.rep_delay = 10**-6
-        options.post_selection.enable = True
-        options.post_selection.strategy = "edge"
-        options.post_selection.x_pulse_type = "xslow"
+        options.bit_flip_checks.pre_circuit.enable = True
+        options.bit_flip_checks.pre_circuit.strategy = "edge"
+        options.bit_flip_checks.pre_circuit.x_pulse_type = "xslow"
 
         encoded = noise_learner_v3_inputs_to_0_3(instructions, options)
         decoded = noise_learner_v3_inputs_from_0_3(encoded)

--- a/test/unit/noise_learner_v3/test_noise_learner_v3.py
+++ b/test/unit/noise_learner_v3/test_noise_learner_v3.py
@@ -37,18 +37,26 @@ class TestNoiseLearnerV3Options(IBMTestCase):
         self.assertIsInstance(nlv3.options, NoiseLearnerV3Options)
         self.assertEqual(nlv3.options, NoiseLearnerV3Options())
 
+    def test_post_selection_warns(self):
+        """Test that enabling post-selection issues a deprecation warning."""
+        options = NoiseLearnerV3Options()
+        with self.assertWarnsRegex(DeprecationWarning, "0.49.0"):
+            options.post_selection.enable = True
+
     def test_options_from_instance(self):
         """Test constructing with an NoiseLearnerV3Options instance."""
         opts_dict = {
-            "post_selection": {"enable": True, "x_pulse_type": "rx", "strategy": "edge"},
+            "bit_flip_checks": {
+                "pre_circuit": {"enable": True, "x_pulse_type": "rx", "strategy": "edge"}
+            },
             "environment": {"log_level": "DEBUG", "job_tags": ["tag1"], "image": "my:image"},
             "execution": {"rep_delay": 42},
         }
         options = NoiseLearnerV3Options(**opts_dict)
         nlv3 = NoiseLearnerV3(mode=get_mocked_backend(), options=options)
-        self.assertTrue(nlv3.options.post_selection.enable)
-        self.assertEqual(nlv3.options.post_selection.x_pulse_type, "rx")
-        self.assertEqual(nlv3.options.post_selection.strategy, "edge")
+        self.assertTrue(nlv3.options.bit_flip_checks.pre_circuit.enable)
+        self.assertEqual(nlv3.options.bit_flip_checks.pre_circuit.x_pulse_type, "rx")
+        self.assertEqual(nlv3.options.bit_flip_checks.pre_circuit.strategy, "edge")
         self.assertEqual(nlv3.options.environment.log_level, "DEBUG")
         self.assertEqual(nlv3.options.environment.job_tags, ["tag1"])
         self.assertEqual(nlv3.options.environment.image, "my:image")
@@ -60,14 +68,16 @@ class TestNoiseLearnerV3Options(IBMTestCase):
     def test_options_from_dict(self):
         """Test constructing with a nested dict."""
         opts_dict = {
-            "post_selection": {"enable": True, "x_pulse_type": "rx", "strategy": "edge"},
+            "bit_flip_checks": {
+                "pre_circuit": {"enable": True, "x_pulse_type": "rx", "strategy": "edge"}
+            },
             "environment": {"log_level": "DEBUG", "job_tags": ["tag1"], "image": "my:image"},
             "execution": {"rep_delay": 42},
         }
         nlv3 = NoiseLearnerV3(mode=get_mocked_backend(), options=opts_dict)
-        self.assertTrue(nlv3.options.post_selection.enable)
-        self.assertEqual(nlv3.options.post_selection.x_pulse_type, "rx")
-        self.assertEqual(nlv3.options.post_selection.strategy, "edge")
+        self.assertTrue(nlv3.options.bit_flip_checks.pre_circuit.enable)
+        self.assertEqual(nlv3.options.bit_flip_checks.pre_circuit.x_pulse_type, "rx")
+        self.assertEqual(nlv3.options.bit_flip_checks.pre_circuit.strategy, "edge")
         self.assertEqual(nlv3.options.environment.log_level, "DEBUG")
         self.assertEqual(nlv3.options.environment.job_tags, ["tag1"])
         self.assertEqual(nlv3.options.environment.image, "my:image")
@@ -79,11 +89,12 @@ class TestNoiseLearnerV3Options(IBMTestCase):
     def test_options_from_partial_dict(self):
         """Test constructing with a nested dict when only specifying some of the options."""
         nlv3 = NoiseLearnerV3(
-            mode=get_mocked_backend(), options={"post_selection": {"strategy": "edge"}}
+            mode=get_mocked_backend(),
+            options={"bit_flip_checks": {"pre_circuit": {"strategy": "edge"}}},
         )
-        self.assertFalse(nlv3.options.post_selection.enable)
-        self.assertEqual(nlv3.options.post_selection.x_pulse_type, "xslow")
-        self.assertEqual(nlv3.options.post_selection.strategy, "edge")
+        self.assertFalse(nlv3.options.bit_flip_checks.pre_circuit.enable)
+        self.assertEqual(nlv3.options.bit_flip_checks.pre_circuit.x_pulse_type, "xslow")
+        self.assertEqual(nlv3.options.bit_flip_checks.pre_circuit.strategy, "edge")
         self.assertEqual(nlv3.options.environment, EnvironmentOptions())
         self.assertEqual(nlv3.options.execution, ExecutionOptions())
 

--- a/test/unit/noise_learner_v3/test_noise_learner_v3.py
+++ b/test/unit/noise_learner_v3/test_noise_learner_v3.py
@@ -43,6 +43,9 @@ class TestNoiseLearnerV3Options(IBMTestCase):
         with self.assertWarnsRegex(DeprecationWarning, "0.49.0"):
             options.post_selection.enable = True
 
+        with self.assertWarnsRegex(DeprecationWarning, "0.49.0"):
+            NoiseLearnerV3Options(post_selection={"enable": True})
+
     def test_options_from_instance(self):
         """Test constructing with an NoiseLearnerV3Options instance."""
         opts_dict = {


### PR DESCRIPTION
### Summary
This PR deprecates the post-selection options of NLV3. Users are pointed to the bit-flip check options instead

Fixes #3159 

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude
