### PR TITLE
Fix the noise injection pass for dynamic circuits

### DIFF
--- a/qiskit_ibm_runtime/executor_local_mode/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/executor_local_mode/insert_noise_pass.py
@@ -74,9 +74,7 @@ class InsertNoisePass(TransformationPass):
         physical_index = {q: dag.find_bit(q).index for q in dag.qubits}
         return self._process_dag(dag, physical_index)
 
-    def _process_dag(
-        self, dag: DAGCircuit, physical_index: dict[Qubit, int]
-    ) -> DAGCircuit:
+    def _process_dag(self, dag: DAGCircuit, physical_index: dict[Qubit, int]) -> DAGCircuit:
         """Process a DAG, recursing into control-flow blocks."""
         for op_node in reversed(list(dag.topological_op_nodes())):
             if op_node.name == "barrier":

--- a/qiskit_ibm_runtime/executor_local_mode/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/executor_local_mode/insert_noise_pass.py
@@ -16,27 +16,21 @@ from __future__ import annotations
 
 import re
 import warnings
-from functools import partial
 from typing import TYPE_CHECKING
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.converters import circuit_to_dag
+from qiskit.circuit.controlflow import ControlFlowOp
+from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.transpiler import TransformationPass
 from qiskit.utils.optionals import HAS_AER
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from qiskit.circuit import Qubit
     from qiskit.dagcircuit import DAGCircuit, DAGOpNode
     from qiskit.quantum_info import PauliLindbladMap
 
 if HAS_AER:
     from qiskit_aer.noise import PauliLindbladError
-
-
-def _find_qubit(dag: DAGCircuit, qubit: Qubit) -> int:
-    return dag.find_bit(qubit).index
 
 
 @HAS_AER.require_in_instance
@@ -77,14 +71,32 @@ class InsertNoisePass(TransformationPass):
         if not self._noise_dict:
             return dag
 
-        for op_node in reversed(list(dag.topological_op_nodes())):
-            if op_node.name != "barrier":
-                continue
+        physical_index = {q: dag.find_bit(q).index for q in dag.qubits}
+        return self._process_dag(dag, physical_index)
 
