### PR TITLE
Complete testing of SamplexItem shape in wrapper estimator

### DIFF
--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -33,7 +33,12 @@ from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
 
 from ...ibm_test_case import IBMEstimatorPrepareTestCase
-from .utils import PARAM_BASIS_3Q_SCENARIOS, SAMPLEX_CIRCUIT_SCENARIOS, TEMPLATE_CIRCUIT_SCENARIO
+from .utils import (
+    PARAM_BASIS_3Q_SCENARIOS,
+    SAMPLEX_CIRCUIT_SCENARIOS,
+    TEMPLATE_CIRCUIT_SCENARIO,
+    TWIRLING_SHAPE_SCENARIOS,
+)
 
 
 @ddt
@@ -620,3 +625,60 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
             prepare_pea(
                 [pub], twirling_options, shots=100, zne_options=zne_options, noise_model_mapping={}
             )
+
+    def _build_trivial_noise_model(self, pubs, twirling_options):
+        """Build a trivial (zero-rate) noise model mapping for the given PUBs."""
+        layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
+        return {
+            annot.ref: PauliLindbladMap.from_sparse_list([], num_qubits=len(layer.qubits))
+            for layer in layers
+            if (annot := get_annotation(layer.operation, InjectNoise))
+        }
+
+    def test_shapes_twirling_configs(self):
+        """Verify the number of randomization and program.shots.
+
+        PEA shape is (num_noise_factors, num_randomizations, num_basis).
+        """
+        noise_factors = [1.0, 3.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "pea"
+        zne_options.noise_factors = noise_factors
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        pub = EstimatorPub.coerce((qc, SparsePauliOp.from_list([("ZZ", 1)])))
+
+        for scenario in TWIRLING_SHAPE_SCENARIOS:
+            if not scenario.twirling_options.enable_gates:
+                continue  # PEA requires enable_gates=True
+            with self.subTest(twirling=scenario.label):
+                noise_model_mapping = self._build_trivial_noise_model(
+                    [pub], scenario.twirling_options
+                )
+                program = prepare_pea(
+                    pubs=[pub],
+                    twirling_options=scenario.twirling_options,
+                    shots=scenario.shots,
+                    zne_options=zne_options,
+                    noise_model_mapping=noise_model_mapping,
+                )
+                item = program.items[0]
+                self.assertEqual(
+                    item.shape[0],
+                    len(noise_factors),
+                    msg=f"[{scenario.label}] expected N={len(noise_factors)}, got {item.shape[0]}",
+                )
+                self.assertEqual(
+                    item.shape[1],
+                    scenario.expected_num_randomizations,
+                    msg=f"[{scenario.label}] expected R={scenario.expected_num_randomizations}, "
+                    f"got {item.shape[1]}",
+                )
+                self.assertEqual(
+                    program.shots,
+                    scenario.expected_shots_per_randomization,
+                    msg=f"[{scenario.label}] expected program.shots="
+                    f"{scenario.expected_shots_per_randomization}, got {program.shots}",
+                )

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -24,6 +24,7 @@ from samplomatic import InjectNoise
 from samplomatic.utils import get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
+from qiskit_ibm_runtime.executor.calculate_twirling_shots import calculate_twirling_shots
 from qiskit_ibm_runtime.executor_estimator.pec.prepare_pec import prepare_pec
 from qiskit_ibm_runtime.executor_estimator.pec.utils import calculate_gamma
 from qiskit_ibm_runtime.executor_estimator.utils import find_unique_layers
@@ -34,7 +35,12 @@ from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
 
 from ...ibm_test_case import IBMEstimatorPrepareTestCase, IBMTestCase
-from .utils import PARAM_BASIS_3Q_SCENARIOS, SAMPLEX_CIRCUIT_SCENARIOS, TEMPLATE_CIRCUIT_SCENARIO
+from .utils import (
+    PARAM_BASIS_3Q_SCENARIOS,
+    SAMPLEX_CIRCUIT_SCENARIOS,
+    TEMPLATE_CIRCUIT_SCENARIO,
+    TWIRLING_SHAPE_SCENARIOS,
+)
 
 
 class TestCalculateGamma(IBMTestCase):
@@ -706,4 +712,97 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
         self.assertEqual(
             item0.shape[0],
             item1.shape[0],
+        )
+
+    def _build_trivial_noise_model(self, pubs, twirling_options):
+        """Build a trivial (zero-rate) noise model mapping for the given PUBs."""
+        layers = find_unique_layers(pubs, twirling_options, inject_noise=True)
+        return {
+            annot.ref: PauliLindbladMap.from_sparse_list([], num_qubits=len(layer.qubits))
+            for layer in layers
+            if (annot := get_annotation(layer.operation, InjectNoise))
+        }
+
+    def test_shapes_twirling_configs(self):
+        """Verify the number of randomization and program.shots."""
+        pec_options = PecOptions()
+        pec_options.noise_gain = 1.0  # no noise removal → gamma=1, no randomization overhead
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        pub = EstimatorPub.coerce((qc, SparsePauliOp.from_list([("ZZ", 1)])))
+
+        for scenario in TWIRLING_SHAPE_SCENARIOS:
+            if not scenario.twirling_options.enable_gates:
+                continue  # PEC requires enable_gates=True
+            with self.subTest(twirling=scenario.label):
+                noise_model_mapping = self._build_trivial_noise_model(
+                    [pub], scenario.twirling_options
+                )
+                program = prepare_pec(
+                    pubs=[pub],
+                    twirling_options=scenario.twirling_options,
+                    shots=scenario.shots,
+                    pec_options=pec_options,
+                    noise_model_mapping=noise_model_mapping,
+                )
+                item = program.items[0]
+                self.assertEqual(
+                    item.shape[0],
+                    scenario.expected_num_randomizations,
+                    msg=f"[{scenario.label}] expected R={scenario.expected_num_randomizations}, "
+                    f"got {item.shape[0]}",
+                )
+                self.assertEqual(
+                    program.shots,
+                    scenario.expected_shots_per_randomization,
+                    msg=f"[{scenario.label}] expected program.shots="
+                    f"{scenario.expected_shots_per_randomization}, got {program.shots}",
+                )
+
+    def test_shapes_overhead_scaling(self):
+        """PEC overhead: num randomizations exceeds baseline when gamma > 1.
+
+        Uses a non-trivial noise model with a known error rate so that gamma > 1 and
+        the scaled num_randomizations exceeds the baseline.
+        """
+        pec_options = PecOptions()
+        # noise_gain=0 means full PEC (maximum overhead scaling)
+        pec_options.noise_gain = 0.0
+
+        twirling_options = TwirlingOptions()
+        twirling_options.enable_gates = True
+        twirling_options.enable_measure = True
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        pub = EstimatorPub.coerce((qc, SparsePauliOp.from_list([("ZZ", 1)])))
+
+        # Build a non-trivial noise model with a meaningful error rate
+        layers = find_unique_layers([pub], twirling_options, inject_noise=True)
+        noise_model_mapping = {
+            annot.ref: PauliLindbladMap.from_sparse_list(
+                [("ZZ", [0, 1], 0.1)], num_qubits=len(layer.qubits)
+            )
+            for layer in layers
+            if (annot := get_annotation(layer.operation, InjectNoise))
+        }
+
+        shots = 1024
+        program = prepare_pec(
+            pubs=[pub],
+            twirling_options=twirling_options,
+            shots=shots,
+            pec_options=pec_options,
+            noise_model_mapping=noise_model_mapping,
+        )
+
+        baseline_num_rand, _ = calculate_twirling_shots(shots, "auto", "auto")
+        item = program.items[0]
+        self.assertGreater(
+            item.shape[0],
+            baseline_num_rand,
+            msg=f"Expected overhead-scaled R > baseline R={baseline_num_rand}, got {item.shape[0]}",
         )

--- a/test/unit/executor_estimator/test_estimator_v2_prepare_vanilla.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare_vanilla.py
@@ -30,7 +30,12 @@ from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
 
 from ...ibm_test_case import IBMEstimatorPrepareTestCase
 from ...utils import combine
-from .utils import PARAM_BASIS_3Q_SCENARIOS, SAMPLEX_CIRCUIT_SCENARIOS, TEMPLATE_CIRCUIT_SCENARIO
+from .utils import (
+    PARAM_BASIS_3Q_SCENARIOS,
+    SAMPLEX_CIRCUIT_SCENARIOS,
+    TEMPLATE_CIRCUIT_SCENARIO,
+    TWIRLING_SHAPE_SCENARIOS,
+)
 
 
 @ddt
@@ -576,3 +581,31 @@ class TestPrepareVanilla(IBMEstimatorPrepareTestCase):
             (48,),
             "Expected TREX item shape (48,) for num_randomizations=48",
         )
