### PR TITLE
Parametize noiseless sim tests to cover more estimator configurations (PEA / PEC/ Resilience levels)

### DIFF
--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -50,12 +50,7 @@ class TestEstimatorWithNoise(IBMTestCase):
 
         Estimator result quality is expected to increase with increasing resilience level.
         """
-        # FIXME: add_projector_observables=False is only needed,
-        # due to a bug in TREX post-processing:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        pub, ideal_evs = create_estimator_test_data(
-            self.backend, self.preset_pass_manager, add_projector_observables=False
-        )
+        pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
 
         # maps resilience level to error (compared to statevector simulation) for each observable
         errors: dict[int, npt.NDArray[np.float64]] = {}
@@ -95,15 +90,9 @@ class TestEstimatorWithoutNoise(IBMTestCase):
 
         Parametrized to run with all three estimator resilience levels.
         """
-        # FIXME: add_projector_observables=False is only needed,
-        # due to a bug in TREX post-processing affecting resilience levels > 0:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        add_projector_observables = True if resilience_level == 0 else False
-
         pub, ideal_evs = create_estimator_test_data(
             self.backend,
             self.preset_pass_manager,
-            add_projector_observables=add_projector_observables,
         )
 
         estimator = create_local_mode_estimator(self.backend)
@@ -125,10 +114,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         estimator.options.resilience.pec_mitigation = True
         estimator.options.twirling.enable_gates = True
         estimator.options.twirling.enable_measure = True
-
-        # FIXME: TREX currently not possible for the projector observables we use here:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        # estimator.options.resilience.measure_mitigation = True
+        estimator.options.resilience.measure_mitigation = True
 
         # TODO: no DD possible on AER without gate durations.
         # Need to test this for a fake backend (e.g. in noisy test).

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -54,7 +54,7 @@ class TestEstimatorWithNoise(IBMTestCase):
         # due to a bug in TREX post-processing:
         # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
         pub, ideal_evs = create_estimator_test_data(
-            self.backend, self.preset_pass_manager, add_projector_observables=False
+            self.backend, self.preset_pass_manager, add_projector_observables=True
         )
 
         # maps resilience level to error (compared to statevector simulation) for each observable
@@ -98,7 +98,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         # FIXME: add_projector_observables=False is only needed,
         # due to a bug in TREX post-processing affecting resilience levels > 0:
         # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        add_projector_observables = True if resilience_level == 0 else False
+        add_projector_observables = True  # if resilience_level == 0 else False
 
         pub, ideal_evs = create_estimator_test_data(
             self.backend,
@@ -117,93 +117,64 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         # ground truth.
         np.testing.assert_allclose(actual=evs, desired=ideal_evs, atol=0.02)
 
-    def test_correct_estimates_with_pec(self):
-        """Tests that EstimatorV2 with PEC produces correct results in a noise-less environment."""
-        pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
-
-        estimator = create_local_mode_estimator(self.backend)
-        estimator.options.resilience.pec_mitigation = True
-        estimator.options.twirling.enable_gates = True
-        estimator.options.twirling.enable_measure = True
-
-        # FIXME: TREX currently not possible for the projector observables we use here:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        # estimator.options.resilience.measure_mitigation = True
-
-        # TODO: no DD possible on AER without gate durations.
-        # Need to test this for a fake backend (e.g. in noisy test).
-        # estimator.options.dynamical_decoupling.enable = True
-
-        layers = [
-            layer
-            for layer in estimator.find_unique_layers([pub])
-            if get_annotation(layer.operation, InjectNoise)
-        ]
-
-        # In a noise-less simulation we do not expect noise. So we can construct the noise_model
-        # with empty noise for all layers:
-        noise_model = {
-            get_annotation(layer.operation, InjectNoise).ref: PauliLindbladMap.identity(
-                layer.operation.num_qubits
-            )
-            for layer in layers
-        }
-
-        estimator.options.resilience.noise_model = noise_model
-
-        result = estimator.run([pub]).result()
-        # We get one expectation value per observable:
-        evs = result[0].data.evs
-
-        # With no noise, we should get expectation values which are more or less equal to
-        # ground truth.
-        np.testing.assert_allclose(actual=evs, desired=ideal_evs, atol=0.02)
-
+    # FIXME: TREX / measure_mitigation currently not possible for the projector observables we use here:
+    # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
+    # estimator.options.resilience.measure_mitigation = True
     @data(
+        # Vanilla
+        {"resilience_level": 0},
+        # Measurement Twirling + TREX
+        {"resilience_level": 1},
+        # ZNE (Gate folding)
+        {"resilience_level": 2},
+        # PEC
         {
-            "resilience": {"pec_mitigation": True, "zne_mitigation": False},
-            "zne": {}
+            "twirling": {"enable_gates": True, "enable_measure": True},
+            "resilience": {
+                "pec_mitigation": True,
+                "zne_mitigation": False,
+                "measure_mitigation": False,
+            },
         },
+        # ZNE (PEA)
         {
-            "resilience": {"pec_mitigation": False, "zne_mitigation": True},
-            "zne": {"amplifier": "pea"}
+            "twirling": {"enable_gates": True, "enable_measure": True},
+            "resilience": {
+                "pec_mitigation": False,
+                "zne_mitigation": True,
+                "zne": {"amplifier": "pea"},
+                "measure_mitigation": False,
+            },
         },
-            )
-    def test_correct_estimates_with_zne_pea(self, resilience_options):
-        """Tests that EstimatorV2 with PEC produces correct results in a noise-less environment."""
+    )
+    def test_correct_estimates_for_different_mitigation_modes(self, option_overrides):
+        """Tests that EstimatorV2 with ZNE/PEA produces correct results in a noise-less environment."""
         pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
 
         estimator = create_local_mode_estimator(self.backend)
