### PR TITLE
Preserve QiskitRuntimeService state when using private environment

### DIFF
--- a/qiskit_ibm_runtime/accounts/account.py
+++ b/qiskit_ibm_runtime/accounts/account.py
@@ -335,6 +335,18 @@ class CloudAccount(Account):
 
     def list_instances(self) -> list[dict[str, Any]]:
         """Retrieve all crns with the IBM Cloud Global Search API."""
+        # Bypass calling Global Search and Global Catalog.
+        if os.environ.get("QISKIT_FUNCTIONS_EXPERIMENTAL"):
+            return [
+                {
+                    "crn": self.instance,
+                    "plan": "plan",
+                    "name": "name",
+                    "tags": [],
+                    "pricing_type": "unknown",
+                }
+            ]
+
         authenticator = self.get_iam_authentificator()
         client = GlobalSearchV2(authenticator=authenticator)
         catalog = GlobalCatalogV1(authenticator=authenticator)

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import warnings
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
@@ -266,14 +265,13 @@ class QiskitRuntimeService:
         self._plans_preference = plans_preference or self._account.plans_preference
         self._tags = tags or self._account.tags
         if self._account.instance:
-            if not os.environ.get("QISKIT_FUNCTIONS_EXPERIMENTAL"):
-                if self._account.instance not in [inst["crn"] for inst in self.instances()]:
-                    raise IBMInputValueError(
-                        "The given API token is associated with an account that does not have "
-                        f"access to the instance {self._account.instance}. "
-                        "To use this instance, use an API token generated from the account "
-                        "with this instance available."
-                    )
+            if self._account.instance not in [inst["crn"] for inst in self.instances()]:
+                raise IBMInputValueError(
+                    "The given API token is associated with an account that does not have access "
+                    f"to the instance {self._account.instance}. "
+                    "To use this instance, use an API token generated from the account "
+                    "with this instance available."
+                )
             self._default_instance = True
             self._api_clients = {self._account.instance: RuntimeClient(self._client_params)}
             self._active_api_client = self._api_clients[self._account.instance]

--- a/test/unit/test_qiskit_runtime_service.py
+++ b/test/unit/test_qiskit_runtime_service.py
@@ -101,7 +101,7 @@ class TestQiskitRuntimeService(IBMTestCase):
         service = QiskitRuntimeService(token="my_token")
         # `_all_instances` contains all the instances available.
         self.assertEqual({instance["crn"] for instance in service._all_instances}, crns_in_registry)
-        # `_backend_configs` is empty.
+        # `_backend_configs` is empty (populated by `backends()`).
         self.assertEqual(service._backend_configs, {})
         # `_api_clients` contains one client per instance available.
         self.assertEqual(set(service._api_clients.keys()), crns_in_registry)
@@ -126,21 +126,20 @@ class TestQiskitRuntimeService(IBMTestCase):
     def test_initialization_state_passing_instance(
         self, with_env_var: bool, registry: OneInstanceNoBackendsRegistry
     ) -> None:
-        """Test `__init__` state variables, passing the `instance` argument on empty registry."""
-        registry.add_instance(Instance("a"))
-        chosen_crn = "crn:v1:bluemix:public:quantum-computing:my-region:a/...:...::"
+        """Test `__init__` state variables, passing the `instance` argument."""
+        chosen_crn = registry.instances["a"].crn
         crns_in_registry = {chosen_crn}
 
         if with_env_var:
             # Using the `QISKIT_FUNCTIONS_EXPERIMENTAL` should have no side effects.
-            with custom_envs({"QISKIT_FUNCTIONS_EXPERIMENTAL": chosen_crn}):
+            with custom_envs({"QISKIT_FUNCTIONS_EXPERIMENTAL": "FOO"}):
                 service = QiskitRuntimeService(token="my_token", instance=chosen_crn)
         else:
             service = QiskitRuntimeService(token="my_token", instance=chosen_crn)
 
         # `_all_instances` contains all the instances available.
         self.assertEqual({instance["crn"] for instance in service._all_instances}, crns_in_registry)
-        # `_backend_configs` is empty.
+        # `_backend_configs` is empty (populated by `backends()`).
         self.assertEqual(service._backend_configs, {})
         # `_api_clients` contains only a client for the specified instance.
         self.assertEqual(set(service._api_clients.keys()), {chosen_crn})