+
+    def test_shapes_twirling_configs(self):
+        """Verify the number of randomization and program.shots."""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        pub = EstimatorPub.coerce((qc, SparsePauliOp.from_list([("ZZ", 1)])))
+
+        for scenario in TWIRLING_SHAPE_SCENARIOS:
+            with self.subTest(twirling=scenario.label):
+                program = prepare_vanilla(
+                    pubs=[pub],
+                    twirling_options=scenario.twirling_options,
+                    shots=scenario.shots,
+                )
+                item = program.items[0]
+                self.assertEqual(
+                    item.shape[0],
+                    scenario.expected_num_randomizations,
+                    msg=f"[{scenario.label}] expected R={scenario.expected_num_randomizations}, "
+                    f"got {item.shape[0]}",
+                )
+                self.assertEqual(
+                    program.shots,
+                    scenario.expected_shots_per_randomization,
+                    msg=f"[{scenario.label}] expected program.shots="
+                    f"{scenario.expected_shots_per_randomization}, got {program.shots}",
+                )

--- a/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
@@ -30,7 +30,12 @@ from qiskit_ibm_runtime.quantum_program.quantum_program import SamplexItem
 
 from ...ibm_test_case import IBMEstimatorPrepareTestCase
 from ...utils import combine
-from .utils import PARAM_BASIS_3Q_SCENARIOS, SAMPLEX_CIRCUIT_SCENARIOS, TEMPLATE_CIRCUIT_SCENARIO
+from .utils import (
+    PARAM_BASIS_3Q_SCENARIOS,
+    SAMPLEX_CIRCUIT_SCENARIOS,
+    TEMPLATE_CIRCUIT_SCENARIO,
+    TWIRLING_SHAPE_SCENARIOS,
+)
 
 
 @ddt
