### PR TITLE
Add `group_by` parameter to `NoiseLearnerV3Result.to_dict`

### DIFF
--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -14,12 +14,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 import numpy as np
 from qiskit.circuit import BoxOp
 from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauliList
-from samplomatic import InjectNoise
+from samplomatic import InjectNoise, Tag
 from samplomatic.utils import get_annotation
 
 if TYPE_CHECKING:
@@ -142,19 +142,24 @@ class NoiseLearnerV3Results:
         self,
         instructions: Sequence[CircuitInstruction],
         require_refs: bool = True,
+        group_by: Literal["inject_noise", "tag"] = "inject_noise",
     ) -> dict[int, PauliLindbladMap]:
-        """Convert to dictionary from :attr:`InjectNoise.ref` to :class:`PauliLindbladMap` objects.
+        """Convert to dictionary from references to :class:`PauliLindbladMap` objects.
+
+        References can be one of :attr:`InjectNoise.ref` or :attr:`Tag.ref` depending on
+        ``group_by`` selection.
 
         This function iterates over a sequence of instructions, extracts the ``ref`` value
-        from the inject noise annotation of each instruction, and returns a dictionary mapping
+        from the annotation of each instruction, and returns a dictionary mapping
         those refs to the corresponding noise data (in :class:`PauliLindbladMap` format) stored in
         this :class:`NoiseLearnerV3Results` object.
 
         Args:
             instructions: The instructions to get the refs from.
-            require_refs: Whether to raise if some of the instructions do not own an inject noise
-                annotation. If ``False``, all the instructions that do not contain an inject noise
-                annotations are simply skipped when constructing the returned dictionary.
+            require_refs: Whether to raise if some of the instructions do not own an
+                annotation. If ``False``, all the instructions that do not contain an
+                annotation are simply skipped when constructing the returned dictionary.
+            group_by: Whether to use ``inject_noise`` or ``tag`` annotations.
 
         Raise:
             ValueError: If ``instructions`` contains a number of elements that is not equal to the
@@ -171,10 +176,11 @@ class NoiseLearnerV3Results:
 
         noise_source = {}
         num_instr = 0
+        annotation_type = Tag if group_by == "tag" else InjectNoise
         for instr, datum in zip(instructions, self.data):
             if not isinstance(instr.operation, BoxOp):
                 raise ValueError("Found an instruction that does not contain a box.")
-            if annotation := get_annotation(instr.operation, InjectNoise):
+            if annotation := get_annotation(instr.operation, annotation_type):
                 num_instr += 1
                 noise_source[annotation.ref] = datum.to_pauli_lindblad_map()
             elif require_refs:

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -143,7 +143,7 @@ class NoiseLearnerV3Results:
         instructions: Sequence[CircuitInstruction],
         require_refs: bool = True,
         group_by: Literal["inject_noise", "tag"] = "inject_noise",
-    ) -> dict[int, PauliLindbladMap]:
+    ) -> dict[str, PauliLindbladMap]:
         """Convert to dictionary from references to :class:`PauliLindbladMap` objects.
 
         References can be one of :attr:`InjectNoise.ref` or :attr:`Tag.ref` depending on

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -159,7 +159,7 @@ class NoiseLearnerV3Results:
             require_refs: Whether to raise if some of the instructions do not own an
                 annotation. If ``False``, all the instructions that do not contain an
                 annotation are simply skipped when constructing the returned dictionary.
-            group_by: If ``tag``, it groups by :class:`~.Tag` annotations. Otherwise, by
+            group_by: If ``"tag"``, it groups by :class:`~.Tag` annotations. Otherwise, by
                 :class:`~.InjectNoise` annotations.
 
         Raise:

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -144,7 +144,7 @@ class NoiseLearnerV3Results:
         require_refs: bool = True,
         group_by: Literal["inject_noise", "tag"] = "inject_noise",
     ) -> dict[str, PauliLindbladMap]:
-        """Convert to dictionary from references to :class:`PauliLindbladMap` objects.
+        """Convert to a dictionary from references to :class:`PauliLindbladMap` objects.
 
         References can be one of :attr:`InjectNoise.ref` or :attr:`Tag.ref` depending on
         ``group_by`` selection.

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -159,7 +159,8 @@ class NoiseLearnerV3Results:
             require_refs: Whether to raise if some of the instructions do not own an
                 annotation. If ``False``, all the instructions that do not contain an
                 annotation are simply skipped when constructing the returned dictionary.
-            group_by: Whether to use ``inject_noise`` or ``tag`` annotations.
+            group_by: If ``tag``, it groups by :class:`~.Tag` annotations. Otherwise, by
+                :class:`~.InjectNoise` annotations.
 
         Raise:
             ValueError: If ``instructions`` contains a number of elements that is not equal to the

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -13,9 +13,10 @@
 """Tests the classes `NoiseLearnerV3Result` and `NoiseLearnerV3Results`."""
 
 import numpy as np
+from ddt import data, ddt
 from qiskit import QuantumCircuit
 from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauliList
-from samplomatic import InjectNoise, Twirl
+from samplomatic import InjectNoise, Tag, Twirl
 
 from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Result, NoiseLearnerV3Results
 
@@ -109,6 +110,7 @@ class TestNoiseLearnerV3Result(IBMTestCase):
         )
 
 
+@ddt
 class TestNoiseLearnerV3Results(IBMTestCase):
     """Tests the ``NoiseLearnerV3Results`` class."""
 
@@ -126,6 +128,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         ]
         self.pauli_lindblad_maps = [result.to_pauli_lindblad_map() for result in self.results]
         self.inject_noise_annotations = [InjectNoise(ref, site="after") for ref in ["hi", "bye"]]
+        self.tag_annotations = [Tag(ref) for ref in ["ciao", "arrivederci"]]
 
     def test_properties_of_iterable(self):
         """Test elementary methods of ``NoiseLearnerV3Results``.
