### PR TITLE
Rename `noise_model_mapping` to `noise_model` in `ResilienceOptions`

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -181,7 +181,7 @@ class EstimatorV2(BaseEstimatorV2):
             noise_model = results.to_dict(layers)
 
             # Assign the learned model so PEC uses it on the next run.
-            est.options.resilience.noise_model_mapping = noise_model
+            est.options.resilience.noise_mapping = noise_model
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
@@ -324,7 +324,7 @@ class EstimatorV2(BaseEstimatorV2):
         )
         # Store raw options, shots and precision for post-processing side to compute metadata.
         quantum_program.passthrough_data["post_processor"]["options"] = options.model_dump(  # type: ignore[index, call-overload]
-            exclude={"resilience": {"noise_model_mapping"}}
+            exclude={"resilience": {"noise_mapping"}}
         )
         quantum_program.passthrough_data["post_processor"]["shots"] = shots  # type: ignore[index, call-overload]
         quantum_program.passthrough_data["post_processor"]["precision"] = resolved_precision  # type: ignore[index, call-overload]

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -181,7 +181,7 @@ class EstimatorV2(BaseEstimatorV2):
             noise_model = results.to_dict(layers)
 
             # Assign the learned model so PEC uses it on the next run.
-            est.options.resilience.noise_mapping = noise_model
+            est.options.resilience.noise_model = noise_model
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
@@ -325,7 +325,7 @@ class EstimatorV2(BaseEstimatorV2):
         )
         # Store raw options, shots and precision for post-processing side to compute metadata.
         quantum_program.passthrough_data["post_processor"]["options"] = options.model_dump(  # type: ignore[index, call-overload]
-            exclude={"resilience": {"noise_mapping"}}
+            exclude={"resilience": {"noise_model"}}
         )
         quantum_program.passthrough_data["post_processor"]["shots"] = shots  # type: ignore[index, call-overload]
         quantum_program.passthrough_data["post_processor"]["precision"] = resolved_precision  # type: ignore[index, call-overload]

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -66,7 +66,7 @@ def prepare_pec(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         pec_options: The options for PEC mitigation.
-        noise_model: Mapping between layer ref to a noise model to use for PEC mitigation.
+        noise_model: Mapping between layer ref to a noise model to use for PEC mitigation
             method. The dict contains layers from all pubs. Assumes that the unique layers
             used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -51,7 +51,7 @@ def prepare_pec(
     twirling_options: TwirlingOptions,
     shots: int,
     pec_options: PecOptions,
-    noise_mapping: dict[str, PauliLindbladMap],
+    noise_model: dict[str, PauliLindbladMap],
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     add_tags: bool = False,
 ) -> QuantumProgram:
@@ -66,7 +66,7 @@ def prepare_pec(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         pec_options: The options for PEC mitigation.
-        noise_mapping: Mapping between layer ref to a noise model to use for PEC mitigation
+        noise_model: Mapping between layer ref to a noise model to use for PEC mitigation
             method. The dict contains layers from all pubs. Assumes that the unique layers
             used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
@@ -84,7 +84,7 @@ def prepare_pec(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
-        IBMInputValueError: If ``noise_mapping`` is missing a noise map for at least one of
+        IBMInputValueError: If ``noise_model`` is missing a noise map for at least one of
             the pubs layers.
     """
     if not twirling_options.enable_gates:
@@ -135,7 +135,7 @@ def prepare_pec(
         # add samplex_arguments related to noise injection
         if pec_options.noise_gain == "auto":
             # calculate the gamma factor without scaling it by noise_factor
-            gamma = calculate_gamma(boxed_circuit, noise_mapping, 1)
+            gamma = calculate_gamma(boxed_circuit, noise_model, 1)
             # calculate the noise factor based on gamma and max_overhead, setting it to ``1``
             # if ``gamma`` is ``1``--i.e., if there is no noise to mitigate.
             noise_gain = 1 if gamma == 1 else 1 - np.log(max_overhead) / np.log(gamma**2)
@@ -161,7 +161,7 @@ def prepare_pec(
         for spec in specs:
             ref = spec.name.split(".")[-1]
             try:
-                pub_noise_model[ref] = noise_mapping[ref]
+                pub_noise_model[ref] = noise_model[ref]
             except KeyError:
                 raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
             # noise_scales and pauli_lindblad_maps should have the same refs

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -66,7 +66,7 @@ def prepare_pec(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         pec_options: The options for PEC mitigation.
-        noise_model: Mapping between layer ref to a noise model to use for PEC mitigation
+        noise_model: Mapping between layer ref to a noise model to use for PEC mitigation.
             method. The dict contains layers from all pubs. Assumes that the unique layers
             used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -51,7 +51,7 @@ def prepare_pec(
     twirling_options: TwirlingOptions,
     shots: int,
     pec_options: PecOptions,
-    noise_model_mapping: dict[str, PauliLindbladMap],
+    noise_mapping: dict[str, PauliLindbladMap],
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     add_tags: bool = False,
 ) -> QuantumProgram:
@@ -66,7 +66,7 @@ def prepare_pec(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         pec_options: The options for PEC mitigation.
-        noise_model_mapping: Mapping between layer ref to a noise model to use for PEC mitigation
+        noise_mapping: Mapping between layer ref to a noise model to use for PEC mitigation
             method. The dict contains layers from all pubs. Assumes that the unique layers
             used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
@@ -84,7 +84,7 @@ def prepare_pec(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
-        IBMInputValueError: If ``noise_model_mapping`` is missing a noise map for at least one of
+        IBMInputValueError: If ``noise_mapping`` is missing a noise map for at least one of
             the pubs layers.
     """
     if not twirling_options.enable_gates:
@@ -135,7 +135,7 @@ def prepare_pec(
         # add samplex_arguments related to noise injection
         if pec_options.noise_gain == "auto":
             # calculate the gamma factor without scaling it by noise_factor
-            gamma = calculate_gamma(boxed_circuit, noise_model_mapping, 1)
+            gamma = calculate_gamma(boxed_circuit, noise_mapping, 1)
             # calculate the noise factor based on gamma and max_overhead, setting it to ``1``
             # if ``gamma`` is ``1``--i.e., if there is no noise to mitigate.
             noise_gain = 1 if gamma == 1 else 1 - np.log(max_overhead) / np.log(gamma**2)
@@ -161,7 +161,7 @@ def prepare_pec(
         for spec in specs:
             ref = spec.name.split(".")[-1]
             try:
-                pub_noise_model[ref] = noise_model_mapping[ref]
+                pub_noise_model[ref] = noise_mapping[ref]
             except KeyError:
                 raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
             # noise_scales and pauli_lindblad_maps should have the same refs

--- a/qiskit_ibm_runtime/executor_estimator/pec/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/utils.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 def calculate_gamma(
     boxed_circuit: QuantumCircuit,
-    noise_mapping: dict[str, PauliLindbladMap],
+    noise_model: dict[str, PauliLindbladMap],
     noise_factor: float,
 ) -> float:
     """Calculate the PEC gamma factor of a circuit based on a noise model.
@@ -43,7 +43,7 @@ def calculate_gamma(
 
     Args:
         boxed_circuit: The annotated circuit to calculate the PEC gamma for.
-        noise_mapping: Mapping between layer ref to a noise model
+        noise_model: Mapping between layer ref to a noise model.
         noise_factor: The noise factor of the noise amplification.
 
     Returns:
@@ -54,12 +54,12 @@ def calculate_gamma(
         if annot := get_annotation(instr.operation, InjectNoise):
             ref = annot.ref
             try:
-                noise_model = noise_mapping[ref]
+                model = noise_model[ref]
             except KeyError:
                 raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
             # scale the noise by noise_factor
-            noise_model = noise_model.scale_rates(noise_factor)
-            gamma *= noise_model.inverse().gamma()
+            model = model.scale_rates(noise_factor)
+            gamma *= model.inverse().gamma()
     return gamma
 
 

--- a/qiskit_ibm_runtime/executor_estimator/pec/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/utils.py
@@ -43,7 +43,7 @@ def calculate_gamma(
 
     Args:
         boxed_circuit: The annotated circuit to calculate the PEC gamma for.
-        noise_model: Mapping between layer ref to a noise model.
+        noise_model: Mapping between layer ref to a noise model
         noise_factor: The noise factor of the noise amplification.
 
     Returns:

--- a/qiskit_ibm_runtime/executor_estimator/pec/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/utils.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 def calculate_gamma(
     boxed_circuit: QuantumCircuit,
-    noise_model_mapping: dict[str, PauliLindbladMap],
+    noise_mapping: dict[str, PauliLindbladMap],
     noise_factor: float,
 ) -> float:
     """Calculate the PEC gamma factor of a circuit based on a noise model.
@@ -43,7 +43,7 @@ def calculate_gamma(
 
     Args:
         boxed_circuit: The annotated circuit to calculate the PEC gamma for.
-        noise_model_mapping: Mapping between layer ref to a noise model
+        noise_mapping: Mapping between layer ref to a noise model
         noise_factor: The noise factor of the noise amplification.
 
     Returns:
@@ -54,7 +54,7 @@ def calculate_gamma(
         if annot := get_annotation(instr.operation, InjectNoise):
             ref = annot.ref
             try:
-                noise_model = noise_model_mapping[ref]
+                noise_model = noise_mapping[ref]
             except KeyError:
                 raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
             # scale the noise by noise_factor

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -95,7 +95,7 @@ def prepare(
             twirling_options=options.twirling,
             shots=shots,
             pec_options=options.resilience.pec,
-            noise_model=options.resilience.noise_mapping,
+            noise_model=options.resilience.noise_model,
             measure_noise_learning=options.resilience.measure_noise_learning
             if options.resilience.measure_mitigation
             else None,
@@ -109,7 +109,7 @@ def prepare(
                 twirling_options=options.twirling,
                 shots=shots,
                 zne_options=options.resilience.zne,
-                noise_model=options.resilience.noise_mapping,
+                noise_model=options.resilience.noise_model,
                 measure_noise_learning=options.resilience.measure_noise_learning
                 if options.resilience.measure_mitigation
                 else None,

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -95,7 +95,7 @@ def prepare(
             twirling_options=options.twirling,
             shots=shots,
             pec_options=options.resilience.pec,
-            noise_model_mapping=options.resilience.noise_model_mapping,
+            noise_mapping=options.resilience.noise_mapping,
             measure_noise_learning=options.resilience.measure_noise_learning
             if options.resilience.measure_mitigation
             else None,
@@ -109,7 +109,7 @@ def prepare(
                 twirling_options=options.twirling,
                 shots=shots,
                 zne_options=options.resilience.zne,
-                noise_model_mapping=options.resilience.noise_model_mapping,
+                noise_mapping=options.resilience.noise_mapping,
                 measure_noise_learning=options.resilience.measure_noise_learning
                 if options.resilience.measure_mitigation
                 else None,

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -95,7 +95,7 @@ def prepare(
             twirling_options=options.twirling,
             shots=shots,
             pec_options=options.resilience.pec,
-            noise_mapping=options.resilience.noise_mapping,
+            noise_model=options.resilience.noise_mapping,
             measure_noise_learning=options.resilience.measure_noise_learning
             if options.resilience.measure_mitigation
             else None,
@@ -109,7 +109,7 @@ def prepare(
                 twirling_options=options.twirling,
                 shots=shots,
                 zne_options=options.resilience.zne,
-                noise_mapping=options.resilience.noise_mapping,
+                noise_model=options.resilience.noise_mapping,
                 measure_noise_learning=options.resilience.measure_noise_learning
                 if options.resilience.measure_mitigation
                 else None,

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -52,7 +52,7 @@ def prepare_pea(
     twirling_options: TwirlingOptions,
     shots: int,
     zne_options: ZneOptions,
-    noise_mapping: dict[str, PauliLindbladMap],
+    noise_model: dict[str, PauliLindbladMap],
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     add_tags: bool = False,
 ) -> QuantumProgram:
@@ -67,7 +67,7 @@ def prepare_pea(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         zne_options: The options for PEA mitigation (which have the same options as ZNE).
-        noise_mapping: Mapping between layer ref to a noise model to use for noise
+        noise_model: Mapping between layer ref to a noise model to use for noise
             amplification. The dict contains layers from all pubs. Assumes that the unique
             layers used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
@@ -85,7 +85,7 @@ def prepare_pea(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
-        IBMInputValueError: If noise_mapping is missing a noise map for at least one of
+        IBMInputValueError: If ``noise_model`` is missing a noise map for at least one of
             the pubs layers.
         IBMInputValueError: If ``noise_factors`` is under-specified for the requested extrapolator.
 
@@ -154,10 +154,10 @@ def prepare_pea(
         for spec in specs:
             ref = spec.name.split(".")[-1]
             try:
-                noise_model = noise_mapping[ref]
+                model = noise_model[ref]
             except KeyError:
                 raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
-            pub_noise_model[ref] = noise_model
+            pub_noise_model[ref] = model
             samplex_arguments[f"noise_scales.{ref}"] = noise_scales
 
         samplex_arguments["pauli_lindblad_maps"] = pub_noise_model

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -52,7 +52,7 @@ def prepare_pea(
     twirling_options: TwirlingOptions,
     shots: int,
     zne_options: ZneOptions,
-    noise_model_mapping: dict[str, PauliLindbladMap],
+    noise_mapping: dict[str, PauliLindbladMap],
     measure_noise_learning: MeasureNoiseLearningOptions | None = None,
     add_tags: bool = False,
 ) -> QuantumProgram:
@@ -67,7 +67,7 @@ def prepare_pea(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         zne_options: The options for PEA mitigation (which have the same options as ZNE).
-        noise_model_mapping: Mapping between layer ref to a noise model to use for noise
+        noise_mapping: Mapping between layer ref to a noise model to use for noise
             amplification. The dict contains layers from all pubs. Assumes that the unique
             layers used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
@@ -85,7 +85,7 @@ def prepare_pea(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
-        IBMInputValueError: If noise_model_mapping is missing a noise map for at least one of
+        IBMInputValueError: If noise_mapping is missing a noise map for at least one of
             the pubs layers.
         IBMInputValueError: If ``noise_factors`` is under-specified for the requested extrapolator.
 
@@ -154,7 +154,7 @@ def prepare_pea(
         for spec in specs:
             ref = spec.name.split(".")[-1]
             try:
-                noise_model = noise_model_mapping[ref]
+                noise_model = noise_mapping[ref]
             except KeyError:
                 raise IBMInputValueError(f"Noise model is missing for layer with reference {ref}")
             pub_noise_model[ref] = noise_model

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -67,7 +67,7 @@ def prepare_pea(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         zne_options: The options for PEA mitigation (which have the same options as ZNE).
-        noise_model: Mapping between layer ref to a noise model to use for noise.
+        noise_model: Mapping between layer ref to a noise model to use for noise
             amplification. The dict contains layers from all pubs. Assumes that the unique
             layers used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
@@ -85,7 +85,7 @@ def prepare_pea(
         IBMInputValueError: If pubs have mismatched precision,
             if a circuit contains mid-circuit measurements, or if a circuit already uses the
             reserved classical register name ``_meas``.
-        IBMInputValueError: If ``noise_model`` is missing a noise map for at least one of
+        IBMInputValueError: If noise_model is missing a noise map for at least one of
             the pubs layers.
         IBMInputValueError: If ``noise_factors`` is under-specified for the requested extrapolator.
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -67,7 +67,7 @@ def prepare_pea(
         measure_noise_learning: The measure noise learning options. If provided, Twirled Readout
             Error eXtinction (TREX) mitigation method will be used.
         zne_options: The options for PEA mitigation (which have the same options as ZNE).
-        noise_model: Mapping between layer ref to a noise model to use for noise
+        noise_model: Mapping between layer ref to a noise model to use for noise.
             amplification. The dict contains layers from all pubs. Assumes that the unique
             layers used for noise learning were extracted using the ``find_unique_layers`` method.
         add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.

--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -49,7 +49,7 @@ class ResilienceOptions(BaseOptionsModel):
     If you enable PEC, you can fine-tune its options by using :attr:`~pec`. See
     :class:`PecOptions` for additional PEC-related options.
 
-    You must also provide a noise model via :attr:`~noise_model_mapping` when enabling PEC.
+    You must also provide a noise model via :attr:`~noise_mapping` when enabling PEC.
     """
 
     pec: PecOptions = PecOptions()
@@ -69,7 +69,7 @@ class ResilienceOptions(BaseOptionsModel):
     zne: ZneOptions = ZneOptions()
     """Additional zero noise extrapolation mitigation options."""
 
-    noise_model_mapping: dict[str, Annotated[PauliLindbladMap, InstanceOf]] = {}
+    noise_mapping: dict[str, Annotated[PauliLindbladMap, InstanceOf]] = {}
     """A noise model mapping for PEC mitigation.
 
     Maps layer references (strings) to :class:`~qiskit.quantum_info.PauliLindbladMap` objects that

--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -49,7 +49,7 @@ class ResilienceOptions(BaseOptionsModel):
     If you enable PEC, you can fine-tune its options by using :attr:`~pec`. See
     :class:`PecOptions` for additional PEC-related options.
 
-    You must also provide a noise model via :attr:`~noise_mapping` when enabling PEC.
+    You must also provide a noise model via :attr:`~noise_model` when enabling PEC.
     """
 
     pec: PecOptions = PecOptions()
@@ -69,7 +69,7 @@ class ResilienceOptions(BaseOptionsModel):
     zne: ZneOptions = ZneOptions()
     """Additional zero noise extrapolation mitigation options."""
 
-    noise_mapping: dict[str, Annotated[PauliLindbladMap, InstanceOf]] = {}
+    noise_model: dict[str, Annotated[PauliLindbladMap, InstanceOf]] = {}
     """A noise model mapping for PEC mitigation.
 
     Maps layer references (strings) to :class:`~qiskit.quantum_info.PauliLindbladMap` objects that

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -133,7 +133,7 @@ class TestEstimator(IBMIntegrationTestCase):
             for layer in layers
             if (annotation := get_annotation(layer.operation, InjectNoise))
         }
-        estimator.options.resilience.noise_model_mapping = noise_model
+        estimator.options.resilience.noise_mapping = noise_model
 
         job = estimator.run(pubs)
         results = job.result()

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -103,7 +103,7 @@ class TestEstimator(IBMIntegrationTestCase):
         estimator.options.resilience.pec_mitigation = True
 
         layers = estimator.find_unique_layers(self.pubs)
-        estimator.options.resilience.noise_model_mapping = {
+        estimator.options.resilience.noise_model = {
             annotation.ref: PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.001)])
             for layer in layers
             if (annotation := get_annotation(layer.operation, InjectNoise))
@@ -139,7 +139,7 @@ class TestEstimator(IBMIntegrationTestCase):
 
         if amplifier == "pea":
             layers = estimator.find_unique_layers(self.pubs)
-            estimator.options.resilience.noise_model_mapping = {
+            estimator.options.resilience.noise_model = {
                 annotation.ref: PauliLindbladMap.from_list(
                     [("X" * layer.operation.num_qubits, 0.001)]
                 )

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -25,6 +25,7 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_ibm_runtime.executor_estimator import EstimatorV2
 from qiskit_ibm_runtime.fake_provider import FakeManilaV2
 from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
+from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ....ibm_test_case import IBMTestCase
 from ....utils import make_mirror_circuit_with_phases
@@ -90,7 +91,10 @@ class TestEstimator(IBMTestCase):
                 resilience_level=resilience_level,
                 # Local mode means that the underlying Executor is running Aer simulation
                 # instead of connecting to a real backend.
-                experimental={"local_mode": True},
+                experimental={
+                    "local_mode": True,
+                    "simulator_options": ExperimentalSimulatorOptions(seed_simulator=42),
+                },
             )
 
             estimator = EstimatorV2(mode=self.backend, options=options)

--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -80,7 +80,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     zne_options=zne_options,
-                    noise_model_mapping={},
+                    noise_mapping={},
                     measure_noise_learning=measure_noise_learning,
                 )
 
@@ -117,7 +117,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         # options produce different layer refs.
         pubs = [scenario.pub for scenario in SAMPLEX_CIRCUIT_SCENARIOS]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_model_mapping = {
+        noise_mapping = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -133,7 +133,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     zne_options=zne_options,
-                    noise_model_mapping=noise_model_mapping,
+                    noise_mapping=noise_mapping,
                     measure_noise_learning=measure_noise_learning,
                 )
                 # PEA always requires enable_gates=True
@@ -158,7 +158,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         scenario = TEMPLATE_CIRCUIT_SCENARIO
         pubs = [scenario.pub]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_model_mapping = {
+        noise_mapping = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -172,7 +172,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             twirling_options=twirling_options,
             shots=10,
             zne_options=zne_options,
-            noise_model_mapping=noise_model_mapping,
+            noise_mapping=noise_mapping,
         )
         self.assertTemplateCircuitIsCorrect(program.items[0], scenario, enable_gates=True)
 
@@ -196,7 +196,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -208,9 +208,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pea(
-            [pub], twirling_options, shots, zne_options, noise_model_mapping
-        )
+        quantum_program = prepare_pea([pub], twirling_options, shots, zne_options, noise_mapping)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, 64)
@@ -229,7 +227,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_model_mapping[noise_layer_ref],
+            noise_mapping[noise_layer_ref],
         )
 
         # Check that samplex_arguments contains noise_scales for the layer
@@ -282,7 +280,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_refs.append(annot.ref)
 
-        noise_model_mapping = {
+        noise_mapping = {
             noise_layer_refs[0]: noise_model_1,
             noise_layer_refs[1]: noise_model_2a,
             noise_layer_refs[2]: noise_model_2b,
@@ -299,7 +297,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
 
         shots = 2048
         quantum_program = prepare_pea(
-            [pub1, pub2], twirling_options, shots, zne_options, noise_model_mapping
+            [pub1, pub2], twirling_options, shots, zne_options, noise_mapping
         )
 
         self.assertEqual(len(quantum_program.items), 2)
@@ -309,7 +307,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[0]}", item1.samplex_arguments)
         self.assertEqual(
             item1.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[0]}"],
-            noise_model_mapping[noise_layer_refs[0]],
+            noise_mapping[noise_layer_refs[0]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[0]}", item1.samplex_arguments)
         # noise_scales shape is (num_noise_factors, 1, 1)
@@ -327,11 +325,11 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[2]}", item2.samplex_arguments)
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[1]}"],
-            noise_model_mapping[noise_layer_refs[1]],
+            noise_mapping[noise_layer_refs[1]],
         )
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[2]}"],
-            noise_model_mapping[noise_layer_refs[2]],
+            noise_mapping[noise_layer_refs[2]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[1]}", item2.samplex_arguments)
         self.assertIn(f"noise_scales.{noise_layer_refs[2]}", item2.samplex_arguments)
@@ -358,8 +356,8 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             )
         )
 
-    def test_prepare_pea_raises_error_with_empty_noise_model_mapping(self):
-        """Test that prepare_pea raises error when noise_model_mapping is empty."""
+    def test_prepare_pea_raises_error_with_empty_noise_mapping(self):
+        """Test that prepare_pea raises error when noise_mapping is empty."""
         circuit = QuantumCircuit(2)
         circuit.h(0)
         circuit.cx(0, 1)
@@ -380,7 +378,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             prepare_pea([pub], twirling_options, 1024, zne_options, {})
 
     def test_prepare_pea_raises_error_with_missing_noise_model_key(self):
-        """Test that prepare_pea raises error when noise_model_mapping is missing a noise model."""
+        """Test that prepare_pea raises error when noise_mapping is missing a noise model."""
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
         circuit1.cx(0, 1)
@@ -402,7 +400,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref_pub1 = annot.ref
 
-        noise_model_mapping = {noise_layer_ref_pub1: noise_model}
+        noise_mapping = {noise_layer_ref_pub1: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -414,7 +412,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
-            prepare_pea([pub1, pub2], twirling_options, 1024, zne_options, noise_model_mapping)
+            prepare_pea([pub1, pub2], twirling_options, 1024, zne_options, noise_mapping)
 
     def test_prepare_pea_with_measure_noise_learning(self):
         """Test prepare_pea with measure noise learning (TREX)."""
@@ -438,7 +436,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -453,7 +451,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             twirling_options,
             1024,
             zne_options,
-            noise_model_mapping,
+            noise_mapping,
             measure_noise_learning,
         )
 
@@ -465,7 +463,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_model_mapping[noise_layer_ref],
+            noise_mapping[noise_layer_ref],
         )
         self.assertIn(f"noise_scales.{noise_layer_ref}", item.samplex_arguments)
         # noise_scales shape is (num_noise_factors, 1, 1)
@@ -516,7 +514,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -528,9 +526,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pea(
-            [pub], twirling_options, shots, zne_options, noise_model_mapping
-        )
+        quantum_program = prepare_pea([pub], twirling_options, shots, zne_options, noise_mapping)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(len(quantum_program.items), 1)
@@ -618,5 +614,5 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             IBMInputValueError, "double_exponential requires at least 4 noise_factors"
         ):
             prepare_pea(
-                [pub], twirling_options, shots=100, zne_options=zne_options, noise_model_mapping={}
+                [pub], twirling_options, shots=100, zne_options=zne_options, noise_mapping={}
             )

--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -117,7 +117,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         # options produce different layer refs.
         pubs = [scenario.pub for scenario in SAMPLEX_CIRCUIT_SCENARIOS]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_mapping = {
+        noise_model = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -133,7 +133,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     zne_options=zne_options,
-                    noise_model=noise_mapping,
+                    noise_model=noise_model,
                     measure_noise_learning=measure_noise_learning,
                 )
                 # PEA always requires enable_gates=True
@@ -158,7 +158,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         scenario = TEMPLATE_CIRCUIT_SCENARIO
         pubs = [scenario.pub]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_mapping = {
+        noise_model = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -172,7 +172,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             twirling_options=twirling_options,
             shots=10,
             zne_options=zne_options,
-            noise_model=noise_mapping,
+            noise_model=noise_model,
         )
         self.assertTemplateCircuitIsCorrect(program.items[0], scenario, enable_gates=True)
 
@@ -196,7 +196,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -208,7 +208,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pea([pub], twirling_options, shots, zne_options, noise_mapping)
+        quantum_program = prepare_pea([pub], twirling_options, shots, zne_options, noise_model)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, 64)
@@ -227,7 +227,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_mapping[noise_layer_ref],
+            noise_model[noise_layer_ref],
         )
 
         # Check that samplex_arguments contains noise_scales for the layer
@@ -280,7 +280,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_refs.append(annot.ref)
 
-        noise_mapping = {
+        noise_model = {
             noise_layer_refs[0]: noise_model_1,
             noise_layer_refs[1]: noise_model_2a,
             noise_layer_refs[2]: noise_model_2b,
@@ -297,7 +297,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
 
         shots = 2048
         quantum_program = prepare_pea(
-            [pub1, pub2], twirling_options, shots, zne_options, noise_mapping
+            [pub1, pub2], twirling_options, shots, zne_options, noise_model
         )
 
         self.assertEqual(len(quantum_program.items), 2)
@@ -307,7 +307,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[0]}", item1.samplex_arguments)
         self.assertEqual(
             item1.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[0]}"],
-            noise_mapping[noise_layer_refs[0]],
+            noise_model[noise_layer_refs[0]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[0]}", item1.samplex_arguments)
         # noise_scales shape is (num_noise_factors, 1, 1)
@@ -325,11 +325,11 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[2]}", item2.samplex_arguments)
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[1]}"],
-            noise_mapping[noise_layer_refs[1]],
+            noise_model[noise_layer_refs[1]],
         )
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[2]}"],
-            noise_mapping[noise_layer_refs[2]],
+            noise_model[noise_layer_refs[2]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[1]}", item2.samplex_arguments)
         self.assertIn(f"noise_scales.{noise_layer_refs[2]}", item2.samplex_arguments)
@@ -356,8 +356,8 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             )
         )
 
-    def test_prepare_pea_raises_error_with_empty_noise_mapping(self):
-        """Test that prepare_pea raises error when noise_mapping is empty."""
+    def test_prepare_pea_raises_error_with_empty_noise_model(self):
+        """Test that prepare_pea raises error when noise_model is empty."""
         circuit = QuantumCircuit(2)
         circuit.h(0)
         circuit.cx(0, 1)
@@ -378,7 +378,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             prepare_pea([pub], twirling_options, 1024, zne_options, {})
 
     def test_prepare_pea_raises_error_with_missing_noise_model_key(self):
-        """Test that prepare_pea raises error when noise_mapping is missing a noise model."""
+        """Test that prepare_pea raises error when noise_model is missing a noise model."""
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
         circuit1.cx(0, 1)
@@ -400,7 +400,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref_pub1 = annot.ref
 
-        noise_mapping = {noise_layer_ref_pub1: noise_model}
+        noise_model = {noise_layer_ref_pub1: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -412,7 +412,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
-            prepare_pea([pub1, pub2], twirling_options, 1024, zne_options, noise_mapping)
+            prepare_pea([pub1, pub2], twirling_options, 1024, zne_options, noise_model)
 
     def test_prepare_pea_with_measure_noise_learning(self):
         """Test prepare_pea with measure noise learning (TREX)."""
@@ -436,7 +436,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -451,7 +451,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             twirling_options,
             1024,
             zne_options,
-            noise_mapping,
+            noise_model,
             measure_noise_learning,
         )
 
@@ -463,7 +463,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_mapping[noise_layer_ref],
+            noise_model[noise_layer_ref],
         )
         self.assertIn(f"noise_scales.{noise_layer_ref}", item.samplex_arguments)
         # noise_scales shape is (num_noise_factors, 1, 1)
@@ -514,7 +514,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         noise_factors = [1, 1.5, 2, 2.5, 3]
         zne_options = ZneOptions()
@@ -526,7 +526,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pea([pub], twirling_options, shots, zne_options, noise_mapping)
+        quantum_program = prepare_pea([pub], twirling_options, shots, zne_options, noise_model)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(len(quantum_program.items), 1)

--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -80,7 +80,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     zne_options=zne_options,
-                    noise_mapping={},
+                    noise_model={},
                     measure_noise_learning=measure_noise_learning,
                 )
 
@@ -133,7 +133,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     zne_options=zne_options,
-                    noise_mapping=noise_mapping,
+                    noise_model=noise_mapping,
                     measure_noise_learning=measure_noise_learning,
                 )
                 # PEA always requires enable_gates=True
@@ -172,7 +172,7 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             twirling_options=twirling_options,
             shots=10,
             zne_options=zne_options,
-            noise_mapping=noise_mapping,
+            noise_model=noise_mapping,
         )
         self.assertTemplateCircuitIsCorrect(program.items[0], scenario, enable_gates=True)
 