@@ -451,3 +456,44 @@ class TestPrepareZne(IBMEstimatorPrepareTestCase):
             IBMInputValueError, "double_exponential requires at least 4 noise_factors"
         ):
             prepare_zne([pub], twirling_options, 100, zne_options)
+
+    def test_shapes_twirling_configs(self):
+        """Verify the number of randomization and program.shots."""
+        noise_factors = [1.0, 3.0]
+        zne_options = ZneOptions()
+        zne_options.amplifier = "gate_folding"
+        zne_options.noise_factors = noise_factors
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        pub = EstimatorPub.coerce((qc, SparsePauliOp.from_list([("ZZ", 1)])))
+
+        for scenario in TWIRLING_SHAPE_SCENARIOS:
+            with self.subTest(twirling=scenario.label):
+                program = prepare_zne(
+                    pubs=[pub],
+                    twirling_options=scenario.twirling_options,
+                    shots=scenario.shots,
+                    zne_options=zne_options,
+                )
+                self.assertEqual(
+                    len(program.items),
+                    len(noise_factors),
+                    msg=f"[{scenario.label}] expected {len(noise_factors)} items, "
+                    f"got {len(program.items)}",
+                )
+                for item in program.items:
+                    self.assertEqual(
+                        item.shape[0],
+                        scenario.expected_num_randomizations,
+                        msg=f"[{scenario.label}] expected R="
+                        f"{scenario.expected_num_randomizations}, "
+                        f"got {item.shape[0]}",
+                    )
+                self.assertEqual(
+                    program.shots,
+                    scenario.expected_shots_per_randomization,
+                    msg=f"[{scenario.label}] expected program.shots="
+                    f"{scenario.expected_shots_per_randomization}, got {program.shots}",
+                )

--- a/test/unit/executor_estimator/utils.py
+++ b/test/unit/executor_estimator/utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,8 @@ import numpy as np
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.primitives.containers.estimator_pub import EstimatorPub, ObservablesArray
 from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_ibm_runtime.options_models.twirling import TwirlingOptions
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -293,4 +296,121 @@ TEMPLATE_CIRCUIT_SCENARIO: TemplateCircuitScenario = _make_template_circuit_scen
 The circuit combines all three structural features exercised by template compilation:
 a CX gate (2Q), a parametric RZ gate, a mid-circuit measurement, and a second CX
 after the measurement.
