### PR TITLE
Rename `group_by` in `NLV3Results.to_dict` to `mode`

### DIFF
--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -142,12 +142,12 @@ class NoiseLearnerV3Results:
         self,
         instructions: Sequence[CircuitInstruction],
         require_refs: bool = True,
-        group_by: Literal["inject_noise", "tag"] = "inject_noise",
+        mode: Literal["inject", "simulate"] = "inject",
     ) -> dict[str, PauliLindbladMap]:
         """Convert to a dictionary from references to :class:`PauliLindbladMap` objects.
 
         References can be one of :attr:`InjectNoise.ref` or :attr:`Tag.ref` depending on
-        ``group_by`` selection.
+        ``mode`` selection.
 
         This function iterates over a sequence of instructions, extracts the ``ref`` value
         from the annotation of each instruction, and returns a dictionary mapping
@@ -159,7 +159,7 @@ class NoiseLearnerV3Results:
             require_refs: Whether to raise if some of the instructions do not own an
                 annotation. If ``False``, all the instructions that do not contain an
                 annotation are simply skipped when constructing the returned dictionary.
-            group_by: If ``"tag"``, it groups by :class:`~.Tag` annotations. Otherwise, by
+            mode: If ``"simulate"``, it groups by :class:`~.Tag` annotations. Otherwise, by
                 :class:`~.InjectNoise` annotations.
 
         Raise:
@@ -177,7 +177,7 @@ class NoiseLearnerV3Results:
 
         noise_source = {}
         num_instr = 0
-        annotation_type = Tag if group_by == "tag" else InjectNoise
+        annotation_type = Tag if mode == "simulate" else InjectNoise
         for instr, datum in zip(instructions, self.data):
             if not isinstance(instr.operation, BoxOp):
                 raise ValueError("Found an instruction that does not contain a box.")

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -142,7 +142,7 @@ class NoiseLearnerV3Results:
         self,
         instructions: Sequence[CircuitInstruction],
         require_refs: bool = True,
-        mode: Literal["inject", "simulate"] = "inject",
+        mode: Literal["injection", "simulation"] = "injection",
     ) -> dict[str, PauliLindbladMap]:
         """Convert to a dictionary from references to :class:`PauliLindbladMap` objects.
 
@@ -159,7 +159,7 @@ class NoiseLearnerV3Results:
             require_refs: Whether to raise if some of the instructions do not own an
                 annotation. If ``False``, all the instructions that do not contain an
                 annotation are simply skipped when constructing the returned dictionary.
-            mode: If ``"simulate"``, it groups by :class:`~.Tag` annotations. Otherwise, by
+            mode: If ``"simulation"``, it groups by :class:`~.Tag` annotations. Otherwise, by
                 :class:`~.InjectNoise` annotations.
 
         Raise:
@@ -177,7 +177,7 @@ class NoiseLearnerV3Results:
 
         noise_source = {}
         num_instr = 0
-        annotation_type = Tag if mode == "simulate" else InjectNoise
+        annotation_type = Tag if mode == "simulation" else InjectNoise
         for instr, datum in zip(instructions, self.data):
             if not isinstance(instr.operation, BoxOp):
                 raise ValueError("Found an instruction that does not contain a box.")

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -140,10 +140,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         self.assertEqual(results[1], self.results[1])
         self.assertEqual(len(results), 3)
 
-    @data("inject", "simulate")
+    @data("injection", "simulation")
     def test_to_dict_valid_input_require_refs_true(self, mode):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
+        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -163,10 +163,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("inject", "simulate")
+    @data("injection", "simulation")
     def test_to_dict_valid_input_require_refs_false(self, mode):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
+        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -187,10 +187,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("inject", "simulate")
+    @data("injection", "simulation")
     def test_to_dict_wrong_num_of_instructions(self, mode):
         """Test ``.to_dict`` raises if number of instructions does not match number of results."""
-        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
+        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -200,14 +200,14 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         with self.assertRaisesRegex(ValueError, "Expected 3 instructions but found 2"):
             NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, mode=mode)
 