@@ -613,6 +613,4 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
         with self.assertRaisesRegex(
             IBMInputValueError, "double_exponential requires at least 4 noise_factors"
         ):
-            prepare_pea(
-                [pub], twirling_options, shots=100, zne_options=zne_options, noise_mapping={}
-            )
+            prepare_pea([pub], twirling_options, shots=100, zne_options=zne_options, noise_model={})

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -49,16 +49,16 @@ class TestCalculateGamma(IBMTestCase):
             circuit.cx(0, 1)
 
         # Create a two-qubit noise model with known gamma
-        noise_model = PauliLindbladMap.from_sparse_list(
+        model = PauliLindbladMap.from_sparse_list(
             [("ZX", [0, 1], 0.1), ("XZ", [0, 1], 0.1)], num_qubits=2
         )
-        noise_mapping = {"layer_0": noise_model}
+        noise_model = {"layer_0": model}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_model, noise_factor)
 
         # Expected gamma is the gamma of the noise model
-        expected_gamma = noise_model.inverse().gamma()
+        expected_gamma = model.inverse().gamma()
         self.assertAlmostEqual(result, expected_gamma)
 
     def test_calculates_gamma_for_multiple_noisy_gates(self):
@@ -76,10 +76,10 @@ class TestCalculateGamma(IBMTestCase):
         noise_model_1 = PauliLindbladMap.from_sparse_list(
             [("XY", [1, 2], 0.2), ("ZX", [1, 2], 0.15)], num_qubits=3
         )