-        estimator.options.resilience.pec_mitigation = True
-        estimator.options.resilience.zne_mitigation = True
-        estimator.options.resilience.zne.amplifier = "pea"
-        estimator.options.twirling.enable_gates = True
-        estimator.options.twirling.enable_measure = True
-
-        # FIXME: TREX currently not possible for the projector observables we use here:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        # estimator.options.resilience.measure_mitigation = True
+        estimator.options.update(**option_overrides)
 
         # TODO: no DD possible on AER without gate durations.
         # Need to test this for a fake backend (e.g. in noisy test).
         # estimator.options.dynamical_decoupling.enable = True
 
-        layers = [
-            layer
-            for layer in estimator.find_unique_layers([pub])
-            if get_annotation(layer.operation, InjectNoise)
-        ]
+        if "resilience_level" not in option_overrides:
+            layers = [
+                layer
+                for layer in estimator.find_unique_layers([pub])
+                if get_annotation(layer.operation, InjectNoise)
+            ]
 
-        # In a noise-less simulation we do not expect noise. So we can construct the noise_model
-        # with empty noise for all layers:
-        noise_model = {
-            get_annotation(layer.operation, InjectNoise).ref: PauliLindbladMap.identity(
-                layer.operation.num_qubits
-            )
-            for layer in layers
-        }
+            # In a noise-less simulation we do not expect noise. So we can construct the noise_model
+            # with empty noise for all layers:
+            noise_model = {
+                get_annotation(layer.operation, InjectNoise).ref: PauliLindbladMap.identity(
+                    layer.operation.num_qubits
+                )
+                for layer in layers
+            }
 
-        estimator.options.resilience.noise_model = noise_model
+            estimator.options.resilience.noise_model = noise_model
 
         result = estimator.run([pub]).result()
         # We get one expectation value per observable:

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -158,3 +158,57 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         # With no noise, we should get expectation values which are more or less equal to
         # ground truth.
         np.testing.assert_allclose(actual=evs, desired=ideal_evs, atol=0.02)
