### PR TITLE
`add_tags=True` in `prepare` when running local mode for executor-based primitives

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -298,7 +298,7 @@ class EstimatorV2(BaseEstimatorV2):
             shots = int(np.ceil(1.0 / (options.default_precision**2)))
 
         # Check if we're in local simulator mode
-        if not self.options.experimental.get("local_mode", False) and isinstance(
+        if not (local_mode := self.options.experimental.get("local_mode", False)) and isinstance(
             self._service, QiskitRuntimeLocalService
         ):
             logger.info("Running in local simulator mode")
@@ -321,7 +321,7 @@ class EstimatorV2(BaseEstimatorV2):
         # Convert pubs to QuantumProgram and map options using the selected prepare function
         logger.info("Starting pre-processing")
         quantum_program, executor_options = prepare(
-            coerced_pubs, options, shots, backend=self._backend
+            coerced_pubs, options, shots, backend=self._backend, add_tags=local_mode
         )
         # Store raw options, shots and precision for post-processing side to compute metadata.
         quantum_program.passthrough_data["post_processor"]["options"] = options.model_dump(  # type: ignore[index, call-overload]

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -321,7 +321,7 @@ class EstimatorV2(BaseEstimatorV2):
         # Convert pubs to QuantumProgram and map options using the selected prepare function
         logger.info("Starting pre-processing")
         quantum_program, executor_options = prepare(
-            coerced_pubs, options, shots, backend=self._backend, add_tags=local_mode
+            coerced_pubs, options, shots, add_tags=local_mode, backend=self._backend
         )
         # Store raw options, shots and precision for post-processing side to compute metadata.
         quantum_program.passthrough_data["post_processor"]["options"] = options.model_dump(  # type: ignore[index, call-overload]

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -58,11 +58,10 @@ def prepare(
         shots: The number of shots to use. Will be overridden by
             ``num_randomizations * shots_per_randomization`` when both are specified explicitly
             and twirling is on.
-        add_tags: Whether to include tags for the boxes. Relevant mainly for debugging.
-            ``False`` will cause no tags to be added (will pass the "none" value to the relevant
-            attribute), while ``True`` will cause tags with the twirled boxes hash to be added
-            (using the "unique_box" value of the relevant attribute). These tags can help
-            injecting noise in simulators.
+        add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
+            (will pass the "none" value to the relevant attribute), while ``True`` will cause tags
+            with the twirled boxes hash to be added (using the "unique_box" value of the relevant
+            attribute). These tags are used to inject noise when running in local mode.
         backend: The backend for which the program is prepared. Only required when dynamical
             decoupling is enabled.
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -59,9 +59,9 @@ def prepare(
             ``num_randomizations * shots_per_randomization`` when both are specified explicitly
             and twirling is on.
         add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
-            (will pass the `"none"` value to the relevant attribute), while ``True`` will cause tags
-            with the twirled boxes hash to be added (using the `"unique_box"` value of the relevant
-            attribute). These tags are used to inject noise when running in local mode.
+            (will pass the ``"none"`` value to the relevant attribute), while ``True`` will cause
+            tags with the twirled boxes hash to be added (using the ``"unique_box"`` value of the
+            relevant attribute). These tags are used to inject noise when running in local mode.
         backend: The backend for which the program is prepared. Only required when dynamical
             decoupling is enabled.
 

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -59,8 +59,8 @@ def prepare(
             ``num_randomizations * shots_per_randomization`` when both are specified explicitly
             and twirling is on.
         add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
-            (will pass the "none" value to the relevant attribute), while ``True`` will cause tags
-            with the twirled boxes hash to be added (using the "unique_box" value of the relevant
+            (will pass the `"none"` value to the relevant attribute), while ``True`` will cause tags
+            with the twirled boxes hash to be added (using the `"unique_box"` value of the relevant
             attribute). These tags are used to inject noise when running in local mode.
         backend: The backend for which the program is prepared. Only required when dynamical
             decoupling is enabled.

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -51,6 +51,7 @@ def prepare(
     pubs: Sequence[SamplerPub],
     options: SamplerOptions,
     default_shots: int | None = None,
+    add_tags: bool = False,
     backend: BackendV2 | None = None,
 ) -> tuple[QuantumProgram, ExecutorOptions]:
     """Convert a sequence of sampler PUBs to a quantum program and map options.
@@ -64,6 +65,10 @@ def prepare(
         options: The options.
         default_shots: Default number of shots if not specified in PUBs. If ``None``,
             uses the value from ``self.options.default_shots``.
+        add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
+            (will pass the "none" value to the relevant attribute), while ``True`` will cause tags
+            with the twirled boxes hash to be added (using the "unique_box" value of the relevant
+            attribute). These tags are used to inject noise when running in local mode.
         backend: The backend for which the program is prepared. Only required when dynamical
             decoupling is enabled.
 
@@ -144,6 +149,7 @@ def prepare(
             enable_measures=bool(options.twirling.enable_measure),
             twirling_strategy=options.twirling.strategy.replace("-", "_"),
             inject_noise_site="after",
+            add_tags="unique_box" if add_tags else "none",
         )
 
         for i, pub in enumerate(pubs):

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -66,9 +66,9 @@ def prepare(
         default_shots: Default number of shots if not specified in PUBs. If ``None``,
             uses the value from ``self.options.default_shots``.
         add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
-            (will pass the `"none"` value to the relevant attribute), while ``True`` will cause tags
-            with the twirled boxes hash to be added (using the `"unique_box"` value of the relevant
-            attribute). These tags are used to inject noise when running in local mode.
+            (will pass the ``"none"`` value to the relevant attribute), while ``True`` will cause
+            tags with the twirled boxes hash to be added (using the ``"unique_box"`` value of the
+            relevant attribute). These tags are used to inject noise when running in local mode.
         backend: The backend for which the program is prepared. Only required when dynamical
             decoupling is enabled.
 

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -66,8 +66,8 @@ def prepare(
         default_shots: Default number of shots if not specified in PUBs. If ``None``,
             uses the value from ``self.options.default_shots``.
         add_tags: Whether to include tags for the boxes. ``False`` will cause no tags to be added
-            (will pass the "none" value to the relevant attribute), while ``True`` will cause tags
-            with the twirled boxes hash to be added (using the "unique_box" value of the relevant
+            (will pass the `"none"` value to the relevant attribute), while ``True`` will cause tags
+            with the twirled boxes hash to be added (using the `"unique_box"` value of the relevant
             attribute). These tags are used to inject noise when running in local mode.
         backend: The backend for which the program is prepared. Only required when dynamical
             decoupling is enabled.

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -199,7 +199,7 @@ class SamplerV2(BaseSamplerV2):
         default_shots = shots if shots is not None else options.default_shots
 
         # Legacy simulator path (no executor)
-        if not self.options.experimental.get("local_mode", False) and isinstance(
+        if not (local_mode := self.options.experimental.get("local_mode", False)) and isinstance(
             self._service, QiskitRuntimeLocalService
         ):
             logger.info("Running in local simulator mode")
@@ -217,7 +217,7 @@ class SamplerV2(BaseSamplerV2):
         # Convert pubs to QuantumProgram and map options using the prepare method
         logger.info("Starting pre-processing")
         quantum_program, executor_options = prepare(
-            coerced_pubs, options, default_shots, backend=self._backend
+            coerced_pubs, options, default_shots, add_tags=local_mode, backend=self._backend
         )
 
         # Initialize executor with settings

--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -16,6 +16,8 @@ from ddt import data, ddt
 from qiskit import QuantumCircuit
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.quantum_info import PauliLindbladMap, SparsePauliOp
+from samplomatic import Tag
+from samplomatic.utils import find_unique_box_instructions, get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.prepare import prepare
@@ -30,6 +32,38 @@ from ...ibm_test_case import IBMTestCase
 @ddt
 class TestPrepare(IBMTestCase):
     """Test the ``prepare`` function."""
+
+    @data("vanilla", "pec", "zne", "pea")
+    def test_add_tags(self, path):
+        """Test that ``prepare`` adds tags when ``add_tags=True``."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+
+        pubs = [EstimatorPub.coerce((circuit, observable))]
+
+        options = EstimatorOptions()
+        options.twirling.enable_gates = True
+        match path:
+            case "vanilla":
+                options.twirling.enable_measure = True
+            case "pec":
+                options.resilience.pec_mitigation = True
+                options.resilience.noise_model = {
+                    "layer_0": PauliLindbladMap.identity(num_qubits=2)
+                }
+            case "zne":
+                options.resilience.zne_mitigation = True
+            case "pea":
+                options.resilience.zne_mitigation = True
+                options.resilience.zne.amplifier = "pea"
+
+        program, _ = prepare(pubs, options, shots=100, add_tags=True)
+
+        for item in program.items:
+            unique_instructions = find_unique_box_instructions(item.circuit)
+            for inst in unique_instructions:
+                self.assertIsNotNone(get_annotation(inst.operation, Tag))
 
     def test_vanilla_path(self):
         """Test the ``prepare`` function when no mitigation is requested."""

--- a/test/unit/executor_sampler/test_prepare.py
+++ b/test/unit/executor_sampler/test_prepare.py
@@ -19,6 +19,8 @@ from ddt import data, ddt
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.primitives.containers.sampler_pub import SamplerPub
+from samplomatic import Tag
+from samplomatic.utils import find_unique_box_instructions, get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_sampler.prepare import prepare
@@ -32,6 +34,21 @@ from ...ibm_test_case import IBMTestCase
 
 class TestPrepare(IBMTestCase):
     """Tests for prepare method."""
+
+    def test_add_tags(self):
+        """Test that tags are added when ``add_tags=True``."""
+        circuit1 = QuantumCircuit(2, 2)
+        circuit1.h(0)
+        circuit1.measure_all()
+
+        pubs = [SamplerPub.coerce(circuit1, shots=1024)]
+        options = SamplerOptions(**{"twirling": {"enable_gates": True, "enable_measure": True}})
+        program, _ = prepare(pubs, options, add_tags=True)
+
+        for item in program.items:
+            unique_instructions = find_unique_box_instructions(item.circuit)
+            for inst in unique_instructions:
+                self.assertIsNotNone(get_annotation(inst.operation, Tag))
 
     def test_multiple_pubs(self):
         """Test conversion of multiple pubs, including parametric circuits."""


### PR DESCRIPTION
### Summary
Because we rely on tags to specify noise for local mode simulations ,`prepare` in the executor-based primitives needs to include `add_tags=True`. This PR adds an `add_tags` argument to `prepare` for `SamplerV2` (`EstimatorV2` already has this) and sets `add_tags=True` when running local mode.

### Details and comments

Closes #3217 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