-        noise_mapping = {"layer_0": noise_model_0, "layer_1": noise_model_1}
+        noise_model = {"layer_0": noise_model_0, "layer_1": noise_model_1}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_model, noise_factor)
 
         # Expected gamma is the product of individual gammas
         expected_gamma = noise_model_0.inverse().gamma() * noise_model_1.inverse().gamma()
@@ -98,10 +98,10 @@ class TestCalculateGamma(IBMTestCase):
 
         # Create noise models
         noise_model_0 = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
-        noise_mapping = {"layer_0": noise_model_0}
+        noise_model = {"layer_0": noise_model_0}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_model, noise_factor)
 
         # Expected gamma is the product of individual gammas
         expected_gamma = noise_model_0.inverse().gamma() * noise_model_0.inverse().gamma()
@@ -115,10 +115,10 @@ class TestCalculateGamma(IBMTestCase):
             circuit.h(0)
             circuit.cx(0, 1)
 
-        noise_mapping = {}
+        noise_model = {}
         noise_factor = 1.0
 
-        result = calculate_gamma(circuit, noise_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_model, noise_factor)
 
         # Gamma should be 1.0 for noiseless circuit
         self.assertEqual(result, 1.0)
@@ -136,11 +136,11 @@ class TestCalculateGamma(IBMTestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("XX", [0, 1], err_rate), ("XZ", [0, 1], err_rate)], num_qubits=2
         )