@@ -137,96 +140,124 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         self.assertEqual(results[1], self.results[1])
         self.assertEqual(len(results), 3)
 
-    def test_to_dict_valid_input_require_refs_true(self):
+    @data("inject_noise", "tag")
+    def test_to_dict_valid_input_require_refs_true(self, group_by):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), self.inject_noise_annotations[0]]):
+        with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
-        with circuit.box(annotations=[self.inject_noise_annotations[1]]):
+        with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
-        returned_dict = NoiseLearnerV3Results(self.results[:2]).to_dict(circuit.data, True)
+        returned_dict = NoiseLearnerV3Results(self.results[:2]).to_dict(
+            circuit.data, True, group_by=group_by
+        )
         self.assertDictEqual(
             {
                 annotation.ref: pauli_lindblad_map
                 for annotation, pauli_lindblad_map in zip(
-                    self.inject_noise_annotations[:2], self.pauli_lindblad_maps[:2]
+                    annotations[:2], self.pauli_lindblad_maps[:2]
                 )
             },
             returned_dict,
         )
 
-    def test_to_dict_valid_input_require_refs_false(self):
+    @data("inject_noise", "tag")
+    def test_to_dict_valid_input_require_refs_false(self, group_by):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), self.inject_noise_annotations[0]]):
+        with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
         with circuit.box(annotations=[Twirl()]):
             circuit.cx(0, 1)
-        with circuit.box(annotations=[self.inject_noise_annotations[1]]):
+        with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
-        returned_dict = NoiseLearnerV3Results(self.results).to_dict(circuit.data, False)
+        returned_dict = NoiseLearnerV3Results(self.results).to_dict(
+            circuit.data, False, group_by=group_by
+        )
         self.assertDictEqual(
             {
                 annotation.ref: pauli_lindblad_map
                 for annotation, pauli_lindblad_map in zip(
-                    self.inject_noise_annotations,
+                    annotations,
                     [self.pauli_lindblad_maps[0], self.pauli_lindblad_maps[2]],
                 )
             },
             returned_dict,
         )
 
-    def test_to_dict_wrong_num_of_instructions(self):
+    @data("inject_noise", "tag")
+    def test_to_dict_wrong_num_of_instructions(self, group_by):
         """Test ``.to_dict`` raises if number of instructions does not match number of results."""
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), self.inject_noise_annotations[0]]):
+        with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
-        with circuit.box(annotations=[self.inject_noise_annotations[1]]):
+        with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "Expected 3 instructions but found 2"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
 
-    def test_to_dict_invalid_for_require_refs_true(self):
-        """Test raising if an instruction does not contain InjectNoise annotation when requires_ref.
+    @data("inject_noise", "tag")
+    def test_to_dict_invalid_for_require_refs_true(self, group_by):
+        """Test raising if an instruction does not contain annotations when requires_ref.
 
         Test that ``NoiseLearnerV3Results.to_dict`` raises if an instruction does not contain
-        the ``InjectNoise`` annotation, when ``requires_ref`` is ``True``.
+        an annotation, when ``requires_ref`` is ``True``.
         """
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), self.inject_noise_annotations[0]]):
+        with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
         with circuit.box(annotations=[Twirl()]):
             circuit.cx(0, 1)
-        with circuit.box(annotations=[self.inject_noise_annotations[1]]):
+        with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "without an inject noise"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
 
-    def test_to_dict_unboxed_instruction(self):
+    @data("inject_noise", "tag")
+    def test_to_dict_unboxed_instruction(self, group_by):
         """Test ``.to_dict`` raises if there is an instruction not in a box."""
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), self.inject_noise_annotations[0]]):
+        with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
         circuit.cx(0, 1)
-        with circuit.box(annotations=[self.inject_noise_annotations[1]]):
+        with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "contain a box"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)
 
-    def test_to_dict_ref_used_twice(self):
+    @data("inject_noise", "tag")
+    def test_to_dict_ref_used_twice(self, group_by):
         """Test ``.to_dict`` raises if an annotation reference is repeated."""
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
-        with circuit.box(annotations=[Twirl(), self.inject_noise_annotations[0]]):
+        with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
-        with circuit.box(annotations=[Twirl(), self.inject_noise_annotations[0]]):
+        with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
-        with circuit.box(annotations=[self.inject_noise_annotations[1]]):
+        with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "multiple instructions with the same ``ref``"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)


### PR DESCRIPTION
### Summary
Adding in support for the `Tag` annotation in `NoiseLearnerV3Result.to_dict` via a `group_by` parameter

### Details and comments

Part of #3053

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
