### PR TITLE
Add `SamplerV2.find_unique_layers` and `add_tags` always true for executor-based primitives

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -154,9 +154,7 @@ class EstimatorV2(BaseEstimatorV2):
 
         super().__setattr__(name, value)
 
-    def find_unique_layers(
-        self, pubs: Iterable[EstimatorPubLike], add_tags: bool = False
-    ) -> list[CircuitInstruction]:
+    def find_unique_layers(self, pubs: Iterable[EstimatorPubLike]) -> list[CircuitInstruction]:
         """Return the unique boxed layers found across the given PUBs.
 
         The returned list contains one instance of each distinct boxed layer (represented as a
@@ -187,7 +185,6 @@ class EstimatorV2(BaseEstimatorV2):
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
-            add_tags: Whether to include tags for the boxes.
 
         Returns:
             The unique boxed layers found across the given PUBs.
@@ -200,7 +197,7 @@ class EstimatorV2(BaseEstimatorV2):
             measure_noise_learning=options.resilience.measure_noise_learning,
             inject_noise=options.resilience.pec_mitigation
             or (options.resilience.zne_mitigation and options.resilience.zne.amplifier == "pea"),
-            add_tags=add_tags,
+            add_tags=True,
         )
 
     def finalize_options(self) -> EstimatorOptions:

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -160,7 +160,9 @@ class EstimatorV2(BaseEstimatorV2):
 
         super().__setattr__(name, value)
 
-    def find_unique_layers(self, pubs: Iterable[EstimatorPubLike]) -> list[CircuitInstruction]:
+    def find_unique_layers(
+        self, pubs: Iterable[EstimatorPubLike], add_tags: bool = False
+    ) -> list[CircuitInstruction]:
         """Return the unique boxed layers found across the given PUBs.
 
         The returned list contains one instance of each distinct boxed layer (represented as a
@@ -191,6 +193,7 @@ class EstimatorV2(BaseEstimatorV2):
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
+            add_tags: Whether to include tags for the boxes.
 
         Returns:
             The unique boxed layers found across the given PUBs.
@@ -203,6 +206,7 @@ class EstimatorV2(BaseEstimatorV2):
             measure_noise_learning=options.resilience.measure_noise_learning,
             inject_noise=options.resilience.pec_mitigation
             or (options.resilience.zne_mitigation and options.resilience.zne.amplifier == "pea"),
+            add_tags=add_tags,
         )
 
     def finalize_options(self) -> EstimatorOptions:

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -288,7 +288,7 @@ def find_unique_layers(
             Error eXtinction (TREX) mitigation method will be accounted for in boxing.
         inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
             of gates.
-        add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
+        add_tags: Whether to include tags for the boxes.
 
     Returns:
         Unique boxed layers found across the given PUBs.

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     from qiskit import QuantumCircuit
     from qiskit.circuit import CircuitInstruction
-    from qiskit.primitives import EstimatorPub
+    from qiskit.primitives import EstimatorPub, SamplerPub
     from samplomatic.samplex import Samplex
 
     from ..options_models.measure_noise_learning import MeasureNoiseLearningOptions
@@ -300,7 +300,7 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
 
 
 def find_unique_layers(
-    pubs: Iterable[EstimatorPub],
+    pubs: Iterable[EstimatorPub | SamplerPub],
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     inject_noise: bool = False,

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -139,13 +139,33 @@ class SamplerV2(BaseSamplerV2):
             The unique boxed layers found across the given PUBs.
         """
         coerced_pubs = [SamplerPub.coerce(pub, None) for pub in pubs]
+        options = self.finalize_options()
         return find_unique_layers(
             pubs=coerced_pubs,
-            twirling_options=self.options.twirling,
+            twirling_options=options.twirling,
             measure_noise_learning=None,
             inject_noise=False,
             add_tags=True,
         )
+
+    def finalize_options(self) -> SamplerOptions:
+        """Construct and finalize the Sampler options.
+
+        This method produces the final :class:`~.SamplerOptions` instance used inside a call to
+        :meth:`~.Sampler.run` by resolving the ``None`` in the twirling options as documented in
+        :class:`~.TwirlingOptions`.
+
+        Returns:
+            The finalized :class:`~.SamplerOptions` object.
+        """
+        finalized_options = deepcopy(self.options)
+
+        if finalized_options.twirling.enable_gates is None:
+            finalized_options.twirling.enable_gates = False
+        if finalized_options.twirling.enable_measure is None:
+            finalized_options.twirling.enable_measure = False
+
+        return finalized_options
 
     def run(self, pubs: Iterable[SamplerPubLike], *, shots: int | None = None) -> RuntimeJobV2:
         """Submit a request to the sampler primitive.
@@ -173,9 +193,7 @@ class SamplerV2(BaseSamplerV2):
 
         # Finalize the options--namely, resolve the ``None`` in the twirling options
         # as documented.
-        options = deepcopy(self.options)
-        options.twirling.enable_gates = options.twirling.enable_gates or False
-        options.twirling.enable_measure = options.twirling.enable_measure or False
+        options = self.finalize_options()
 
         # Determine default shots: run parameter takes precedence over options.default_shots
         default_shots = shots if shots is not None else options.default_shots

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -126,9 +126,7 @@ class SamplerV2(BaseSamplerV2):
 
         super().__setattr__(name, value)
 
-    def find_unique_layers(
-        self, pubs: Iterable[SamplerPubLike], add_tags: bool = False
-    ) -> list[CircuitInstruction]:
+    def find_unique_layers(self, pubs: Iterable[SamplerPubLike]) -> list[CircuitInstruction]:
         """Return the unique boxed layers found across the given PUBs.
 
         The returned list contains one instance of each distinct boxed layer (represented as a
@@ -136,7 +134,6 @@ class SamplerV2(BaseSamplerV2):
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
-            add_tags: Whether to include tags for the boxes.
 
         Returns:
             The unique boxed layers found across the given PUBs.
@@ -145,7 +142,7 @@ class SamplerV2(BaseSamplerV2):
         return find_unique_layers(
             pubs=coerced_pubs,
             twirling_options=self.options.twirling,
-            add_tags=add_tags,
+            add_tags=True,
         )
 
     def run(self, pubs: Iterable[SamplerPubLike], *, shots: int | None = None) -> RuntimeJobV2:

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -26,11 +26,13 @@ from ..executor import Executor
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.sampler import SamplerOptions
 from .prepare import prepare
+from .utils import find_unique_layers
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Any
 
+    from qiskit.circuit import CircuitInstruction
     from qiskit.primitives.containers.sampler_pub import SamplerPubLike
     from qiskit.providers import BackendV2
 
@@ -123,6 +125,28 @@ class SamplerV2(BaseSamplerV2):
                 raise TypeError(f"Expected SamplerOptions or dict, got {type(value)}")
 
         super().__setattr__(name, value)
+
+    def find_unique_layers(
+        self, pubs: Iterable[SamplerPubLike], add_tags: bool = False
+    ) -> list[CircuitInstruction]:
+        """Return the unique boxed layers found across the given PUBs.
+
+        The returned list contains one instance of each distinct boxed layer (represented as a
+        :class:`~.CircuitInstruction`) appearing in the input PUBs.
+
+        Args:
+            pubs: The list of PUBs to return a list of unique boxes for.
+            add_tags: Whether to include tags for the boxes.
+
+        Returns:
+            The unique boxed layers found across the given PUBs.
+        """
+        coerced_pubs = [SamplerPub.coerce(pub, None) for pub in pubs]
+        return find_unique_layers(
+            pubs=coerced_pubs,
+            twirling_options=self.options.twirling,
+            add_tags=add_tags,
+        )
 
     def run(self, pubs: Iterable[SamplerPubLike], *, shots: int | None = None) -> RuntimeJobV2:
         """Submit a request to the sampler primitive.

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -23,10 +23,10 @@ from qiskit.primitives.containers.sampler_pub import SamplerPub
 
 from ..base_primitive import get_mode_service_backend
 from ..executor import Executor
+from ..executor_estimator.utils import find_unique_layers
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.sampler import SamplerOptions
 from .prepare import prepare
-from .utils import find_unique_layers
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -142,6 +142,8 @@ class SamplerV2(BaseSamplerV2):
         return find_unique_layers(
             pubs=coerced_pubs,
             twirling_options=self.options.twirling,
+            measure_noise_learning=None,
+            inject_noise=False,
             add_tags=True,
         )
 

--- a/qiskit_ibm_runtime/executor_sampler/utils.py
+++ b/qiskit_ibm_runtime/executor_sampler/utils.py
@@ -14,16 +14,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
-from qiskit.circuit import BoxOp
+from qiskit.circuit import BoxOp, ClassicalRegister
+from qiskit.circuit.exceptions import CircuitError
+from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import find_unique_box_instructions
 
 from ..exceptions import IBMInputValueError
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
-    from qiskit.circuit import QuantumCircuit
+    from qiskit.circuit import CircuitInstruction, QuantumCircuit
     from qiskit.primitives.containers.sampler_pub import SamplerPub
 
     from ..options_models.twirling import TwirlingOptions
@@ -108,3 +111,132 @@ def extract_shots_from_pubs(pubs: Sequence[SamplerPub], default_shots: int | Non
     if len(pub_shots) != 1:
         raise IBMInputValueError(f"All pubs must have the same number of shots. Found: {pub_shots}")
     return next(iter(pub_shots))
+
+
+def box_circuit(
+    circuit: QuantumCircuit,
+    enable_gates: bool,
+    measure_annotations: str,
+    twirling_strategy: str,
+    twirling_group: str,
+    add_tags: Literal["none", "unique_box", "unique_instance", "noise_ref"] = "none",
+) -> QuantumCircuit:
+    """Group the operations in the given ``circuit`` into boxes.
+
+    This function removes the final measurement layer from the given circuit and adds a new
+    measurement layer with a dedicated register name. Then, it uses the
+    :meth:`~samplomatic.transpiler.generate_boxing_pass_manager` to group the operations in a
+    circuit into boxes.
+
+    Args:
+        circuit: The quantum circuit to box.
+        enable_gates: Whether to group gates into boxes. This value is passed directly to the
+            ``enable_gates`` argument of
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+        measure_annotations: The annotations placed on the measurement boxes. The measurements
+            are grouped into boxes by default, and the value of ``measure_annotations`` passed
+            directly to the ``measure_annotations`` argument of
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
+            API docs for a full list of supported values.
+        twirling_strategy: The strategy for whether and how twirling boxes are extended to
+            include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
+            argument of
+            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
+            API docs for a full list of supported values.
+        twirling_group: The group to use for the twirling boxes.
+            Check the :meth:`~.samplomatic.transpiler.generate_boxing_pass_manager` documentation
+            for supported values.
+        inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
+            of gates. If ``True``, :meth:`~samplomatic.transpiler.generate_boxing_pass_manager` is
+            called with arguments ``inject_noise_targets`` and ``inject_noise_strategy`` set to
+            ``"gates"`` and ``"uniform_modification"`` respectively; if ``False``, it is called with
+            ``inject_noise_targets`` and ``inject_noise_strategy`` set to ``"none"`` and
+            ``"no_modification"``. See the Samplomatic API docs for more details regarding these
+            values.
+        add_tags: Whether to include tags for the boxes.
+
+    Returns:
+        The boxed circuit.
+    """
+    # Remove any existing final measurements
+    prepared_circuit = circuit.remove_final_measurements(inplace=False)
+
+    # Add final measurements
+    creg = ClassicalRegister(prepared_circuit.num_qubits, "_meas")
+    try:
+        prepared_circuit.add_register(creg)
+    except CircuitError:
+        raise IBMInputValueError("Name `_meas` is reserved for a dedicated classical register.")
+    prepared_circuit.barrier()
+    prepared_circuit.measure(prepared_circuit.qubits, creg)
+
+    boxing_pm = generate_boxing_pass_manager(
+        enable_gates=enable_gates,
+        enable_measures=True,
+        twirling_strategy=twirling_strategy,
+        twirling_group=twirling_group,
+        measure_annotations=measure_annotations,
+        inject_noise_site="after",
+        inject_noise_targets="none",
+        inject_noise_strategy="no_modification",
+        add_tags=add_tags,
+    )
+    boxed_circuit = boxing_pm.run(prepared_circuit)
+    return boxed_circuit
+
+
+def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
+    twirling_options: TwirlingOptions,
+    twirling_group: str = "balanced_pauli",
+    add_tags: bool = False,
+) -> dict[str, Any]:
+    """A helper to map options to kwargs for the boxing passmanager.
+
+    Args:
+        twirling_options: Twirling options.
+        twirling_group: The group to use for the twirling boxes.
+        add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
+            (will pass the "none" value to the relevant attribute), while ``True`` will cause tags
+            with the twirled boxes hash to be added (using the "unique_box" value of the relevant
+            attribute). These tags can help injecting noise in simulators.
+
+    Returns:
+        Options to the boxing passmanager.
+    """
+    return {
+        "enable_gates": twirling_options.enable_gates,
+        "measure_annotations": "all" if twirling_options.enable_measure else "change_basis",
+        "twirling_strategy": twirling_options.strategy.replace("-", "_"),
+        "twirling_group": twirling_group,
+        "add_tags": "unique_box" if add_tags else "none",
+    }
+
+
+def find_unique_layers(
+    pubs: Iterable[SamplerPub],
+    twirling_options: TwirlingOptions,
+    add_tags: bool = False,
+) -> list[CircuitInstruction]:
+    """Return the unique boxed layers found across the given PUBs.
+
+    Args:
+        pubs: The list of PUBs to return a list of unique boxes for.
+        twirling_options: Twirling options.
+        measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
+            Error eXtinction (TREX) mitigation method will be accounted for in boxing.
+        inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
+            of gates.
+        add_tags: Whether to include tags for the boxes.
+
+    Returns:
+        Unique boxed layers found across the given PUBs.
+    """
+    pm_kwargs = options_to_boxing_pm_kwargs(
+        twirling_options,
+        add_tags=add_tags,
+    )
+    boxed_circuits = (box_circuit(circuit=pub.circuit, **pm_kwargs) for pub in pubs)
+    instructions = (box for boxed_circuit in boxed_circuits for box in boxed_circuit)
+    return find_unique_box_instructions(
+        instructions=instructions, normalize_annotations=None, undress_boxes=True
+    )

--- a/qiskit_ibm_runtime/executor_sampler/utils.py
+++ b/qiskit_ibm_runtime/executor_sampler/utils.py
@@ -14,19 +14,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
-from qiskit.circuit import BoxOp, ClassicalRegister
-from qiskit.circuit.exceptions import CircuitError
-from samplomatic.transpiler import generate_boxing_pass_manager
-from samplomatic.utils import find_unique_box_instructions
+from qiskit.circuit import BoxOp
 
 from ..exceptions import IBMInputValueError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Sequence
 
-    from qiskit.circuit import CircuitInstruction, QuantumCircuit
+    from qiskit.circuit import QuantumCircuit
     from qiskit.primitives.containers.sampler_pub import SamplerPub
 
     from ..options_models.twirling import TwirlingOptions
@@ -111,132 +108,3 @@ def extract_shots_from_pubs(pubs: Sequence[SamplerPub], default_shots: int | Non
     if len(pub_shots) != 1:
         raise IBMInputValueError(f"All pubs must have the same number of shots. Found: {pub_shots}")
     return next(iter(pub_shots))
-
-
-def box_circuit(
-    circuit: QuantumCircuit,
-    enable_gates: bool,
-    measure_annotations: str,
-    twirling_strategy: str,
-    twirling_group: str,
-    add_tags: Literal["none", "unique_box", "unique_instance", "noise_ref"] = "none",
-) -> QuantumCircuit:
-    """Group the operations in the given ``circuit`` into boxes.
-
-    This function removes the final measurement layer from the given circuit and adds a new
-    measurement layer with a dedicated register name. Then, it uses the
-    :meth:`~samplomatic.transpiler.generate_boxing_pass_manager` to group the operations in a
-    circuit into boxes.
-
-    Args:
-        circuit: The quantum circuit to box.
-        enable_gates: Whether to group gates into boxes. This value is passed directly to the
-            ``enable_gates`` argument of
-            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`.
-        measure_annotations: The annotations placed on the measurement boxes. The measurements
-            are grouped into boxes by default, and the value of ``measure_annotations`` passed
-            directly to the ``measure_annotations`` argument of
-            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
-            API docs for a full list of supported values.
-        twirling_strategy: The strategy for whether and how twirling boxes are extended to
-            include eligible idle qubits. This value is passed directly to the ``twirling_strategy``
-            argument of
-            :meth:`~samplomatic.transpiler.generate_boxing_pass_manager`. See the Samplomatic
-            API docs for a full list of supported values.
-        twirling_group: The group to use for the twirling boxes.
-            Check the :meth:`~.samplomatic.transpiler.generate_boxing_pass_manager` documentation
-            for supported values.
-        inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
-            of gates. If ``True``, :meth:`~samplomatic.transpiler.generate_boxing_pass_manager` is
-            called with arguments ``inject_noise_targets`` and ``inject_noise_strategy`` set to
-            ``"gates"`` and ``"uniform_modification"`` respectively; if ``False``, it is called with
-            ``inject_noise_targets`` and ``inject_noise_strategy`` set to ``"none"`` and
-            ``"no_modification"``. See the Samplomatic API docs for more details regarding these
-            values.
-        add_tags: Whether to include tags for the boxes.
-
-    Returns:
-        The boxed circuit.
-    """
-    # Remove any existing final measurements
-    prepared_circuit = circuit.remove_final_measurements(inplace=False)
-
-    # Add final measurements
-    creg = ClassicalRegister(prepared_circuit.num_qubits, "_meas")
-    try:
-        prepared_circuit.add_register(creg)
-    except CircuitError:
-        raise IBMInputValueError("Name `_meas` is reserved for a dedicated classical register.")
-    prepared_circuit.barrier()
-    prepared_circuit.measure(prepared_circuit.qubits, creg)
-
-    boxing_pm = generate_boxing_pass_manager(
-        enable_gates=enable_gates,
-        enable_measures=True,
-        twirling_strategy=twirling_strategy,
-        twirling_group=twirling_group,
-        measure_annotations=measure_annotations,
-        inject_noise_site="after",
-        inject_noise_targets="none",
-        inject_noise_strategy="no_modification",
-        add_tags=add_tags,
-    )
-    boxed_circuit = boxing_pm.run(prepared_circuit)
-    return boxed_circuit
-
-
-def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
-    twirling_options: TwirlingOptions,
-    twirling_group: str = "balanced_pauli",
-    add_tags: bool = False,
-) -> dict[str, Any]:
-    """A helper to map options to kwargs for the boxing passmanager.
-
-    Args:
-        twirling_options: Twirling options.
-        twirling_group: The group to use for the twirling boxes.
-        add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
-            (will pass the "none" value to the relevant attribute), while ``True`` will cause tags
-            with the twirled boxes hash to be added (using the "unique_box" value of the relevant
-            attribute). These tags can help injecting noise in simulators.
-
-    Returns:
-        Options to the boxing passmanager.
-    """
-    return {
-        "enable_gates": twirling_options.enable_gates,
-        "measure_annotations": "all" if twirling_options.enable_measure else "change_basis",
-        "twirling_strategy": twirling_options.strategy.replace("-", "_"),
-        "twirling_group": twirling_group,
-        "add_tags": "unique_box" if add_tags else "none",
-    }
-
-
-def find_unique_layers(
-    pubs: Iterable[SamplerPub],
-    twirling_options: TwirlingOptions,
-    add_tags: bool = False,
-) -> list[CircuitInstruction]:
-    """Return the unique boxed layers found across the given PUBs.
-
-    Args:
-        pubs: The list of PUBs to return a list of unique boxes for.
-        twirling_options: Twirling options.
-        measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
-            Error eXtinction (TREX) mitigation method will be accounted for in boxing.
-        inject_noise: Whether to add :class:`~samplomatic.InjectNoise` annotations to the boxes
-            of gates.
-        add_tags: Whether to include tags for the boxes.
-
-    Returns:
-        Unique boxed layers found across the given PUBs.
-    """
-    pm_kwargs = options_to_boxing_pm_kwargs(
-        twirling_options,
-        add_tags=add_tags,
-    )
-    boxed_circuits = (box_circuit(circuit=pub.circuit, **pm_kwargs) for pub in pubs)
-    instructions = (box for boxed_circuit in boxed_circuits for box in boxed_circuit)
-    return find_unique_box_instructions(
-        instructions=instructions, normalize_annotations=None, undress_boxes=True
-    )


### PR DESCRIPTION
### Summary
Adding in `find_unique_layers` for the wrapper sampler and setting `add_tags` to `True` for both wrappers. This provides users with layers that are always tagged for noise injection in the local mode simulator 

### Details and comments

Closes #3177

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