-        noise_mapping = {"layer_0": noise_model}
+        noise_model = {"layer_0": noise_model}
 
         # Test with different noise factors
         noise_factor = 2.0
-        result = calculate_gamma(circuit, noise_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_model, noise_factor)
 
         # Expected gamma with amplified noise
         # gamma = w + abs(1-w), w = 0.5*(1+e^(-2*err))
@@ -167,10 +167,10 @@ class TestCalculateGamma(IBMTestCase):
         noise_model_1 = PauliLindbladMap.from_sparse_list(
             [("XZ", [1, 2], 0.15), ("XY", [1, 2], 0.2)], num_qubits=3
         )
-        noise_mapping = {"layer_0": noise_model_0, "layer_1": noise_model_1}
+        noise_model = {"layer_0": noise_model_0, "layer_1": noise_model_1}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_model, noise_factor)
 
         # Expected gamma is product of only the noisy gates
         expected_gamma = noise_model_0.inverse().gamma() * noise_model_1.inverse().gamma()
@@ -187,17 +187,17 @@ class TestCalculateGamma(IBMTestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("IX", [0, 1], 0.1), ("XI", [0, 1], 0.1)], num_qubits=2
         )
-        noise_mapping = {"layer_0": noise_model}
+        noise_model = {"layer_0": noise_model}
 
         # With zero noise factor, the noise is effectively removed
         noise_factor = 0.0
