### PR TITLE
Don't parameterize over `enable_gates` with PEA\PEC tests

### DIFF
--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -40,11 +40,9 @@ from .utils import PARAM_BASIS_3Q_SCENARIOS
 class TestPreparePea(IBMTestCase):
     """Tests for the ``prepare_pea`` function."""
 
-    @data([True, True, True], [True, False, False])
+    @data([True, True], [False, False])
     @unpack
-    def test_param_basis_expansion_3q(
-        self, enable_gates, enable_measure, enable_measure_noise_learning
-    ):
+    def test_param_basis_expansion_3q(self, enable_measure, enable_measure_noise_learning):
         """Test parameter-basis expansion with three-qubit observables."""
         observables = PARAM_BASIS_3Q_SCENARIOS.observables
         num_qubits = observables.num_qubits
@@ -53,7 +51,7 @@ class TestPreparePea(IBMTestCase):
         circuit.rz(Parameter("alpha"), 0)
 
         twirling_options = TwirlingOptions()
-        twirling_options.enable_gates = enable_gates
+        twirling_options.enable_gates = True
         twirling_options.enable_measure = enable_measure
 
         measure_noise_learning = (

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -218,11 +218,9 @@ class TestCalculateGamma(IBMTestCase):
 class TestPreparePec(IBMTestCase):
     """Tests for the ``prepare_pec`` function."""
 
-    @data([True, True, True], [True, False, False])
+    @data([True, True], [False, False])
     @unpack
-    def test_param_basis_expansion_3q(
-        self, enable_gates, enable_measure, enable_measure_noise_learning
-    ):
+    def test_param_basis_expansion_3q(self, enable_measure, enable_measure_noise_learning):
         """Test parameter-basis expansion with three-qubit observables."""
         observables = PARAM_BASIS_3Q_SCENARIOS.observables
         num_qubits = observables.num_qubits
@@ -231,7 +229,7 @@ class TestPreparePec(IBMTestCase):
         circuit.rz(Parameter("alpha"), 0)
 
         twirling_options = TwirlingOptions()
-        twirling_options.enable_gates = enable_gates
+        twirling_options.enable_gates = True
         twirling_options.enable_measure = enable_measure
 
         measure_noise_learning = (


### PR DESCRIPTION
### Summary
Minor cleanup post #3088. There is no point in parameterizing over `enable_gates` with PEA\PEC.

- [X] I didn't use LLM tooling, or only used it privately.