-            if _new_subdag := self._new_subdag(op_node, partial(_find_qubit, dag)):
-                dag.substitute_node_with_dag(
-                    node=op_node,
-                    input_dag=_new_subdag,
+    def _process_dag(
+        self, dag: DAGCircuit, physical_index: dict[Qubit, int]
+    ) -> DAGCircuit:
+        """Process a DAG, recursing into control-flow blocks."""
+        for op_node in reversed(list(dag.topological_op_nodes())):
+            if op_node.name == "barrier":
+                if _new_subdag := self._new_subdag(op_node, physical_index):
+                    dag.substitute_node_with_dag(node=op_node, input_dag=_new_subdag)
+            elif isinstance(op_node.op, ControlFlowOp):
+                new_blocks = []
+                for block in op_node.op.blocks:
+                    # Map each local qubit of the block to the physical index in the
+                    # parent DAG via the op_node's qargs list.
+                    block_physical_index = {
+                        q: physical_index[op_node.qargs[i]] for i, q in enumerate(block.qubits)
+                    }
+                    block_dag = circuit_to_dag(block)
+                    new_block_dag = self._process_dag(block_dag, block_physical_index)
+                    new_blocks.append(dag_to_circuit(new_block_dag))
+
+                dag.substitute_node(
+                    op_node,
+                    op_node.op.replace_blocks(new_blocks),
                 )
 
         return dag
@@ -105,7 +117,7 @@ class InsertNoisePass(TransformationPass):
         return tag
 
     def _new_subdag(
-        self, op_node: DAGOpNode, find_qubit: Callable[[Qubit], int]
+        self, op_node: DAGOpNode, physical_index: dict[Qubit, int]
     ) -> DAGCircuit | None:
         # Qiskit has no public API for reading barrier labels; _label is the only option.
         label = op_node.op._label
@@ -135,7 +147,7 @@ class InsertNoisePass(TransformationPass):
         # The PauliLindbladMap's indices are interpreted in ascending physical-qubit order
         # of the parent DAG, so we apply the resulting error to the local qc.qubits in the
         # permutation that orders op_node.qargs by their physical index.
-        physical_indices = [find_qubit(q) for q in op_node.qargs]
+        physical_indices = [physical_index[q] for q in op_node.qargs]
         plm_indices = sorted(range(len(physical_indices)), key=physical_indices.__getitem__)
 
         qc = QuantumCircuit(op_node.num_qubits)

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -152,7 +152,7 @@ class TestInsertNoisePass(IBMTestCase):
     def test_noise_injected_inside_control_flow_block(self):
         """Test that noise is injected into barriers inside control flow blocks."""
         separate_body = QuantumCircuit(QuantumRegister(2, "inner"))
-        separate_body.append(Barrier(2, label="R0@tag=r0"), separate_body.qubits)
+        separate_body.append(Barrier(2, label="R0@tag=r0"), [0, 1])
 
         circuit = QuantumCircuit(3, 1)
         circuit.measure(0, 0)

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -175,8 +175,8 @@ class TestInsertNoisePass(IBMTestCase):
             #   if_body.qubits[1] -> parent qubit 0
             
             self.assertEqual(if_body.num_qubits, 2)
-            self.assertIs(if_instr.qubits[0], result.qubits[2])
-            self.assertIs(if_instr.qubits[1], result.qubits[0])
+            self.assertEqual(result.find_bit(if_instr.qubits[0]).index, 2)
+            self.assertEqual(result.find_bit(if_instr.qubits[1]).index, 0)
             
             self.assertEqual(len(_noise_error_ops(if_body)), 1)
             barrier_instr = next(instr for instr in if_body.data if instr.operation.name == "barrier")

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -17,7 +17,7 @@ from unittest import skipUnless
 
 import numpy as np
 from ddt import data, ddt, unpack
-from qiskit.circuit import Barrier, QuantumCircuit
+from qiskit.circuit import Barrier, QuantumCircuit, QuantumRegister
 from qiskit.quantum_info import DensityMatrix, PauliLindbladMap
 from qiskit.transpiler import PassManager
 from qiskit.utils import optionals
@@ -148,3 +148,45 @@ class TestInsertNoisePass(IBMTestCase):
         expected_p1 = (1 - np.exp(-2 * rates_per_physical_qubit)) / 2
         actual_p1 = np.array([dm.probabilities([q])[1] for q in range(circuit.num_qubits)])
         np.testing.assert_allclose(actual_p1, expected_p1, atol=1e-10)
+
+    def test_noise_injected_inside_control_flow_block(self):
+        """Test that noise is injected into barriers inside control flow blocks."""
+        separate_body = QuantumCircuit(QuantumRegister(2, "inner"))
+        separate_body.append(Barrier(2, label="R0@tag=r0"), separate_body.qubits)
+
+        circuit = QuantumCircuit(3, 1)
+        circuit.measure(0, 0)
+        with circuit.if_test((circuit.clbits[0], 1)):
+            circuit.append(Barrier(2, label="R0@tag=r0"), [2, 0])
+        circuit.if_test((circuit.clbits[0], True), separate_body, [2, 0], [])
+
+        noise_dict = {"r0": PauliLindbladMap.from_list([("XI", 0.1)])}
+        result = PassManager([InsertNoisePass(noise_dict=noise_dict, noise_after=True)]).run(
+            circuit
+        )
+
+        if_instrs = [instr for instr in result.data if instr.operation.name == "if_else"]
+        self.assertEqual(len(if_instrs), 2)
+        for if_instr in if_instrs:
+            if_body = if_instr.operation.blocks[0]
+
+            # if_instr.qubits = [circuit.qubits[2], circuit.qubits[0]], so:
+            #   if_body.qubits[0] -> parent qubit 2
+            #   if_body.qubits[1] -> parent qubit 0
+            
+            self.assertEqual(if_body.num_qubits, 2)
+            self.assertIs(if_instr.qubits[0], result.qubits[2])
+            self.assertIs(if_instr.qubits[1], result.qubits[0])
+            
+            self.assertEqual(len(_noise_error_ops(if_body)), 1)
+            barrier_instr = next(instr for instr in if_body.data if instr.operation.name == "barrier")
+            noise_instr = next(instr for instr in if_body.data if instr.operation.name == "quantum_channel")
+
+            # The barrier preserves its original local qubit order [0, 1].
+            self.assertIs(barrier_instr.qubits[0], if_body.qubits[0])
+            self.assertIs(barrier_instr.qubits[1], if_body.qubits[1])
+
+            # Barrier qargs [2, 0] sorted ascending -> [0, 2], so the noise channel must
+            # be applied to local qubit 1 (parent qubit 0) then local qubit 0 (parent qubit 2).
+            self.assertIs(noise_instr.qubits[0], if_body.qubits[1])
+            self.assertIs(noise_instr.qubits[1], if_body.qubits[0])

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -183,10 +183,10 @@ class TestInsertNoisePass(IBMTestCase):
             noise_instr = next(instr for instr in if_body.data if instr.operation.name == "quantum_channel")
 
             # The barrier preserves its original local qubit order [0, 1].
-            self.assertIs(barrier_instr.qubits[0], if_body.qubits[0])
-            self.assertIs(barrier_instr.qubits[1], if_body.qubits[1])
+            self.assertEqual(if_body.find_bit(barrier_instr.qubits[0]).index, 0)
+            self.assertEqual(if_body.find_bit(barrier_instr.qubits[1]).index, 1)
 
             # Barrier qargs [2, 0] sorted ascending -> [0, 2], so the noise channel must
             # be applied to local qubit 1 (parent qubit 0) then local qubit 0 (parent qubit 2).
-            self.assertIs(noise_instr.qubits[0], if_body.qubits[1])
-            self.assertIs(noise_instr.qubits[1], if_body.qubits[0])
+            self.assertEqual(if_body.find_bit(noise_instr.qubits[0]).index, 1)
+            self.assertEqual(if_body.find_bit(noise_instr.qubits[1]).index, 0)

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -150,14 +150,23 @@ class TestInsertNoisePass(IBMTestCase):
         np.testing.assert_allclose(actual_p1, expected_p1, atol=1e-10)
 
     def test_noise_injected_inside_control_flow_block(self):
-        """Test that noise is injected into barriers inside control flow blocks."""
+        """Test that noise is injected into barriers inside control flow blocks.
+
+        "XI" is LSB-rightmost, so X acts on the higher physical index of the pair.
+        Every barrier below spans physical qubits {0, 2}, so X must land on physical qubit 2
+        regardless of the qubit order written in the barrier or how the block attaches to the
+        outer circuit.
+        """
         separate_body = QuantumCircuit(QuantumRegister(2, "inner"))
         separate_body.append(Barrier(2, label="R0@tag=r0"), [0, 1])
 
         circuit = QuantumCircuit(3, 1)
         circuit.measure(0, 0)
         with circuit.if_test((circuit.clbits[0], 1)):
+            circuit.append(Barrier(2, label="R0@tag=r0"), [0, 2])
+        with circuit.if_test((circuit.clbits[0], 1)):
             circuit.append(Barrier(2, label="R0@tag=r0"), [2, 0])
+        circuit.if_test((circuit.clbits[0], True), separate_body, [0, 2], [])
         circuit.if_test((circuit.clbits[0], True), separate_body, [2, 0], [])
 
         noise_dict = {"r0": PauliLindbladMap.from_list([("XI", 0.1)])}
@@ -165,32 +174,24 @@ class TestInsertNoisePass(IBMTestCase):
             circuit
         )
 