-        result = calculate_gamma(circuit, noise_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_model, noise_factor)
 
         # Gamma should be 1.0 when noise is scaled to zero
         self.assertAlmostEqual(result, 1.0)
 
     def test_missing_map_raises(self):
-        """Test that gamma calculation raises if maps are missing from ``noise_mapping``."""
+        """Test that gamma calculation raises if maps are missing from ``noise_model``."""
         # Create a simple circuit with one two-qubit gate annotated with noise
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[InjectNoise(ref="ref", site="after")]):
@@ -208,10 +208,10 @@ class TestCalculateGamma(IBMTestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("ZX", [0, 1], 0.1), ("XZ", [0, 1], 0.1)], num_qubits=2
         )
-        noise_mapping = {"another_ref": noise_model}
+        noise_model = {"another_ref": noise_model}
 
         with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
-            calculate_gamma(circuit, noise_mapping, noise_factor=1)
+            calculate_gamma(circuit, noise_model, noise_factor=1)
 
 
 @ddt
@@ -284,7 +284,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         # options produce different layer refs.
         pubs = [scenario.pub for scenario in SAMPLEX_CIRCUIT_SCENARIOS]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_mapping = {
+        noise_model = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -300,7 +300,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     pec_options=PecOptions(),
-                    noise_model=noise_mapping,
+                    noise_model=noise_model,
                     measure_noise_learning=measure_noise_learning,
                 )
                 # PEC always requires enable_gates=True
@@ -321,7 +321,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         scenario = TEMPLATE_CIRCUIT_SCENARIO
         pubs = [scenario.pub]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_mapping = {
+        noise_model = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -335,7 +335,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             twirling_options=twirling_options,
             shots=10,
             pec_options=PecOptions(),
-            noise_model=noise_mapping,
+            noise_model=noise_model,
         )
         self.assertTemplateCircuitIsCorrect(program.items[0], scenario, enable_gates=True)
 
@@ -359,7 +359,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -369,7 +369,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_mapping)
+        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_model)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, 64)
@@ -383,7 +383,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_mapping[noise_layer_ref],
+            noise_model[noise_layer_ref],
         )
 
         # Check that samplex_arguments contains noise_scales for the layer
@@ -435,7 +435,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_refs.append(annot.ref)
 