-    @data("inject", "simulate")
+    @data("injection", "simulation")
     def test_to_dict_invalid_for_require_refs_true(self, mode):
         """Test raising if an instruction does not contain annotations when requires_ref.
 
         Test that ``NoiseLearnerV3Results.to_dict`` raises if an instruction does not contain
         an annotation, when ``requires_ref`` is ``True``.
         """
-        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
+        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -219,10 +219,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         with self.assertRaisesRegex(ValueError, "without an inject noise"):
             NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, mode=mode)
 
-    @data("inject", "simulate")
+    @data("injection", "simulation")
     def test_to_dict_unboxed_instruction(self, mode):
         """Test ``.to_dict`` raises if there is an instruction not in a box."""
-        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
+        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -233,10 +233,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         with self.assertRaisesRegex(ValueError, "contain a box"):
             NoiseLearnerV3Results(self.results).to_dict(circuit.data, mode=mode)
 
-    @data("inject", "simulate")
+    @data("injection", "simulation")
     def test_to_dict_ref_used_twice(self, mode):
         """Test ``.to_dict`` raises if an annotation reference is repeated."""
-        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
+        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -140,12 +140,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         self.assertEqual(results[1], self.results[1])
         self.assertEqual(len(results), 3)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_valid_input_require_refs_true(self, group_by):
+    @data("inject", "simulate")
+    def test_to_dict_valid_input_require_refs_true(self, mode):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -153,7 +151,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         returned_dict = NoiseLearnerV3Results(self.results[:2]).to_dict(
-            circuit.data, True, group_by=group_by
+            circuit.data, True, mode=mode
         )
         self.assertDictEqual(
             {
@@ -165,12 +163,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("inject_noise", "tag")
-    def test_to_dict_valid_input_require_refs_false(self, group_by):
+    @data("inject", "simulate")
+    def test_to_dict_valid_input_require_refs_false(self, mode):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -179,9 +175,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
-        returned_dict = NoiseLearnerV3Results(self.results).to_dict(
-            circuit.data, False, group_by=group_by
-        )
+        returned_dict = NoiseLearnerV3Results(self.results).to_dict(circuit.data, False, mode=mode)
         self.assertDictEqual(
             {
                 annotation.ref: pauli_lindblad_map
@@ -193,12 +187,10 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("inject_noise", "tag")
-    def test_to_dict_wrong_num_of_instructions(self, group_by):
+    @data("inject", "simulate")
+    def test_to_dict_wrong_num_of_instructions(self, mode):
         """Test ``.to_dict`` raises if number of instructions does not match number of results."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -206,18 +198,16 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "Expected 3 instructions but found 2"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, mode=mode)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_invalid_for_require_refs_true(self, group_by):
+    @data("inject", "simulate")
+    def test_to_dict_invalid_for_require_refs_true(self, mode):
         """Test raising if an instruction does not contain annotations when requires_ref.
 
         Test that ``NoiseLearnerV3Results.to_dict`` raises if an instruction does not contain
         an annotation, when ``requires_ref`` is ``True``.
         """
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -227,14 +217,12 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "without an inject noise"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, mode=mode)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_unboxed_instruction(self, group_by):
+    @data("inject", "simulate")
+    def test_to_dict_unboxed_instruction(self, mode):
         """Test ``.to_dict`` raises if there is an instruction not in a box."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -243,14 +231,12 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "contain a box"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, mode=mode)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_ref_used_twice(self, group_by):
+    @data("inject", "simulate")
+    def test_to_dict_ref_used_twice(self, mode):
         """Test ``.to_dict`` raises if an annotation reference is repeated."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations if mode == "inject" else self.tag_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -260,4 +246,4 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "multiple instructions with the same ``ref``"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, mode=mode)


### PR DESCRIPTION
### Summary
Rename `group_by` in `NLV3Results.to_dict` to `mode` to improve user experience

### Details and comments

Closes #3220

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