-        if_instrs = [instr for instr in result.data if instr.operation.name == "if_else"]
-        self.assertEqual(len(if_instrs), 2)
-        for if_instr in if_instrs:
+        def get_noise_physical_qubits(if_instr):
+            """Return the physical qubit indices the single noise channel in if_instr acts on."""
             if_body = if_instr.operation.blocks[0]
+            noise_instrs = [i for i in if_body.data if i.operation.name == "quantum_channel"]
+            self.assertEqual(len(noise_instrs), 1)
+            noise_instr = noise_instrs[0]
+            physical_qubits = []
+            for local_qubit in noise_instr.qubits:
+                local_idx = if_body.find_bit(local_qubit).index
+                parent_qubit = if_instr.qubits[local_idx]
+                physical_qubits.append(result.find_bit(parent_qubit).index)
+            return physical_qubits
 
-            # if_instr.qubits = [circuit.qubits[2], circuit.qubits[0]], so:
-            #   if_body.qubits[0] -> parent qubit 2
-            #   if_body.qubits[1] -> parent qubit 0
+        if_instrs = [instr for instr in result.data if instr.operation.name == "if_else"]
+        self.assertEqual(len(if_instrs), 4)
 
-            self.assertEqual(if_body.num_qubits, 2)
-            self.assertEqual(result.find_bit(if_instr.qubits[0]).index, 2)
-            self.assertEqual(result.find_bit(if_instr.qubits[1]).index, 0)
-
-            self.assertEqual(len(_noise_error_ops(if_body)), 1)
-            barrier_instr = next(
-                instr for instr in if_body.data if instr.operation.name == "barrier"
-            )
-            noise_instr = next(
-                instr for instr in if_body.data if instr.operation.name == "quantum_channel"
-            )
-
-            # The barrier preserves its original local qubit order [0, 1].
-            self.assertEqual(if_body.find_bit(barrier_instr.qubits[0]).index, 0)
-            self.assertEqual(if_body.find_bit(barrier_instr.qubits[1]).index, 1)
-
-            # Barrier qargs [2, 0] sorted ascending -> [0, 2], so the noise channel must
-            # be applied to local qubit 1 (parent qubit 0) then local qubit 0 (parent qubit 2).
-            self.assertEqual(if_body.find_bit(noise_instr.qubits[0]).index, 1)
-            self.assertEqual(if_body.find_bit(noise_instr.qubits[1]).index, 0)
+        # All four cases span physical qubits {0, 2}; "XI" (LSB-right) -> X on physical qubit 2.
+        self.assertEqual(get_noise_physical_qubits(if_instrs[0]), [0, 2])  # barrier [0, 2]
+        self.assertEqual(get_noise_physical_qubits(if_instrs[1]), [0, 2])  # barrier [2, 0]
+        self.assertEqual(get_noise_physical_qubits(if_instrs[2]), [0, 2])  # separate_body, attached [0, 2]
+        self.assertEqual(get_noise_physical_qubits(if_instrs[3]), [0, 2])  # separate_body, attached [2, 0]

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -148,3 +148,17 @@ class TestInsertNoisePass(IBMTestCase):
         expected_p1 = (1 - np.exp(-2 * rates_per_physical_qubit)) / 2
         actual_p1 = np.array([dm.probabilities([q])[1] for q in range(circuit.num_qubits)])
         np.testing.assert_allclose(actual_p1, expected_p1, atol=1e-10)