-        noise_mapping = {
+        noise_model = {
             noise_layer_refs[0]: noise_model_1,
             noise_layer_refs[1]: noise_model_2a,
             noise_layer_refs[2]: noise_model_2b,
@@ -450,7 +450,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
 
         shots = 2048
         quantum_program = prepare_pec(
-            [pub1, pub2], twirling_options, shots, pec_options, noise_mapping
+            [pub1, pub2], twirling_options, shots, pec_options, noise_model
         )
 
         self.assertEqual(len(quantum_program.items), 2)
@@ -460,7 +460,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[0]}", item1.samplex_arguments)
         self.assertEqual(
             item1.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[0]}"],
-            noise_mapping[noise_layer_refs[0]],
+            noise_model[noise_layer_refs[0]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[0]}", item1.samplex_arguments)
 
@@ -470,11 +470,11 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[2]}", item2.samplex_arguments)
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[1]}"],
-            noise_mapping[noise_layer_refs[1]],
+            noise_model[noise_layer_refs[1]],
         )
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[2]}"],
-            noise_mapping[noise_layer_refs[2]],
+            noise_model[noise_layer_refs[2]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[1]}", item2.samplex_arguments)
         self.assertIn(f"noise_scales.{noise_layer_refs[2]}", item2.samplex_arguments)
@@ -503,7 +503,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = "auto"  # Should default to 0
@@ -514,7 +514,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_mapping)
+        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_model)
 
         item = cast("SamplexItem", quantum_program.items[0])
 
@@ -526,8 +526,8 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], expected_noise_gain
         )
 
-    def test_prepare_pec_raises_error_with_empty_noise_mapping(self):
-        """Test that prepare_pec raises error when noise_mapping is empty."""
+    def test_prepare_pec_raises_error_with_empty_noise_model(self):
+        """Test that prepare_pec raises error when noise_model is empty."""
         circuit = QuantumCircuit(2)
         circuit.h(0)
         circuit.cx(0, 1)
@@ -546,7 +546,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             prepare_pec([pub], twirling_options, 1024, pec_options, {})
 
     def test_prepare_pec_raises_error_with_missing_noise_model_key(self):
-        """Test that prepare_pec raises error when noise_mapping is missing a noise model."""
+        """Test that prepare_pec raises error when noise_model is missing a noise model."""
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
         circuit1.cx(0, 1)
@@ -568,7 +568,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -578,7 +578,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
-            prepare_pec([pub1, pub2], twirling_options, 1024, pec_options, noise_mapping)
+            prepare_pec([pub1, pub2], twirling_options, 1024, pec_options, noise_model)
 
     def test_prepare_pec_with_measure_noise_learning(self):
         """Test prepare_pec with measure noise learning (TREX)."""
@@ -597,7 +597,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -610,7 +610,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         quantum_program = prepare_pec(
-            [pub], twirling_options, 1024, pec_options, noise_mapping, measure_noise_learning
+            [pub], twirling_options, 1024, pec_options, noise_model, measure_noise_learning
         )
 
         # Should have 2 items: 1 for pub + 1 TREX calibration
@@ -621,7 +621,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_mapping[noise_layer_ref],
+            noise_model[noise_layer_ref],
         )
         self.assertIn(f"noise_scales.{noise_layer_ref}", item.samplex_arguments)
         expected_noise_factor = pec_options.noise_gain - 1
@@ -649,7 +649,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
-        noise_mapping = {noise_layer_ref: PauliLindbladMap.identity(num_qubits=2)}
+        noise_model = {noise_layer_ref: PauliLindbladMap.identity(num_qubits=2)}
 
         pec_options = PecOptions()
         twirling_options = TwirlingOptions()
@@ -657,7 +657,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_mapping)
+        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_model)
         item = cast("SamplexItem", quantum_program.items[0])
         self.assertEqual(item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], 0)
 
@@ -682,7 +682,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         noise_layer_ref = next(
             annot.ref for layer in layers if (annot := get_annotation(layer.operation, InjectNoise))
         )
-        noise_mapping = {noise_layer_ref: noise_model}
+        noise_model = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -691,9 +691,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_gates = True
         twirling_options.enable_measure = True
 
-        quantum_program = prepare_pec(
-            [pub, pub], twirling_options, 1024, pec_options, noise_mapping
-        )
+        quantum_program = prepare_pec([pub, pub], twirling_options, 1024, pec_options, noise_model)
 
         item0 = cast("SamplexItem", quantum_program.items[0])
         item1 = cast("SamplexItem", quantum_program.items[1])

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -52,10 +52,10 @@ class TestCalculateGamma(IBMTestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("ZX", [0, 1], 0.1), ("XZ", [0, 1], 0.1)], num_qubits=2
         )
-        noise_model_mapping = {"layer_0": noise_model}
+        noise_mapping = {"layer_0": noise_model}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_model_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_mapping, noise_factor)
 
         # Expected gamma is the gamma of the noise model
         expected_gamma = noise_model.inverse().gamma()
@@ -76,10 +76,10 @@ class TestCalculateGamma(IBMTestCase):
         noise_model_1 = PauliLindbladMap.from_sparse_list(
             [("XY", [1, 2], 0.2), ("ZX", [1, 2], 0.15)], num_qubits=3
         )
-        noise_model_mapping = {"layer_0": noise_model_0, "layer_1": noise_model_1}
+        noise_mapping = {"layer_0": noise_model_0, "layer_1": noise_model_1}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_model_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_mapping, noise_factor)
 
         # Expected gamma is the product of individual gammas
         expected_gamma = noise_model_0.inverse().gamma() * noise_model_1.inverse().gamma()
@@ -98,10 +98,10 @@ class TestCalculateGamma(IBMTestCase):
 
         # Create noise models
         noise_model_0 = PauliLindbladMap.from_sparse_list([("XX", [0, 1], 0.1)], num_qubits=2)
-        noise_model_mapping = {"layer_0": noise_model_0}
+        noise_mapping = {"layer_0": noise_model_0}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_model_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_mapping, noise_factor)
 
         # Expected gamma is the product of individual gammas
         expected_gamma = noise_model_0.inverse().gamma() * noise_model_0.inverse().gamma()
@@ -115,10 +115,10 @@ class TestCalculateGamma(IBMTestCase):
             circuit.h(0)
             circuit.cx(0, 1)
 
-        noise_model_mapping = {}
+        noise_mapping = {}
         noise_factor = 1.0
 
-        result = calculate_gamma(circuit, noise_model_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_mapping, noise_factor)
 
         # Gamma should be 1.0 for noiseless circuit
         self.assertEqual(result, 1.0)
@@ -136,11 +136,11 @@ class TestCalculateGamma(IBMTestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("XX", [0, 1], err_rate), ("XZ", [0, 1], err_rate)], num_qubits=2
         )
-        noise_model_mapping = {"layer_0": noise_model}
+        noise_mapping = {"layer_0": noise_model}
 
         # Test with different noise factors
         noise_factor = 2.0
-        result = calculate_gamma(circuit, noise_model_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_mapping, noise_factor)
 
         # Expected gamma with amplified noise
         # gamma = w + abs(1-w), w = 0.5*(1+e^(-2*err))
@@ -167,10 +167,10 @@ class TestCalculateGamma(IBMTestCase):
         noise_model_1 = PauliLindbladMap.from_sparse_list(
             [("XZ", [1, 2], 0.15), ("XY", [1, 2], 0.2)], num_qubits=3
         )
-        noise_model_mapping = {"layer_0": noise_model_0, "layer_1": noise_model_1}
+        noise_mapping = {"layer_0": noise_model_0, "layer_1": noise_model_1}
 
         noise_factor = 1.0
-        result = calculate_gamma(circuit, noise_model_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_mapping, noise_factor)
 
         # Expected gamma is product of only the noisy gates
         expected_gamma = noise_model_0.inverse().gamma() * noise_model_1.inverse().gamma()