+
+    @data(
+        {
+            "resilience": {"pec_mitigation": True, "zne_mitigation": False},
+            "zne": {}
+        },
+        {
+            "resilience": {"pec_mitigation": False, "zne_mitigation": True},
+            "zne": {"amplifier": "pea"}
+        },
+            )
+    def test_correct_estimates_with_zne_pea(self, resilience_options):
+        """Tests that EstimatorV2 with PEC produces correct results in a noise-less environment."""
+        pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
+
+        estimator = create_local_mode_estimator(self.backend)
+        estimator.options.resilience.pec_mitigation = True
+        estimator.options.resilience.zne_mitigation = True
+        estimator.options.resilience.zne.amplifier = "pea"
+        estimator.options.twirling.enable_gates = True
+        estimator.options.twirling.enable_measure = True
+
+        # FIXME: TREX currently not possible for the projector observables we use here:
+        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
+        # estimator.options.resilience.measure_mitigation = True
+
+        # TODO: no DD possible on AER without gate durations.
+        # Need to test this for a fake backend (e.g. in noisy test).
+        # estimator.options.dynamical_decoupling.enable = True
+
+        layers = [
+            layer
+            for layer in estimator.find_unique_layers([pub])
+            if get_annotation(layer.operation, InjectNoise)
+        ]
+
+        # In a noise-less simulation we do not expect noise. So we can construct the noise_model
+        # with empty noise for all layers:
+        noise_model = {
+            get_annotation(layer.operation, InjectNoise).ref: PauliLindbladMap.identity(
+                layer.operation.num_qubits
+            )
+            for layer in layers
+        }
+
+        estimator.options.resilience.noise_model = noise_model
+
+        result = estimator.run([pub]).result()
+        # We get one expectation value per observable:
+        evs = result[0].data.evs
+
+        # With no noise, we should get expectation values which are more or less equal to
+        # ground truth.
+        np.testing.assert_allclose(actual=evs, desired=ideal_evs, atol=0.02)

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -48,6 +48,7 @@ def create_estimator_test_data(backend, preset_pass_manager):
     y_q1 = np.sin(phi)
     l_q0 = (1 + np.sin(theta)) / 2
     z_q0 = np.cos(theta)
+    x_q2 = sq2_half
     proj_q2 = (1 + sq2_half) / 2
     z0_q0 = (1 + np.cos(theta)) / 2
 
@@ -58,6 +59,7 @@ def create_estimator_test_data(backend, preset_pass_manager):
         ("-IYI", proj_q2 * y_q1),
         ("IIY0", y_q1 * z0_q0),
         ("I1YI", proj_q2 * y_q1),
+        ("IXII", x_q2),
     ]
 
     # Prepare a PUB with multiple observables to estimate expectation values on.

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -24,7 +24,7 @@ from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
 from ....utils import make_mirror_circuit_with_phases
 
 
-def create_estimator_test_data(backend, preset_pass_manager, add_projector_observables=True):
+def create_estimator_test_data(backend, preset_pass_manager):
     """Create a pub and ideal expectation values for it."""
     # Use standard mirror circuit.
     # - No measurements, as StatevectorEstimator does not support them.
@@ -45,20 +45,21 @@ def create_estimator_test_data(backend, preset_pass_manager, add_projector_obser
         ("IIZ", np.cos(theta)),
         ("IYZ", np.cos(theta)),
         ("XIZ", np.cos(theta)),
+        ("1IZ", 0.5 * np.cos(theta)),
+        ("IrZ", np.cos(theta)),
+        ("X+I", 0.5),
+        ("0IZ", 0.5 * np.cos(theta)),
+        ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
+        ("X-I", 0.5),
     ]
-    if add_projector_observables:
-        observable_ideal_ev_pairs.extend(
-            [
-                ("1IZ", 0.5 * np.cos(theta)),
-                ("IYr", np.sin(np.pi / 4 - theta / 2) ** 2),
-                ("X+I", 0.5),
-                ("0IZ", 0.5 * np.cos(theta)),
-                ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
-                ("X-I", 0.5),
-            ]
-        )
 
     # Prepare a PUB with multiple observables to estimate expectation values on.