+
+    def test_noise_injected_inside_control_flow_block(self):
+        """Test that noise is injected into barriers inside control flow blocks."""
+        circuit = QuantumCircuit(2, 1)
+        circuit.measure(0, 0)
+        with circuit.if_test((circuit.clbits[0], 1)):
+            circuit.append(Barrier(2, label="R0@tag=r0"), [0, 1])
+
+        noise_dict = {"r0": PauliLindbladMap.from_list([("XI", 0.1), ("IX", 0.2)])}
+        pm = PassManager([InsertNoisePass(noise_dict=noise_dict, noise_after=True)])
+        result = pm.run(circuit)
+
+        if_body = next(instr for instr in result.data if instr.operation.name == "if_else")
+        self.assertEqual(len(_noise_error_ops(if_body.operation.blocks[0])), 1)

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -193,5 +193,9 @@ class TestInsertNoisePass(IBMTestCase):
         # All four cases span physical qubits {0, 2}; "XI" (LSB-right) -> X on physical qubit 2.
         self.assertEqual(get_noise_physical_qubits(if_instrs[0]), [0, 2])  # barrier [0, 2]
         self.assertEqual(get_noise_physical_qubits(if_instrs[1]), [0, 2])  # barrier [2, 0]
-        self.assertEqual(get_noise_physical_qubits(if_instrs[2]), [0, 2])  # separate_body, attached [0, 2]
-        self.assertEqual(get_noise_physical_qubits(if_instrs[3]), [0, 2])  # separate_body, attached [2, 0]
+        self.assertEqual(
+            get_noise_physical_qubits(if_instrs[2]), [0, 2]
+        )  # separate_body, attached [0, 2]
+        self.assertEqual(
+            get_noise_physical_qubits(if_instrs[3]), [0, 2]
+        )  # separate_body, attached [2, 0]

--- a/test/unit/executor_local_mode/test_insert_noise_pass.py
+++ b/test/unit/executor_local_mode/test_insert_noise_pass.py
@@ -173,14 +173,18 @@ class TestInsertNoisePass(IBMTestCase):
             # if_instr.qubits = [circuit.qubits[2], circuit.qubits[0]], so:
             #   if_body.qubits[0] -> parent qubit 2
             #   if_body.qubits[1] -> parent qubit 0
-            
+
             self.assertEqual(if_body.num_qubits, 2)
             self.assertEqual(result.find_bit(if_instr.qubits[0]).index, 2)
             self.assertEqual(result.find_bit(if_instr.qubits[1]).index, 0)
-            
+
             self.assertEqual(len(_noise_error_ops(if_body)), 1)
-            barrier_instr = next(instr for instr in if_body.data if instr.operation.name == "barrier")
-            noise_instr = next(instr for instr in if_body.data if instr.operation.name == "quantum_channel")
+            barrier_instr = next(
+                instr for instr in if_body.data if instr.operation.name == "barrier"
+            )
+            noise_instr = next(
+                instr for instr in if_body.data if instr.operation.name == "quantum_channel"
+            )
 
             # The barrier preserves its original local qubit order [0, 1].
             self.assertEqual(if_body.find_bit(barrier_instr.qubits[0]).index, 0)


### PR DESCRIPTION
### Summary

Fixes #3133.

#3133 discusses whether to fix the noise injection pass for dynamic circuits, considering that this is not a use case that we envisage. This PR takes the approach of fixing the pass: I find it simpler than figuring out exactly which use cases we're expected to support, raising errors or warnings for what we don't support, and documenting all this.

### Details and comments

Still in progress. In particular it will be probably modified to align with decisions about qubit ordering that were taken in https://github.com/Qiskit/qiskit-noise-learning/pull/36.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Bob