@@ -187,17 +187,17 @@ class TestCalculateGamma(IBMTestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("IX", [0, 1], 0.1), ("XI", [0, 1], 0.1)], num_qubits=2
         )
-        noise_model_mapping = {"layer_0": noise_model}
+        noise_mapping = {"layer_0": noise_model}
 
         # With zero noise factor, the noise is effectively removed
         noise_factor = 0.0
-        result = calculate_gamma(circuit, noise_model_mapping, noise_factor)
+        result = calculate_gamma(circuit, noise_mapping, noise_factor)
 
         # Gamma should be 1.0 when noise is scaled to zero
         self.assertAlmostEqual(result, 1.0)
 
     def test_missing_map_raises(self):
-        """Test that gamma calculation raises if maps are missing from ``noise_model_mapping``."""
+        """Test that gamma calculation raises if maps are missing from ``noise_mapping``."""
         # Create a simple circuit with one two-qubit gate annotated with noise
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[InjectNoise(ref="ref", site="after")]):
@@ -208,10 +208,10 @@ class TestCalculateGamma(IBMTestCase):
         noise_model = PauliLindbladMap.from_sparse_list(
             [("ZX", [0, 1], 0.1), ("XZ", [0, 1], 0.1)], num_qubits=2
         )
-        noise_model_mapping = {"another_ref": noise_model}
+        noise_mapping = {"another_ref": noise_model}
 
         with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
-            calculate_gamma(circuit, noise_model_mapping, noise_factor=1)
+            calculate_gamma(circuit, noise_mapping, noise_factor=1)
 
 
 @ddt
@@ -254,7 +254,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     pec_options=PecOptions(),
-                    noise_model_mapping={},
+                    noise_mapping={},
                     measure_noise_learning=measure_noise_learning,
                 )
 
@@ -284,7 +284,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         # options produce different layer refs.
         pubs = [scenario.pub for scenario in SAMPLEX_CIRCUIT_SCENARIOS]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_model_mapping = {
+        noise_mapping = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -300,7 +300,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     pec_options=PecOptions(),
-                    noise_model_mapping=noise_model_mapping,
+                    noise_mapping=noise_mapping,
                     measure_noise_learning=measure_noise_learning,
                 )
                 # PEC always requires enable_gates=True
@@ -321,7 +321,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         scenario = TEMPLATE_CIRCUIT_SCENARIO
         pubs = [scenario.pub]
         layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
-        noise_model_mapping = {
+        noise_mapping = {
             annot.ref: PauliLindbladMap.from_sparse_list(
                 [("Z" * len(layer.qubits), list(range(len(layer.qubits))), 0.1)],
                 num_qubits=len(layer.qubits),
@@ -335,7 +335,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             twirling_options=twirling_options,
             shots=10,
             pec_options=PecOptions(),
-            noise_model_mapping=noise_model_mapping,
+            noise_mapping=noise_mapping,
         )
         self.assertTemplateCircuitIsCorrect(program.items[0], scenario, enable_gates=True)
 
@@ -359,7 +359,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -369,9 +369,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pec(
-            [pub], twirling_options, shots, pec_options, noise_model_mapping
-        )
+        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_mapping)
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, 64)
@@ -385,7 +383,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_model_mapping[noise_layer_ref],
+            noise_mapping[noise_layer_ref],
         )
 
         # Check that samplex_arguments contains noise_scales for the layer
@@ -437,7 +435,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_refs.append(annot.ref)
 
-        noise_model_mapping = {
+        noise_mapping = {
             noise_layer_refs[0]: noise_model_1,
             noise_layer_refs[1]: noise_model_2a,
             noise_layer_refs[2]: noise_model_2b,
@@ -452,7 +450,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
 
         shots = 2048
         quantum_program = prepare_pec(
-            [pub1, pub2], twirling_options, shots, pec_options, noise_model_mapping
+            [pub1, pub2], twirling_options, shots, pec_options, noise_mapping
         )
 
         self.assertEqual(len(quantum_program.items), 2)
@@ -462,7 +460,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[0]}", item1.samplex_arguments)
         self.assertEqual(
             item1.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[0]}"],
-            noise_model_mapping[noise_layer_refs[0]],
+            noise_mapping[noise_layer_refs[0]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[0]}", item1.samplex_arguments)
 
@@ -472,11 +470,11 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_refs[2]}", item2.samplex_arguments)
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[1]}"],
-            noise_model_mapping[noise_layer_refs[1]],
+            noise_mapping[noise_layer_refs[1]],
         )
         self.assertEqual(
             item2.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_refs[2]}"],
-            noise_model_mapping[noise_layer_refs[2]],
+            noise_mapping[noise_layer_refs[2]],
         )
         self.assertIn(f"noise_scales.{noise_layer_refs[1]}", item2.samplex_arguments)
         self.assertIn(f"noise_scales.{noise_layer_refs[2]}", item2.samplex_arguments)
@@ -505,7 +503,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = "auto"  # Should default to 0
@@ -516,9 +514,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pec(
-            [pub], twirling_options, shots, pec_options, noise_model_mapping
-        )
+        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_mapping)
 
         item = cast("SamplexItem", quantum_program.items[0])
 
@@ -530,8 +526,8 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], expected_noise_gain
         )
 
-    def test_prepare_pec_raises_error_with_empty_noise_model_mapping(self):
-        """Test that prepare_pec raises error when noise_model_mapping is empty."""
+    def test_prepare_pec_raises_error_with_empty_noise_mapping(self):
+        """Test that prepare_pec raises error when noise_mapping is empty."""
         circuit = QuantumCircuit(2)
         circuit.h(0)
         circuit.cx(0, 1)
@@ -550,7 +546,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             prepare_pec([pub], twirling_options, 1024, pec_options, {})
 
     def test_prepare_pec_raises_error_with_missing_noise_model_key(self):
-        """Test that prepare_pec raises error when noise_model_mapping is missing a noise model."""
+        """Test that prepare_pec raises error when noise_mapping is missing a noise model."""
         circuit1 = QuantumCircuit(2)
         circuit1.h(0)
         circuit1.cx(0, 1)
@@ -572,7 +568,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -582,7 +578,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         with self.assertRaisesRegex(IBMInputValueError, "Noise model is missing"):
-            prepare_pec([pub1, pub2], twirling_options, 1024, pec_options, noise_model_mapping)
+            prepare_pec([pub1, pub2], twirling_options, 1024, pec_options, noise_mapping)
 
     def test_prepare_pec_with_measure_noise_learning(self):
         """Test prepare_pec with measure noise learning (TREX)."""
@@ -601,7 +597,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
 
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -614,7 +610,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         quantum_program = prepare_pec(
-            [pub], twirling_options, 1024, pec_options, noise_model_mapping, measure_noise_learning
+            [pub], twirling_options, 1024, pec_options, noise_mapping, measure_noise_learning
         )
 
         # Should have 2 items: 1 for pub + 1 TREX calibration
@@ -625,7 +621,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertIn(f"pauli_lindblad_maps.{noise_layer_ref}", item.samplex_arguments)
         self.assertEqual(
             item.samplex_arguments[f"pauli_lindblad_maps.{noise_layer_ref}"],
-            noise_model_mapping[noise_layer_ref],
+            noise_mapping[noise_layer_ref],
         )
         self.assertIn(f"noise_scales.{noise_layer_ref}", item.samplex_arguments)
         expected_noise_factor = pec_options.noise_gain - 1
@@ -653,7 +649,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         for layer in layers:
             if annot := get_annotation(layer.operation, InjectNoise):
                 noise_layer_ref = annot.ref
