### PR TITLE
Revert LegacySimulatorOptions and adding ExperimentalSimulatorOptions

### DIFF
--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -22,6 +22,7 @@ from ..executor_local_mode import SimRuntimeJob
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.converters import to_runtime_options
 from ..options_models.executor import ExecutorOptions
+from ..options_models.simulator import ExperimentalSimulatorOptions
 from ..quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
 from ..utils.default_session import get_cm_session
 
@@ -97,6 +98,9 @@ class Executor:
         if isinstance(self._service, QiskitRuntimeLocalService) and not local_mode:
             raise ValueError("The executor is currently not supported in local mode.")
 
+        if local_mode and self.options.experimental.get("sim_options", None) is None:
+            self.options.experimental["sim_options"] = ExperimentalSimulatorOptions()
+
     def __setattr__(self, name: str, value: Any) -> None:
         """Set attribute ``name`` to ``value``.
 
@@ -123,7 +127,9 @@ class Executor:
         """
         if isinstance(self._service, QiskitRuntimeLocalService):
             return SimRuntimeJob(
-                backend=self._backend, program=program, options=self.options.simulator
+                backend=self._backend,
+                program=program,
+                options=self.options.experimental["sim_options"],
             )
 
         try:

--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -98,8 +98,10 @@ class Executor:
         if isinstance(self._service, QiskitRuntimeLocalService) and not local_mode:
             raise ValueError("The executor is currently not supported in local mode.")
 
-        if local_mode and self.options.experimental.get("sim_options", None) is None:
-            self.options.experimental["sim_options"] = ExperimentalSimulatorOptions()
+        if local_mode:
+            self.options.experimental["simulator_options"] = self.options.experimental.get(
+                "simulator_options", ExperimentalSimulatorOptions()
+            )
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Set attribute ``name`` to ``value``.
@@ -129,7 +131,7 @@ class Executor:
             return SimRuntimeJob(
                 backend=self._backend,
                 program=program,
-                options=self.options.experimental["sim_options"],
+                options=self.options.experimental["simulator_options"],
             )
 
         try:

--- a/qiskit_ibm_runtime/executor_local_mode/executor_local_mode.py
+++ b/qiskit_ibm_runtime/executor_local_mode/executor_local_mode.py
@@ -23,7 +23,7 @@ from .run_quantum_program import run_quantum_program
 if TYPE_CHECKING:
     from qiskit.providers import BackendV2
 
-    from ..options_models.simulator import SimulatorOptions
+    from ..options_models.simulator import ExperimentalSimulatorOptions
     from ..quantum_program import QuantumProgram
 
 
@@ -32,8 +32,8 @@ class SimRuntimeJob(PrimitiveJob):
 
     **Noise injection**
 
-    When ``noise_model`` is provided in :class:`~.SimulatorOptions`, Pauli-Lindblad noise is
-    injected into circuits at tagged barriers via :class:`~.InsertNoisePass`.  Samplomatic
+    When ``noise_model`` is provided in :class:`~.ExperimentalSimulatorOptions`, Pauli-Lindblad
+    noise is injected into circuits at tagged barriers via :class:`~.InsertNoisePass`.  Samplomatic
     inserts three barriers around each boxed gate — left (``L``), middle (``M``), and right (``R``)
     — with labels of the form ``<pos><idx>@tag=<tag>`` (e.g. ``R0@tag=r0``).  By default,
     noise is injected at the ``R`` (right) barriers, i.e. *after* the gate.  Use
@@ -62,7 +62,7 @@ class SimRuntimeJob(PrimitiveJob):
         self,
         backend: BackendV2,
         program: QuantumProgram,
