### PR TITLE
Fix circuit metadata not restored when decoding with RuntimeDecoder

### DIFF
--- a/qiskit_ibm_runtime/json.py
+++ b/qiskit_ibm_runtime/json.py
@@ -149,7 +149,7 @@ def _load_qpy(file_obj: BinaryIO) -> list[Any]:
             UserWarning,
             stacklevel=2,
         )
-    return load(file_obj)
+    return load(file_obj, metadata_deserializer=RuntimeDecoder)
 
 
 def _decode_and_deserialize(data: str, deserializer: Callable, decompress: bool = True) -> Any:

--- a/release-notes/unreleased/2696.bug.rst
+++ b/release-notes/unreleased/2696.bug.rst
@@ -1,0 +1,6 @@
+``RuntimeDecoder`` now restores special types inside ``QuantumCircuit.metadata`` when
+decoding payloads that contain circuits. The QPY load path passes
+``metadata_deserializer=RuntimeDecoder`` to ``qiskit.qpy.load``, matching the
+``RuntimeEncoder`` that the dump path already passes as ``metadata_serializer``.
+Previously, circuit metadata containing values such as NumPy arrays came back as raw
+``{"__type__": ...}`` dictionaries after decoding, instead of the original objects.

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -285,6 +285,25 @@ if __name__ == '__main__':
 
         self.assertTrue(json.dumps(payload, cls=RuntimeEncoder))
 
+    def test_circuit_metadata_round_trip(self):
+        """Test circuit metadata is restored when decoding."""
+        expected = np.arange(0, 10, dtype=np.float64)
+        inner = QuantumCircuit(1)
+        inner.metadata = {"test": expected}
+        circ = QuantumCircuit(1)
+        circ.metadata = {"test": expected, "inner": inner}
+        payload = {"circuits": [circ]}
+
+        decoded = json.loads(json.dumps(payload, cls=RuntimeEncoder), cls=RuntimeDecoder)
+        metadata = decoded["circuits"][0].metadata
+        self.assertIsInstance(metadata["test"], np.ndarray)
+        self.assertEqual(metadata["test"].dtype, expected.dtype)
+        self.assertTrue(np.array_equal(metadata["test"], expected))
+        self.assertIsInstance(metadata["inner"], QuantumCircuit)
+        self.assertIsInstance(metadata["inner"].metadata["test"], np.ndarray)
+        self.assertEqual(metadata["inner"].metadata["test"].dtype, expected.dtype)
+        self.assertTrue(np.array_equal(metadata["inner"].metadata["test"], expected))
+
 
 @ddt
 class TestContainerSerialization(IBMTestCase):


### PR DESCRIPTION
### Summary

Decoding a payload that contains a `QuantumCircuit` now restores the circuit's
metadata: `qiskit.qpy.load` is called with `metadata_deserializer=RuntimeDecoder`,
matching the `RuntimeEncoder` the dump side already passes as `metadata_serializer`.
One line in `_load_qpy`, plus a regression test and a release note.

Fixes #2696.

### Details and comments

Before #946 neither side of the QPY path passed a metadata coder. 
#946 fixed an encode-side crash by adding `RuntimeEncoder` to the dump call, but the load side was
never given the matching decoder, and the test added there (`test_circuit_metadata`)
only encodes. 
This adds the missing half; the encode side and the wire format are
untouched.

The new test covers two cases: an ndarray in metadata (the issue's case) and a circuit
nested inside another circuit's metadata (pins the recursive decode). Assertions are
exact (`isinstance`, dtype, `np.array_equal`). 
It fails on `main` and passes with this
change; the full unit suite passes (1972 passed / 42 skipped, the 1971 of `main` plus
this test).

One behaviour change to be aware of: metadata hand-written in the encoder's own
convention is now decoded (a dict like `{"__type__": "ndarray", "__value__": ...}`
becomes an object), and `"__type__"` without `"__value__"` raises `KeyError` from the
unguarded access in `RuntimeDecoder.object_hook`. Both edges already exist for every
non-metadata part of a payload; this change makes them reachable from circuit metadata
too. Depth is already unbounded on the client side for nested payload structures,
with the interpreter's recursion limit as the only stop, and that is unchanged here.
What this adds is a second route into the same machinery, through circuit metadata,
where each nested circuit costs a decompress and a parse instead of a single hook
call. Exercised to 50 levels locally. If you want a guard on the missing
`"__value__"` case, I would rather do that as a separate follow-up than grow this
diff.

Not tested against payloads produced by the service, only client-side round trips.

If returning the raw dicts was intentional, a documentation note on `RuntimeDecoder`
would be the right change instead, and I'm fine closing this in favour of that.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: Claude Code 2.1.119 (mainly for translation and good grammar) 
- [x] I used the following tool to modify or generate code: Claude Code 2.1.119.