### PR TITLE
Fix/pec stds num randomizations 1

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -475,7 +475,10 @@ def _process_expectation_values_pec(
 
         exp_vals[bcast_index] = exp_val * pec_gamma
         ensemble_stds[bcast_index] = np.sqrt(ensemble_variance * pec_gamma**2 / total_shots)
-        stds[bcast_index] = np.sqrt(twirl_variance * pec_gamma**2 / num_randomizations)
+        if num_randomizations == 1:
+            stds[bcast_index] = ensemble_stds[bcast_index]
+        else:
+            stds[bcast_index] = np.sqrt(twirl_variance * pec_gamma**2 / num_randomizations)
 
     return exp_vals, stds, ensemble_stds
 


### PR DESCRIPTION
### Summary

Adds the same edge case guard that Non-PEC branches hit, [here](https://github.com/Qiskit/qiskit-ibm-runtime/blob/bea5c6006f19ba5613a874d2a4902ff28ea05b04/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py#L346).

### Details and comments

Fixes #3226 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