-        options: SimulatorOptions,
+        options: ExperimentalSimulatorOptions,
     ):
         super().__init__(
             function=run_quantum_program,

--- a/qiskit_ibm_runtime/options/__init__.py
+++ b/qiskit_ibm_runtime/options/__init__.py
@@ -81,7 +81,7 @@ Suboptions
    ExecutionOptionsV2
    SamplerExecutionOptionsV2
    EnvironmentOptions
-   LegacySimulatorOptions
+   SimulatorOptions
 
 """
 
@@ -97,6 +97,6 @@ from .pec_options import PecOptions
 from .resilience_options import ResilienceOptionsV2
 from .sampler_execution_options import SamplerExecutionOptionsV2
 from .sampler_options import SamplerOptions
-from .simulator_options import LegacySimulatorOptions
+from .simulator_options import SimulatorOptions
 from .twirling_options import TwirlingOptions
 from .zne_options import ZneOptions

--- a/qiskit_ibm_runtime/options/options.py
+++ b/qiskit_ibm_runtime/options/options.py
@@ -23,7 +23,7 @@ from qiskit.transpiler import CouplingMap
 
 from ..runtime_options import RuntimeOptions
 from .environment_options import EnvironmentOptions
-from .simulator_options import LegacySimulatorOptions
+from .simulator_options import SimulatorOptions
 from .utils import (
     Dict,
     Unset,
@@ -134,7 +134,7 @@ class OptionsV2(BaseOptions):
             :class:`EnvironmentOptions` for all available options.
 
         simulator: Simulator options. See
-            :class:`LegacySimulatorOptions` for all available options.
+            :class:`~.SimulatorOptions` for all available options.
     """
 
     _VERSION: int = Field(2, frozen=True)
@@ -142,7 +142,7 @@ class OptionsV2(BaseOptions):
     # Options not really related to primitives.
     max_execution_time: UnsetType | int = Unset
     environment: EnvironmentOptions | Dict = Field(default_factory=EnvironmentOptions)
-    simulator: LegacySimulatorOptions | Dict = Field(default_factory=LegacySimulatorOptions)
+    simulator: SimulatorOptions | Dict = Field(default_factory=SimulatorOptions)
 
     def update(self, **kwargs: Any) -> None:
         """Update the options."""

--- a/qiskit_ibm_runtime/options/simulator_options.py
+++ b/qiskit_ibm_runtime/options/simulator_options.py
@@ -28,7 +28,7 @@ class NoiseModel:
 
 
 @primitive_dataclass
-class LegacySimulatorOptions:
+class SimulatorOptions:
     """Simulator options.
 
     For best practice in simulating a backend make sure to pass the

--- a/qiskit_ibm_runtime/options_models/estimator.py
+++ b/qiskit_ibm_runtime/options_models/estimator.py
@@ -23,7 +23,7 @@ from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
 from .resilience import ResilienceOptions
-from .simulator import LegacySimulatorOptions
+from .simulator import SimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -64,7 +64,7 @@ class EstimatorOptions(BaseOptionsModel):
     dynamical_decoupling: DynamicalDecouplingOptions = DynamicalDecouplingOptions()
     """Dynamical decoupling options."""
 
-    simulator: LegacySimulatorOptions = LegacySimulatorOptions()
+    simulator: SimulatorOptions = SimulatorOptions()
     """Simulator options."""
 
     experimental: dict = {}

--- a/qiskit_ibm_runtime/options_models/executor.py
+++ b/qiskit_ibm_runtime/options_models/executor.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from .base import BaseOptionsModel
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
-from .simulator import SimulatorOptions
 
 
 class ExecutorOptions(BaseOptionsModel):
@@ -31,10 +30,3 @@ class ExecutorOptions(BaseOptionsModel):
 
     experimental: dict = {}
     """Experimental options that are passed to the executor."""
-
-    simulator: SimulatorOptions = SimulatorOptions()
-    """Simulator options.
-
-    These options are used when an executor is initialized with a backend that is a simulator,
-    and they are ignored otherwise.
-    """

--- a/qiskit_ibm_runtime/options_models/sampler.py
+++ b/qiskit_ibm_runtime/options_models/sampler.py
@@ -18,7 +18,7 @@ from .base import BaseOptionsModel
 from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import SamplerEnvironmentOptions
 from .execution import SamplerExecutionOptions
-from .simulator import LegacySimulatorOptions
+from .simulator import SimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -37,7 +37,7 @@ class SamplerOptions(BaseOptionsModel):
     twirling: TwirlingOptions = TwirlingOptions()
     """Pauli twirling options."""
 
-    simulator: LegacySimulatorOptions = LegacySimulatorOptions()
+    simulator: SimulatorOptions = SimulatorOptions()
     """Simulator options."""
 
     experimental: dict = {}

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -35,7 +35,7 @@ else:
     noise_model_type: TypeAlias = dict | None  # type: ignore[no-redef, misc]
 
 
-class SimulatorOptions(BaseOptionsModel):
+class ExperimentalSimulatorOptions(BaseOptionsModel):
     """Simulator options."""
 
     angle_decimals: int = 5
@@ -56,7 +56,7 @@ class SimulatorOptions(BaseOptionsModel):
     """Whether to emit a warning when an entry is missing in :attr:`layer_noise_dict`."""
 
 
-class LegacySimulatorOptions(BaseOptionsModel):
+class SimulatorOptions(BaseOptionsModel):
     """Legacy Simulator options.
 
     Used to control local mode simulation.

--- a/test/unit/executor/test_executor.py
+++ b/test/unit/executor/test_executor.py
@@ -21,7 +21,6 @@ from qiskit_ibm_runtime.executor import Executor
 from qiskit_ibm_runtime.options_models.environment import EnvironmentOptions
 from qiskit_ibm_runtime.options_models.execution import ExecutionOptions
 from qiskit_ibm_runtime.options_models.executor import ExecutorOptions
-from qiskit_ibm_runtime.options_models.simulator import SimulatorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 
 from ...ibm_test_case import IBMTestCase
@@ -36,7 +35,6 @@ class TestExecutorOptions(IBMTestCase):
         executor = Executor(mode=get_mocked_backend())
         self.assertIsInstance(executor.options, ExecutorOptions)
         self.assertEqual(executor.options, ExecutorOptions())
-        self.assertEqual(executor.options.simulator, SimulatorOptions())
 
     def test_options_from_instance(self):
         """Test constructing with an ExecutorOptions instance."""

--- a/test/unit/executor_local_mode/test_executor_local_mode.py
+++ b/test/unit/executor_local_mode/test_executor_local_mode.py
@@ -17,7 +17,7 @@ from unittest import skipUnless
 from qiskit.utils import optionals
 
 from qiskit_ibm_runtime.executor_local_mode import SimRuntimeJob
-from qiskit_ibm_runtime.options_models.simulator import SimulatorOptions
+from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.results import QuantumProgramResult
 
@@ -34,6 +34,6 @@ class TestSimRuntimeJob(IBMTestCase):
     def test_result(self):
         """Test that result returns a ``QuantumProgramResult``."""
         job = SimRuntimeJob(
-            AerSimulator(method="stabilizer"), QuantumProgram(1), SimulatorOptions()
+            AerSimulator(method="stabilizer"), QuantumProgram(1), ExperimentalSimulatorOptions()
         )
         self.assertIsInstance(job.result(), QuantumProgramResult)

--- a/test/unit/options_models/test_simulator.py
+++ b/test/unit/options_models/test_simulator.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Tests for SimulatorOptions and SimulatorOptions."""
+"""Tests for SimulatorOptions and ExperimentalSimulatorOptions."""
 
 from unittest.mock import patch
 

--- a/test/unit/options_models/test_simulator.py
+++ b/test/unit/options_models/test_simulator.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Tests for SimulatorOptions and LegacySimulatorOptions."""
+"""Tests for SimulatorOptions and SimulatorOptions."""
 
 from unittest.mock import patch
 
@@ -18,17 +18,20 @@ from ddt import data, ddt
 from pydantic import ValidationError
 from qiskit.transpiler import CouplingMap
 
-from qiskit_ibm_runtime.options_models.simulator import LegacySimulatorOptions, SimulatorOptions
+from qiskit_ibm_runtime.options_models.simulator import (
+    ExperimentalSimulatorOptions,
+    SimulatorOptions,
+)
 
 from ...ibm_test_case import IBMTestCase
 
 
-class TestSimulatorOptions(IBMTestCase):
-    """Tests for SimulatorOptions."""
+class TestExperimentalSimulatorOptions(IBMTestCase):
+    """Tests for ExperimentalSimulatorOptions."""
 
     def test_simulator_options_default(self):
         """Test that simulator options have correct defaults."""
-        options = SimulatorOptions()
+        options = ExperimentalSimulatorOptions()
 
         self.assertEqual(options.angle_decimals, 5)
         self.assertIsNone(options.noise_model)
@@ -37,12 +40,12 @@ class TestSimulatorOptions(IBMTestCase):
 
 
 @ddt
-class TestLegacySimulatorOptions(IBMTestCase):
-    """Tests for LegacySimulatorOptions."""
+class TestSimulatorOptions(IBMTestCase):
+    """Tests for SimulatorOptions."""
 
     def test_simulator_options_default(self):
         """Test that simulator options have correct defaults."""
-        options = LegacySimulatorOptions()
+        options = SimulatorOptions()
 
         self.assertIsNone(options.noise_model)
         self.assertIsNone(options.seed_simulator)
@@ -52,7 +55,7 @@ class TestLegacySimulatorOptions(IBMTestCase):
     @data([[0, 1], [1, 2]], CouplingMap([[0, 1], [1, 2]]))
     def test_coupling_map_valid(self, coupling_map):
         """Test setting coupling map."""
-        options = LegacySimulatorOptions()
+        options = SimulatorOptions()
         options.coupling_map = coupling_map
 
         self.assertEqual(options.coupling_map, coupling_map)
@@ -61,15 +64,15 @@ class TestLegacySimulatorOptions(IBMTestCase):
     def test_coupling_map_invalid_type_raises(self, input):
         """Non-list, non-CouplingMap, non-None value should raise ValidationError."""
         with self.assertRaises(ValidationError):
-            LegacySimulatorOptions(coupling_map=input)
+            SimulatorOptions(coupling_map=input)
 
     def test_noise_model_invalid_type_no_aer_raises(self):
         """Passing a non-dict noise_model raises when Aer is not installed."""
         with patch("qiskit_ibm_runtime.options_models.simulator.optionals.HAS_AER", False):
             with self.assertRaises(ValidationError):
-                LegacySimulatorOptions(noise_model=object())
+                SimulatorOptions(noise_model=object())
 
     def test_noise_model_invalid_type_with_aer_raises(self):
         """A non-dict, non-AerNoiseModel value raises ValidationError."""
         with self.assertRaises(ValidationError):
-            LegacySimulatorOptions(noise_model=12345)
+            SimulatorOptions(noise_model=12345)


### PR DESCRIPTION
### Summary
Reverting the rename to `LegacySimulatorOptions` for users for the next release and renaming the new `SimulatorOptions` to `ExperimentalSimulatorOptions`

### Details and comments

Part of #3053

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