-        noise_model_mapping = {noise_layer_ref: PauliLindbladMap.identity(num_qubits=2)}
+        noise_mapping = {noise_layer_ref: PauliLindbladMap.identity(num_qubits=2)}
 
         pec_options = PecOptions()
         twirling_options = TwirlingOptions()
@@ -661,9 +657,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         shots = 1024
-        quantum_program = prepare_pec(
-            [pub], twirling_options, shots, pec_options, noise_model_mapping
-        )
+        quantum_program = prepare_pec([pub], twirling_options, shots, pec_options, noise_mapping)
         item = cast("SamplexItem", quantum_program.items[0])
         self.assertEqual(item.samplex_arguments[f"noise_scales.{noise_layer_ref}"], 0)
 
@@ -688,7 +682,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         noise_layer_ref = next(
             annot.ref for layer in layers if (annot := get_annotation(layer.operation, InjectNoise))
         )
-        noise_model_mapping = {noise_layer_ref: noise_model}
+        noise_mapping = {noise_layer_ref: noise_model}
 
         pec_options = PecOptions()
         pec_options.noise_gain = 0.5
@@ -698,7 +692,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         twirling_options.enable_measure = True
 
         quantum_program = prepare_pec(
-            [pub, pub], twirling_options, 1024, pec_options, noise_model_mapping
+            [pub, pub], twirling_options, 1024, pec_options, noise_mapping
         )
 
         item0 = cast("SamplexItem", quantum_program.items[0])

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -254,7 +254,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     pec_options=PecOptions(),
-                    noise_mapping={},
+                    noise_model={},
                     measure_noise_learning=measure_noise_learning,
                 )
 
@@ -300,7 +300,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
                     twirling_options=twirling_options,
                     shots=10,
                     pec_options=PecOptions(),
-                    noise_mapping=noise_mapping,
+                    noise_model=noise_mapping,
                     measure_noise_learning=measure_noise_learning,
                 )
                 # PEC always requires enable_gates=True
@@ -335,7 +335,7 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
             twirling_options=twirling_options,
             shots=10,
             pec_options=PecOptions(),
-            noise_mapping=noise_mapping,
+            noise_model=noise_mapping,
         )
         self.assertTemplateCircuitIsCorrect(program.items[0], scenario, enable_gates=True)
 

--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -54,7 +54,7 @@ class TestPrepare(IBMTestCase):
         options = EstimatorOptions()
         options.twirling.enable_gates = True
         options.resilience.pec_mitigation = True
-        options.resilience.noise_mapping = {"layer_0": PauliLindbladMap.identity(num_qubits=2)}
+        options.resilience.noise_model = {"layer_0": PauliLindbladMap.identity(num_qubits=2)}
 
         circuit = QuantumCircuit(2)
         circuit.h(0)

--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -54,9 +54,7 @@ class TestPrepare(IBMTestCase):
         options = EstimatorOptions()
         options.twirling.enable_gates = True
         options.resilience.pec_mitigation = True
-        options.resilience.noise_model_mapping = {
-            "layer_0": PauliLindbladMap.identity(num_qubits=2)
-        }
+        options.resilience.noise_mapping = {"layer_0": PauliLindbladMap.identity(num_qubits=2)}
 
         circuit = QuantumCircuit(2)
         circuit.h(0)

--- a/test/unit/options_models/test_resilience.py
+++ b/test/unit/options_models/test_resilience.py
@@ -36,7 +36,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         self.assertFalse(opts.zne_mitigation)
         self.assertEqual(opts.zne.amplifier, "gate_folding")
         self.assertEqual(opts.zne.noise_factors, "auto")
-        self.assertEqual(opts.noise_model_mapping, {})
+        self.assertEqual(opts.noise_mapping, {})
 
     def test_set_all_options(self):
         """All fields accept explicit non-default values."""
@@ -47,7 +47,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
             pec={"max_overhead": 50, "noise_gain": 0.5},
             zne_mitigation=True,
             zne={"amplifier": "gate_folding_front", "noise_factors": [1, 3, 5]},
-            noise_model_mapping={
+            noise_mapping={
                 "layer_0": PauliLindbladMap.identity(num_qubits=1),
                 "layer_1": PauliLindbladMap.identity(num_qubits=1),
             },
@@ -60,7 +60,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         self.assertTrue(opts.zne_mitigation)
         self.assertEqual(opts.zne.amplifier, "gate_folding_front")
         self.assertEqual(list(opts.zne.noise_factors), [1, 3, 5])
-        self.assertEqual(set(opts.noise_model_mapping.keys()), {"layer_0", "layer_1"})
+        self.assertEqual(set(opts.noise_mapping.keys()), {"layer_0", "layer_1"})
 
     @data(
         "not_a_dict",
@@ -69,7 +69,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         {"layer_0": "bad_value"},  # non-PauliLindbladMap value
         {"layer_0": None},  # None as a value
     )
-    def test_invalid_noise_model_mapping(self, value):
-        """Invalid noise_model_mapping values raise ValidationError."""
-        with self.assertRaisesRegex(ValidationError, "noise_model_mapping"):
-            ResilienceOptions(noise_model_mapping=value)
+    def test_invalid_noise_mapping(self, value):
+        """Invalid noise_mapping values raise ValidationError."""
+        with self.assertRaisesRegex(ValidationError, "noise_mapping"):
+            ResilienceOptions(noise_mapping=value)

--- a/test/unit/options_models/test_resilience.py
+++ b/test/unit/options_models/test_resilience.py
@@ -36,7 +36,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         self.assertFalse(opts.zne_mitigation)
         self.assertEqual(opts.zne.amplifier, "gate_folding")
         self.assertEqual(opts.zne.noise_factors, "auto")
-        self.assertEqual(opts.noise_mapping, {})
+        self.assertEqual(opts.noise_model, {})
 
     def test_set_all_options(self):
         """All fields accept explicit non-default values."""
@@ -47,7 +47,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
             pec={"max_overhead": 50, "noise_gain": 0.5},
             zne_mitigation=True,
             zne={"amplifier": "gate_folding_front", "noise_factors": [1, 3, 5]},
-            noise_mapping={
+            noise_model={
                 "layer_0": PauliLindbladMap.identity(num_qubits=1),
                 "layer_1": PauliLindbladMap.identity(num_qubits=1),
             },
@@ -60,7 +60,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         self.assertTrue(opts.zne_mitigation)
         self.assertEqual(opts.zne.amplifier, "gate_folding_front")
         self.assertEqual(list(opts.zne.noise_factors), [1, 3, 5])
-        self.assertEqual(set(opts.noise_mapping.keys()), {"layer_0", "layer_1"})
+        self.assertEqual(set(opts.noise_model.keys()), {"layer_0", "layer_1"})
 
     @data(
         "not_a_dict",
@@ -69,7 +69,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         {"layer_0": "bad_value"},  # non-PauliLindbladMap value
         {"layer_0": None},  # None as a value
     )
-    def test_invalid_noise_mapping(self, value):
-        """Invalid noise_mapping values raise ValidationError."""
-        with self.assertRaisesRegex(ValidationError, "noise_mapping"):
-            ResilienceOptions(noise_mapping=value)
+    def test_invalid_noise_model(self, value):
+        """Invalid noise_model values raise ValidationError."""
+        with self.assertRaisesRegex(ValidationError, "noise_model"):
+            ResilienceOptions(noise_model=value)


### PR DESCRIPTION
### Summary
As suggested, here we rename the `noise_model_mapping` option in `ResilienceOptions` (along with other misc instances) to `noise_model` 

### Details and comments

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
