### PR TITLE
Fix dtype of noise factors in prepare_pea function for consistency

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -96,9 +96,9 @@ def prepare_pea(
         raise IBMInputValueError("PEA mitigation must be used with ``pea`` as noise amplification.")
 
     if zne_options.noise_factors == "auto":
-        noise_factors = np.array(PEA_DEFAULT_NOISE_FACTORS)
+        noise_factors = np.array(PEA_DEFAULT_NOISE_FACTORS, dtype=float)
     else:
-        noise_factors = np.array(zne_options.noise_factors)
+        noise_factors = np.array(zne_options.noise_factors, dtype=float)
 
     extrapolated_noise_factors = zne_options.extrapolated_noise_factors
     if extrapolated_noise_factors == "auto":


### PR DESCRIPTION
### PEA integer `noise_factors` fails QPY encoding

`prepare_pea.py` builds `noise_factors = np.array(zne_options.noise_factors)` with no `dtype=float` (unlike `prepare_zne.py`, which casts explicitly). An integer `noise_factors` sequence therefore encodes as `int64`, which the QPY/tensor schema rejects: `ValueError: Unexpected NumPy dtype 'int64', one of ('f64', 'bool', 'u8', 'c128') expected.`

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