+
+    # FIXME: Composing observables from plain `Operator` instead of directly passing strings,
+    # due to a bug in TREX post-processing affecting resilience levels > 0:
+    # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
+    # Once this is fixed, we can do:
+    # observables = [obs_string for obs_string, _ in observable_ideal_ev_pairs]
     observables = [
         SparsePauliOp.from_operator(Operator.from_label(obs_string)).apply_layout(
             isa_circuit.layout

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -33,26 +33,6 @@ def create_estimator_test_data(backend, preset_pass_manager):
         backend, num_qubits=4, add_measurement=False, add_rx=False
     )
 
-    ## Add rotations to produce eigenstates of X, Y and Z:
-    # circuit.rx(Parameter("rx_0"), 0)
-    # circuit.rx(Parameter("rx_1"), 1)
-    # circuit.ry(Parameter("ry_2"), 2)
-    # isa_circuit = preset_pass_manager.run(circuit)
-    # theta = np.pi / 8
-    # parameters = [theta, -np.pi / 2, np.pi / 2]
-
-    # observable_ideal_ev_pairs: list[tuple[str, float]] = [
-    #    ("IIZ", np.cos(theta)),
-    #    ("IYZ", np.cos(theta)),
-    #    ("XIZ", np.cos(theta)),
-    #    ("IrZ", np.cos(theta)),
-    #    ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
-    #    ("1IZ", 0.5 * np.cos(theta)),
-    #    ("X+I", 0.5),
-    #    ("0IZ", 0.5 * np.cos(theta)),
-    #    ("X-I", 0.5),
-    # ]
-
     circuit.rx(Parameter("rx_0"), 0)
     circuit.rx(Parameter("rx_1"), 1)
     circuit.ry(Parameter("ry_2"), 2)

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -30,27 +30,54 @@ def create_estimator_test_data(backend, preset_pass_manager):
     # - No measurements, as StatevectorEstimator does not support them.
     # - No trailing Rx gates, as we want to add our own rotations
     circuit = make_mirror_circuit_with_phases(
-        backend, num_qubits=3, add_measurement=False, add_rx=False
+        backend, num_qubits=4, add_measurement=False, add_rx=False
     )
 
-    # Add rotations to produce eigenstates of X, Y and Z:
+    ## Add rotations to produce eigenstates of X, Y and Z:
+    # circuit.rx(Parameter("rx_0"), 0)
+    # circuit.rx(Parameter("rx_1"), 1)
+    # circuit.ry(Parameter("ry_2"), 2)
+    # isa_circuit = preset_pass_manager.run(circuit)
+    # theta = np.pi / 8
+    # parameters = [theta, -np.pi / 2, np.pi / 2]
+
+    # observable_ideal_ev_pairs: list[tuple[str, float]] = [
+    #    ("IIZ", np.cos(theta)),
+    #    ("IYZ", np.cos(theta)),
+    #    ("XIZ", np.cos(theta)),
+    #    ("IrZ", np.cos(theta)),
+    #    ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
+    #    ("1IZ", 0.5 * np.cos(theta)),
+    #    ("X+I", 0.5),
+    #    ("0IZ", 0.5 * np.cos(theta)),
+    #    ("X-I", 0.5),
+    # ]
+
     circuit.rx(Parameter("rx_0"), 0)
     circuit.rx(Parameter("rx_1"), 1)
     circuit.ry(Parameter("ry_2"), 2)
+    circuit.ry(Parameter("ry_3"), 3)
     isa_circuit = preset_pass_manager.run(circuit)
-    theta = np.pi / 8
-    parameters = [theta, -np.pi / 2, np.pi / 2]
+
+    theta = np.pi / 5
+    phi = np.pi / 3
+    parameters = [theta, -phi, 3 * np.pi / 4, -3 * np.pi / 4]
+
+    sq2_half = np.sqrt(2) / 2
+    r_q1 = (1 + np.sin(phi)) / 2
+    y_q1 = np.sin(phi)
+    l_q0 = (1 + np.sin(theta)) / 2
+    z_q0 = np.cos(theta)
+    proj_q2 = (1 + sq2_half) / 2
+    z0_q0 = (1 + np.cos(theta)) / 2
 
     observable_ideal_ev_pairs: list[tuple[str, float]] = [
-        ("IIZ", np.cos(theta)),
-        ("IYZ", np.cos(theta)),
-        ("XIZ", np.cos(theta)),
-        ("1IZ", 0.5 * np.cos(theta)),
-        ("IrZ", np.cos(theta)),
-        ("X+I", 0.5),
-        ("0IZ", 0.5 * np.cos(theta)),
-        ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
-        ("X-I", 0.5),
+        ("IIrl", r_q1 * l_q0),
+        ("IIrZ", r_q1 * z_q0),
+        ("I+YI", proj_q2 * y_q1),
+        ("-IYI", proj_q2 * y_q1),
+        ("IIY0", y_q1 * z0_q0),
+        ("I1YI", proj_q2 * y_q1),
     ]
 
     # Prepare a PUB with multiple observables to estimate expectation values on.


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Includes changes from https://github.com/Qiskit/qiskit-ibm-runtime/pull/3234, so diff will become simpler, after #3234 is merged.

Adds more code-re-use by parametrizing the test. This way we can cover what would have been 3 tests with one. Most notably, I added PEA variant

### Details and comments

Fixes #

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