--- a/test/unit/test_qiskit_runtime_service.py
+++ b/test/unit/test_qiskit_runtime_service.py
@@ -12,6 +12,9 @@
 
 """Tests for `QiskitRuntimeService`."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 from qiskit import QuantumCircuit
@@ -24,6 +27,9 @@ from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
 from ..registries import Backend, Instance, OneInstanceNoBackendsRegistry
 from ..utils import transpile_pubs
+
+if TYPE_CHECKING:
+    from ..registries import DefaultRegistry
 
 
 class TestQiskitRuntimeService(IBMTestCase):
@@ -79,3 +85,36 @@ class TestQiskitRuntimeService(IBMTestCase):
         backend_b._api_client.program_run.assert_not_called()
         backend_c._api_client.program_run.assert_not_called()
         self.assertEqual(service._active_api_client, backend_b._api_client)
+
+    @mock_responses
+    def test_initialization_state_variables(self, registry: DefaultRegistry) -> None:
+        """Test state variables populated during `QiskitRuntimeService.__init__`."""
+        crns_in_registry = {instance.crn for instance in registry.instances.values()}
+        backends_in_registry = {
+            instance.crn: set(registry.backends[instance.name])
+            for instance in registry.instances.values()
+        }
+
+        service = QiskitRuntimeService(token="my_token")
+        # `_all_instance` contains all the instances available.
+        self.assertEqual({instance["crn"] for instance in service._all_instances}, crns_in_registry)
+        # `_backend_configs` is empty.
+        self.assertEqual(service._backend_configs, {})
+        # `_api_clients` contains one client per instance available.
+        self.assertEqual(set(service._api_clients.keys()), crns_in_registry)
+        # `_active_api_client` is among the ones in `_api_clients`.
+        self.assertIn(service._active_api_client, service._api_clients.values())
+        # `_backends_info_per_instance` contains one entry per instance, with its backends.
+        self.assertEqual(
+            {
+                crn: {info["name"] for info in value}
+                for crn, value in service._backends_info_per_instance.items()
+            },
+            backends_in_registry,
+        )
+
+        # `_backend_instance_groups` contains one entry per instance, with its backends.
+        self.assertEqual(
+            {info["crn"]: set(info["backends"]) for info in service._backend_instance_groups},
+            backends_in_registry,
+        )

--- a/test/unit/test_qiskit_runtime_service.py
+++ b/test/unit/test_qiskit_runtime_service.py
@@ -17,21 +17,24 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+from ddt import data, ddt
 from qiskit import QuantumCircuit
 
 from qiskit_ibm_runtime import SamplerV2
 from qiskit_ibm_runtime.exceptions import IBMRuntimeError
 from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 
+from ..account import custom_envs
 from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
-from ..registries import Backend, Instance, OneInstanceNoBackendsRegistry
+from ..registries import Backend, DefaultRegistry, Instance, OneInstanceNoBackendsRegistry
 from ..utils import transpile_pubs
 
 if TYPE_CHECKING:
     from ..registries import DefaultRegistry
 
 
+@ddt
 class TestQiskitRuntimeService(IBMTestCase):
     """Class for testing the `QiskitRuntimeService` class."""
 
@@ -87,8 +90,8 @@ class TestQiskitRuntimeService(IBMTestCase):
         self.assertEqual(service._active_api_client, backend_b._api_client)
 
     @mock_responses
-    def test_initialization_state_variables(self, registry: DefaultRegistry) -> None:
-        """Test state variables populated during `__init__`."""
+    def test_initialization_state(self, registry: DefaultRegistry) -> None:
+        """Test `__init__` state variables, with default arguments."""
         crns_in_registry = {instance.crn for instance in registry.instances.values()}
         backends_in_registry = {
             instance.crn: set(registry.backends[instance.name])
@@ -118,16 +121,23 @@ class TestQiskitRuntimeService(IBMTestCase):
             backends_in_registry,
         )
 
-    @mock_responses
-    def test_initialization_state_variables_passing_instance(
-        self, registry: DefaultRegistry
+    @mock_responses(OneInstanceNoBackendsRegistry)
+    @data(True, False)
+    def test_initialization_state_passing_instance(
+        self, with_env_var: bool, registry: OneInstanceNoBackendsRegistry
     ) -> None:
-        """Test state variables populated during `__init__`, passing the `instance` argument."""
-        chosen_crn = registry.instances["a"].crn
-        crns_in_registry = {instance.crn for instance in registry.instances.values()}
+        """Test `__init__` state variables, passing the `instance` argument on empty registry."""
+        registry.add_instance(Instance("a"))
+        chosen_crn = "crn:v1:bluemix:public:quantum-computing:my-region:a/...:...::"
+        crns_in_registry = {chosen_crn}
 
-        service = QiskitRuntimeService(token="my_token", instance="a")
-        print(service._backends_info_per_instance)
+        if with_env_var:
+            # Using the `QISKIT_FUNCTIONS_EXPERIMENTAL` should have no side effects.
+            with custom_envs({"QISKIT_FUNCTIONS_EXPERIMENTAL": chosen_crn}):
+                service = QiskitRuntimeService(token="my_token", instance=chosen_crn)
+        else:
+            service = QiskitRuntimeService(token="my_token", instance=chosen_crn)
+
         # `_all_instances` contains all the instances available.
         self.assertEqual({instance["crn"] for instance in service._all_instances}, crns_in_registry)
         # `_backend_configs` is empty.

--- a/test/unit/test_qiskit_runtime_service.py
+++ b/test/unit/test_qiskit_runtime_service.py
@@ -88,7 +88,7 @@ class TestQiskitRuntimeService(IBMTestCase):
 
     @mock_responses
     def test_initialization_state_variables(self, registry: DefaultRegistry) -> None:
-        """Test state variables populated during `QiskitRuntimeService.__init__`."""
+        """Test state variables populated during `__init__`."""
         crns_in_registry = {instance.crn for instance in registry.instances.values()}
         backends_in_registry = {
             instance.crn: set(registry.backends[instance.name])
@@ -96,7 +96,7 @@ class TestQiskitRuntimeService(IBMTestCase):
         }
 
         service = QiskitRuntimeService(token="my_token")
-        # `_all_instance` contains all the instances available.
+        # `_all_instances` contains all the instances available.
         self.assertEqual({instance["crn"] for instance in service._all_instances}, crns_in_registry)
         # `_backend_configs` is empty.
         self.assertEqual(service._backend_configs, {})
@@ -112,9 +112,31 @@ class TestQiskitRuntimeService(IBMTestCase):
             },
             backends_in_registry,
         )
-
         # `_backend_instance_groups` contains one entry per instance, with its backends.
         self.assertEqual(
             {info["crn"]: set(info["backends"]) for info in service._backend_instance_groups},
             backends_in_registry,
         )
+
+    @mock_responses
+    def test_initialization_state_variables_passing_instance(
+        self, registry: DefaultRegistry
+    ) -> None:
+        """Test state variables populated during `__init__`, passing the `instance` argument."""
+        chosen_crn = registry.instances["a"].crn
+        crns_in_registry = {instance.crn for instance in registry.instances.values()}
+
+        service = QiskitRuntimeService(token="my_token", instance="a")
+        print(service._backends_info_per_instance)
+        # `_all_instances` contains all the instances available.
+        self.assertEqual({instance["crn"] for instance in service._all_instances}, crns_in_registry)
+        # `_backend_configs` is empty.
+        self.assertEqual(service._backend_configs, {})
+        # `_api_clients` contains only a client for the specified instance.
+        self.assertEqual(set(service._api_clients.keys()), {chosen_crn})
+        # `_active_api_client` is among the ones in `_api_clients`.
+        self.assertIn(service._active_api_client, service._api_clients.values())
+        # `_backends_info_per_instance` is empty.
+        self.assertEqual(service._backends_info_per_instance, {})
+        # `_backend_instance_groups` is empty.
+        self.assertEqual(service._backend_instance_groups, [])


### PR DESCRIPTION
### Summary

Revision to #3135, moving the skipping of validation of instances lower into the stack. This should allow for the state variables in `QiskitRuntimeService` to be more consistent with the regular path, in particular the `._all_instances` variable which guards further attempts to retrieve instance information from the global services - and minimize the risk of inconsistent behavior when using that feature.

### Details and comments

Related to #3134

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