+"""
+
+
+@dataclass(frozen=True)
+class TwirlingShapeScenario:
+    """A single twirling configuration with pre-computed expected shape outputs.
+
+    Used by ``test_shapes_twirling_configs`` in each prepare-function test class to
+    isolate the randomization axis (num_randomizations) and ``program.shots`` independently of the
+    PUB's observable structure.
+    """
+
+    label: str
+    """Human-readable name used in :meth:`~unittest.TestCase.subTest` labels."""
+
+    twirling_options: TwirlingOptions
+    """Fully configured twirling options to pass to the prepare function."""
+
+    shots: int
+    """Integer shots to pass to the prepare function."""
+
+    expected_num_randomizations: int
+    """Pre-computed num_randomizations: the expected randomization axis of the item shape."""
+
+    expected_shots_per_randomization: int
+    """Pre-computed ``program.shots``: the shots stored on the :class:`~.QuantumProgram`."""
+
+
+def _make_twirling_shape_scenarios() -> list[TwirlingShapeScenario]:
+    """Build the five canonical twirling configurations for shape testing.
+
+    All scenarios use ``shots=1024``.  Expected values are derived from
+    :func:`~qiskit_ibm_runtime.executor.calculate_twirling_shots`:
+
+    * No twirling: R=1, program.shots=1024
+    * Both auto:   shots_per_rand = max(64, ceil(1024/32)) = 64;
+                   num_rand = ceil(1024/64) = 16  →  R=16, program.shots=64
+    * num_rand=8:  shots_per_rand = ceil(1024/8) = 128  →  R=8,  program.shots=128
+    * spr=128:     num_rand = ceil(1024/128) = 8  →  R=8,  program.shots=128
+    * Both fixed (num_rand=4, spr=256): shots is ignored  →  R=4,  program.shots=256
+    """
+    shots = 1024
+
+    # No twirling
+    no_twirl = TwirlingOptions()
+    no_twirl.enable_gates = False
+    no_twirl.enable_measure = False
+
+    # Both auto
+    both_auto = TwirlingOptions()
+    both_auto.enable_gates = True
+    both_auto.enable_measure = True
+
+    # num_randomizations fixed, shots_per_randomization auto
+    num_rand_fixed = TwirlingOptions()
+    num_rand_fixed.enable_gates = True
+    num_rand_fixed.enable_measure = True
+    num_rand_fixed.num_randomizations = 8
+
+    # shots_per_randomization fixed, num_randomizations auto
+    spr_fixed = TwirlingOptions()
+    spr_fixed.enable_gates = True
+    spr_fixed.enable_measure = True
+    spr_fixed.shots_per_randomization = 128
+
+    # Both fixed — shots argument is completely ignored
+    both_fixed = TwirlingOptions()
+    both_fixed.enable_gates = True
+    both_fixed.enable_measure = True
+    both_fixed.num_randomizations = 4
+    both_fixed.shots_per_randomization = 256
+
+    return [
+        TwirlingShapeScenario(
+            label="no_twirling",
+            twirling_options=no_twirl,
+            shots=shots,
+            expected_num_randomizations=1,
+            expected_shots_per_randomization=shots,
+        ),
+        TwirlingShapeScenario(
+            label="both_auto",
+            twirling_options=both_auto,
+            shots=shots,
+            expected_num_randomizations=math.ceil(shots / max(64, math.ceil(shots / 32))),
+            expected_shots_per_randomization=max(64, math.ceil(shots / 32)),
+        ),
+        TwirlingShapeScenario(
+            label="num_rand_fixed",
+            twirling_options=num_rand_fixed,
+            shots=shots,
+            expected_num_randomizations=8,
+            expected_shots_per_randomization=math.ceil(shots / 8),
+        ),
+        TwirlingShapeScenario(
+            label="shots_per_rand_fixed",
+            twirling_options=spr_fixed,
+            shots=shots,
+            expected_num_randomizations=math.ceil(shots / 128),
+            expected_shots_per_randomization=128,
+        ),
+        TwirlingShapeScenario(
+            label="both_fixed",
+            twirling_options=both_fixed,
+            shots=shots,
+            expected_num_randomizations=4,
+            expected_shots_per_randomization=256,
+        ),
+    ]
+
+
+TWIRLING_SHAPE_SCENARIOS: list[TwirlingShapeScenario] = _make_twirling_shape_scenarios()
+"""Five twirling configurations for randomization-axis shape tests.
+
+Covers: no twirling, both-auto, num_rand fixed, shots_per_rand fixed, both fixed.
+All use shots=1024 with pre-computed expected_num_randomizations and
+expected_shots_per_randomization.
 """


### PR DESCRIPTION
### Summary
Fixes #3194.
The shape elements we want to test are num_randomizations, shots per randomization (though not strictly a SampleItem property) and the number of param-basis pairs. The last one was already covered by #3087, so this PR completes the other two elements in a unified way for all `prepare_x` functions. 

### AI/LLM disclosure

- [X] I used the following tool to generate or modify code: IBM BOB
