### PR TITLE
Add `types` to `find_unique_layers`

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -224,7 +224,7 @@ class EstimatorV2(BaseEstimatorV2):
             or (options.resilience.zne_mitigation and options.resilience.zne.amplifier == "pea"),
             add_tags=True,
         )
-        box_types = ("gate", "measurement", "unknown") if types == "all" else ("gate",)
+        box_types = ("gates", "measurement", "unknown") if types == "all" else ("gates",)
         return [layer for layer in layers if find_box_type(layer) in box_types]
 
     def finalize_options(self) -> EstimatorOptions:

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -22,8 +22,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 from qiskit.primitives.base import BaseEstimatorV2
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
-from samplomatic import InjectNoise, Tag
-from samplomatic.utils import get_annotation
 
 from ..base_primitive import get_mode_service_backend
 from ..exceptions import IBMInputValueError
@@ -31,7 +29,7 @@ from ..executor import Executor
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.estimator import EstimatorOptions
 from .prepare import prepare
-from .utils import find_unique_layers, resolve_precision
+from .utils import find_box_type, find_unique_layers, resolve_precision
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -201,7 +199,7 @@ class EstimatorV2(BaseEstimatorV2):
             est = EstimatorV2(mode, options)
             est.options.resilience.pec_mitigation = True
 
-            layers = est.find_unique_layers(pubs, mode="gates")
+            layers = est.find_unique_layers(pubs, types="gates")
 
             results = NoiseLearnerV3(mode).run(layers).result()
             noise_model = results.to_dict(layers)
@@ -214,7 +212,7 @@ class EstimatorV2(BaseEstimatorV2):
             types: The types of layers to return. Can be either ``"gates"`` or ``"all"``.
 
         Returns:
-            The unique boxed layers found across the given PUBs.
+            The unique boxed layers of a certain type found across the given PUBs.
         """
         coerced_pubs = [EstimatorPub.coerce(pub, None) for pub in pubs]
         options = self.finalize_options()
@@ -226,8 +224,8 @@ class EstimatorV2(BaseEstimatorV2):
             or (options.resilience.zne_mitigation and options.resilience.zne.amplifier == "pea"),
             add_tags=True,
         )
-        annotation_type = Tag if types == "all" else InjectNoise
-        return [layer for layer in layers if get_annotation(layer.operation, annotation_type)]
+        box_types = ("gate", "measurement", "unknown") if types == "all" else ("gate",)
+        return [layer for layer in layers if find_box_type(layer) in box_types]
 
     def finalize_options(self) -> EstimatorOptions:
         """Construct and finalize the Estimator options.

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 import warnings
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import numpy as np
 from qiskit.primitives.base import BaseEstimatorV2
@@ -29,7 +29,7 @@ from ..executor import Executor
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.estimator import EstimatorOptions
 from .prepare import prepare
-from .utils import find_box_type, find_unique_layers, resolve_precision
+from .utils import BoxType, find_box_type, find_unique_layers, resolve_precision
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -224,7 +224,7 @@ class EstimatorV2(BaseEstimatorV2):
             or (options.resilience.zne_mitigation and options.resilience.zne.amplifier == "pea"),
             add_tags=True,
         )
-        box_types = ("gates", "measurement", "unknown") if types == "all" else ("gates",)
+        box_types = get_args(BoxType) if types == "all" else ("gates",)
         return [layer for layer in layers if find_box_type(layer) in box_types]
 
     def finalize_options(self) -> EstimatorOptions:

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -185,24 +185,23 @@ class EstimatorV2(BaseEstimatorV2):
         super().__setattr__(name, value)
 
     def find_unique_layers(
-        self, pubs: Iterable[EstimatorPubLike], types: Literal["2Q", "all"] = "2Q"
+        self, pubs: Iterable[EstimatorPubLike], types: Literal["gates", "all"] = "gates"
     ) -> list[CircuitInstruction]:
         """Return the unique boxed layers found across the given PUBs.
 
-        The ``types`` of layers can be either ``"2Q"`` or ``"all"``, corresponding to 2-qubit
+        The ``types`` of layers can be either ``"gates"`` or ``"all"``, corresponding to only
         gate layers or all layers, respectively. The returned list then contains one instance of
         each distinct boxed layer (represented as a :class:`~.CircuitInstruction`) appearing
         in the input PUBs.
 
-        For example, for noise learning, keep only the 2-qubit layers that carry an
-        class:`~samplomatic.InjectNoise` annotation:
+        For example, for noise learning, keep only the qubit gate layers:
 
         .. code-block:: python
 
             est = EstimatorV2(mode, options)
             est.options.resilience.pec_mitigation = True
 
-            layers = est.find_unique_layers(pubs, mode="2Q")
+            layers = est.find_unique_layers(pubs, mode="gates")
 
             results = NoiseLearnerV3(mode).run(layers).result()
             noise_model = results.to_dict(layers)
@@ -212,7 +211,7 @@ class EstimatorV2(BaseEstimatorV2):
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
-            types: The types of layers to return. Can be either ``"2Q"`` or ``"all"``.
+            types: The types of layers to return. Can be either ``"gates"`` or ``"all"``.
 
         Returns:
             The unique boxed layers found across the given PUBs.

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from qiskit.primitives.base import BaseEstimatorV2
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from samplomatic import InjectNoise, Tag
+from samplomatic.utils import get_annotation
 
 from ..base_primitive import get_mode_service_backend
 from ..exceptions import IBMInputValueError
@@ -154,28 +156,25 @@ class EstimatorV2(BaseEstimatorV2):
 
         super().__setattr__(name, value)
 
-    def find_unique_layers(self, pubs: Iterable[EstimatorPubLike]) -> list[CircuitInstruction]:
+    def find_unique_layers(
+        self, pubs: Iterable[EstimatorPubLike], types: Literal["2Q", "all"] = "2Q"
+    ) -> list[CircuitInstruction]:
         """Return the unique boxed layers found across the given PUBs.
 
-        The returned list contains one instance of each distinct boxed layer (represented as a
-        :class:`~.CircuitInstruction`) appearing in the input PUBs.
+        The ``types`` of layers can be either ``"2Q"`` or ``"all"``, corresponding to 2-qubit
+        gate layers or all layers, respectively. The returned list then contains one instance of
+        each distinct boxed layer (represented as a :class:`~.CircuitInstruction`) appearing
+        in the input PUBs.
 
-        For noise learning, keep only the boxes that carry an :class:`~samplomatic.InjectNoise`
-        annotation:
+        For example, for noise learning, keep only the 2-qubit layers that carry an
+        class:`~samplomatic.InjectNoise` annotation:
 
         .. code-block:: python
-
-            from samplomatic import InjectNoise
-            from samplomatic.utils import get_annotation
 
             est = EstimatorV2(mode, options)
             est.options.resilience.pec_mitigation = True
 
-            layers = [
-                layer
-                for layer in est.find_unique_layers(pubs)
-                if get_annotation(layer.operation, InjectNoise)
-            ]
+            layers = est.find_unique_layers(pubs, mode="2Q")
 
             results = NoiseLearnerV3(mode).run(layers).result()
             noise_model = results.to_dict(layers)
@@ -185,13 +184,14 @@ class EstimatorV2(BaseEstimatorV2):
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
+            types: The types of layers to return. Can be either ``"2Q"`` or ``"all"``.
 
         Returns:
             The unique boxed layers found across the given PUBs.
         """
         coerced_pubs = [EstimatorPub.coerce(pub, None) for pub in pubs]
         options = self.finalize_options()
-        return find_unique_layers(
+        layers = find_unique_layers(
             pubs=coerced_pubs,
             twirling_options=options.twirling,
             measure_noise_learning=options.resilience.measure_noise_learning,
@@ -199,6 +199,8 @@ class EstimatorV2(BaseEstimatorV2):
             or (options.resilience.zne_mitigation and options.resilience.zne.amplifier == "pea"),
             add_tags=True,
         )
+        annotation_type = Tag if types == "all" else InjectNoise
+        return [layer for layer in layers if get_annotation(layer.operation, annotation_type)]
 
     def finalize_options(self) -> EstimatorOptions:
         """Construct and finalize the Estimator options.

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -18,7 +18,7 @@ permanent location (qiskit-addons or qiskit core) in the future.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -55,6 +55,9 @@ _REQUIRED_NOISE_FACTORS = {
     "fallback": 1,
     **{f"polynomial_degree_{degree}": degree + 1 for degree in range(1, 8)},
 }
+
+# TypeAlias for a BoxOp type
+BoxType: TypeAlias = Literal["gates", "measurement", "unknown"]
 
 
 def validate_noise_factors(
@@ -333,14 +336,14 @@ def find_unique_layers(
     )
 
 
-def find_box_type(instruction: BoxOp) -> Literal["gate", "measurement", "unknown"]:
+def find_box_type(instruction: BoxOp) -> BoxType:
     """Find the type of :class:`~qiskit.circuit.BoxOp` that ``instruction`` contains.
 
     Args:
         instruction: The instruction to get the type of.
 
     Returns:
-        The box type. Can be one of ``"gate"``, ``"measurement"``, or ``"unknown"``.
+        The box type. Can be one of ``"gates"``, ``"measurement"``, or ``"unknown"``.
 
     Raises:
         IBMInputValueError: If ``instruction`` does not contain a box.
@@ -352,13 +355,13 @@ def find_box_type(instruction: BoxOp) -> Literal["gate", "measurement", "unknown
     undressed_box = undress_box(box)
 
     if len(undressed_box.body) == 0:
-        return "gate"
+        return "gates"
 
     all_gates = all(op.is_standard_gate() or op.name == "barrier" for op in undressed_box.body)
     all_measurement = all(op.name in ["measure", "barrier"] for op in undressed_box.body)
 
     if all_gates and not all_measurement:
-        return "gate"
+        return "gates"
     elif not all_gates and all_measurement:
         return "measurement"
 

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
     from qiskit import QuantumCircuit
-    from qiskit.circuit import CircuitInstruction
+    from qiskit.circuit import BoxOp, CircuitInstruction
     from qiskit.primitives import EstimatorPub, SamplerPub
     from samplomatic.samplex import Samplex
 
@@ -41,7 +41,7 @@ from qiskit.circuit.exceptions import CircuitError
 from qiskit.quantum_info import Pauli, PauliList
 from samplomatic import ChangeBasis
 from samplomatic.transpiler import generate_boxing_pass_manager
-from samplomatic.utils import find_unique_box_instructions, get_annotation
+from samplomatic.utils import find_unique_box_instructions, get_annotation, undress_box
 
 from ..exceptions import IBMInputValueError
 
@@ -331,6 +331,38 @@ def find_unique_layers(
     return find_unique_box_instructions(
         instructions=instructions, normalize_annotations=None, undress_boxes=True
     )
+
+
+def find_box_type(instruction: BoxOp) -> Literal["gate", "measurement", "unknown"]:
+    """Find the type of :class:`~qiskit.circuit.BoxOp` that ``instruction`` contains.
+
+    Args:
+        instruction: The instruction to get the type of.
+
+    Returns:
+        The box type. Can be one of ``"gate"``, ``"measurement"``, or ``"unknown"``.
+
+    Raises:
+        IBMInputValueError: If ``instruction`` does not contain a box.
+    """
+    box = instruction.operation
+    if (name := box.name) != "box":
+        raise IBMInputValueError(f"Expected a 'box' but found '{name}'.")
+
+    undressed_box = undress_box(box)
+
+    if len(undressed_box.body) == 0:
+        return "gate"
+
+    all_gates = all(op.is_standard_gate() or op.name == "barrier" for op in undressed_box.body)
+    all_measurement = all(op.name in ["measure", "barrier"] for op in undressed_box.body)
+
+    if all_gates and not all_measurement:
+        return "gate"
+    elif not all_gates and all_measurement:
+        return "measurement"
+
+    return "unknown"
 
 
 def compute_samplex_arguments(

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from qiskit.primitives.base import BaseSamplerV2
 from qiskit.primitives.containers.sampler_pub import SamplerPub
+from samplomatic import InjectNoise, Tag
+from samplomatic.utils import get_annotation
 
 from ..base_primitive import get_mode_service_backend
 from ..executor import Executor
@@ -126,27 +128,34 @@ class SamplerV2(BaseSamplerV2):
 
         super().__setattr__(name, value)
 
-    def find_unique_layers(self, pubs: Iterable[SamplerPubLike]) -> list[CircuitInstruction]:
-        """Return the unique boxed layers found across the given PUBs.
+    def find_unique_layers(
+        self, pubs: Iterable[SamplerPubLike], types: Literal["2Q", "all"] = "2Q"
+    ) -> list[CircuitInstruction]:
+        """Return the unique boxed layers found across the given PUBs of a given type.
 
-        The returned list contains one instance of each distinct boxed layer (represented as a
-        :class:`~.CircuitInstruction`) appearing in the input PUBs.
+        The ``types`` of layers can be either ``"2Q"`` or ``"all"``, corresponding to 2-qubit
+        gate layers or all layers, respectively. The returned list then contains one instance of
+        each distinct boxed layer (represented as a :class:`~.CircuitInstruction`) appearing
+        in the input PUBs.
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
+            types: The types of layers to return. Can be either ``"2Q"`` or ``"all"``.
 
         Returns:
             The unique boxed layers found across the given PUBs.
         """
         coerced_pubs = [SamplerPub.coerce(pub, None) for pub in pubs]
         options = self.finalize_options()
-        return find_unique_layers(
+        layers = find_unique_layers(
             pubs=coerced_pubs,
             twirling_options=options.twirling,
             measure_noise_learning=None,
             inject_noise=False,
             add_tags=True,
         )
+        annotated_type = Tag if types == "all" else InjectNoise
+        return [layer for layer in layers if get_annotation(layer, annotated_type)]
 
     def finalize_options(self) -> SamplerOptions:
         """Construct and finalize the Sampler options.

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -129,18 +129,18 @@ class SamplerV2(BaseSamplerV2):
         super().__setattr__(name, value)
 
     def find_unique_layers(
-        self, pubs: Iterable[SamplerPubLike], types: Literal["2Q", "all"] = "2Q"
+        self, pubs: Iterable[SamplerPubLike], types: Literal["gates", "all"] = "gates"
     ) -> list[CircuitInstruction]:
         """Return the unique boxed layers found across the given PUBs of a given type.
 
-        The ``types`` of layers can be either ``"2Q"`` or ``"all"``, corresponding to 2-qubit
+        The ``types`` of layers can be either ``"gates"`` or ``"all"``, corresponding to only
         gate layers or all layers, respectively. The returned list then contains one instance of
         each distinct boxed layer (represented as a :class:`~.CircuitInstruction`) appearing
         in the input PUBs.
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.
-            types: The types of layers to return. Can be either ``"2Q"`` or ``"all"``.
+            types: The types of layers to return. Can be either ``"gates"`` or ``"all"``.
 
         Returns:
             The unique boxed layers found across the given PUBs.

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -16,14 +16,14 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, get_args
 
 from qiskit.primitives.base import BaseSamplerV2
 from qiskit.primitives.containers.sampler_pub import SamplerPub
 
 from ..base_primitive import get_mode_service_backend
 from ..executor import Executor
-from ..executor_estimator.utils import find_box_type, find_unique_layers
+from ..executor_estimator.utils import BoxType, find_box_type, find_unique_layers
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.sampler import SamplerOptions
 from .prepare import prepare
@@ -152,7 +152,7 @@ class SamplerV2(BaseSamplerV2):
             inject_noise=False,
             add_tags=True,
         )
-        box_types = ("gate", "measurement", "unknown") if types == "all" else ("gate",)
+        box_types = get_args(BoxType) if types == "all" else ("gates",)
         return [layer for layer in layers if find_box_type(layer) in box_types]
 
     def finalize_options(self) -> SamplerOptions:

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -20,12 +20,10 @@ from typing import TYPE_CHECKING, Literal
 
 from qiskit.primitives.base import BaseSamplerV2
 from qiskit.primitives.containers.sampler_pub import SamplerPub
-from samplomatic import InjectNoise, Tag
-from samplomatic.utils import get_annotation
 
 from ..base_primitive import get_mode_service_backend
 from ..executor import Executor
-from ..executor_estimator.utils import find_unique_layers
+from ..executor_estimator.utils import find_box_type, find_unique_layers
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.sampler import SamplerOptions
 from .prepare import prepare
@@ -143,7 +141,7 @@ class SamplerV2(BaseSamplerV2):
             types: The types of layers to return. Can be either ``"gates"`` or ``"all"``.
 
         Returns:
-            The unique boxed layers found across the given PUBs.
+            The unique boxed layers of a certain type found across the given PUBs.
         """
         coerced_pubs = [SamplerPub.coerce(pub, None) for pub in pubs]
         options = self.finalize_options()
@@ -154,8 +152,8 @@ class SamplerV2(BaseSamplerV2):
             inject_noise=False,
             add_tags=True,
         )
-        annotated_type = Tag if types == "all" else InjectNoise
-        return [layer for layer in layers if get_annotation(layer, annotated_type)]
+        box_types = ("gate", "measurement", "unknown") if types == "all" else ("gate",)
+        return [layer for layer in layers if find_box_type(layer) in box_types]
 
     def finalize_options(self) -> SamplerOptions:
         """Construct and finalize the Sampler options.

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -99,7 +99,7 @@ class TestEstimator(IBMIntegrationTestCase):
         estimator = EstimatorV2(self.backend)
         estimator.options.resilience.pec_mitigation = True
 
-        layers = estimator.find_unique_layers(self.pubs)
+        layers = estimator.find_unique_layers(self.pubs, types="gates")
         estimator.options.resilience.noise_model = {
             annotation.ref: PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.001)])
             for layer in layers
@@ -135,7 +135,7 @@ class TestEstimator(IBMIntegrationTestCase):
         estimator.options.resilience.zne.amplifier = amplifier
 
         if amplifier == "pea":
-            layers = estimator.find_unique_layers(self.pubs)
+            layers = estimator.find_unique_layers(self.pubs, types="gates")
             estimator.options.resilience.noise_model = {
                 annotation.ref: PauliLindbladMap.from_list(
                     [("X" * layer.operation.num_qubits, 0.001)]

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -117,7 +117,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         # ground truth.
         np.testing.assert_allclose(actual=evs, desired=ideal_evs, atol=0.02)
 
-    def test_correct_estimates_with_pec(self):
+    def test_correct_estimates_with_pectest_correct_estimates_with_pec(self):
         """Tests that EstimatorV2 with PEC produces correct results in a noise-less environment."""
         pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
 
@@ -134,11 +134,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         # Need to test this for a fake backend (e.g. in noisy test).
         # estimator.options.dynamical_decoupling.enable = True
 
-        layers = [
-            layer
-            for layer in estimator.find_unique_layers([pub])
-            if get_annotation(layer.operation, InjectNoise)
-        ]
+        layers = estimator.find_unique_layers([pub], types="2Q")
 
         # In a noise-less simulation we do not expect noise. So we can construct the noise_model
         # with empty noise for all layers:

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -112,7 +112,7 @@ class TestEstimatorWithNoise(IBMTestCase):
         # Add noise to every unique layer, independent of its content (gates or measurements).
         simulated_noise_model = {
             annotation.ref: PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.005)])
-            for layer in base_level_estimator.find_unique_layers([pub])
+            for layer in base_level_estimator.find_unique_layers([pub], types="all")
             if (annotation := get_annotation(layer.operation, Tag))
         }
         base_level_estimator.options.experimental["simulator_options"] = (
@@ -138,7 +138,7 @@ class TestEstimatorWithNoise(IBMTestCase):
             inject_noise_annotation.ref: simulated_noise_model[
                 get_annotation(layer.operation, Tag).ref
             ]
-            for layer in estimator.find_unique_layers([pub])
+            for layer in estimator.find_unique_layers([pub], types="all")
             if (inject_noise_annotation := get_annotation(layer.operation, InjectNoise))
         }
         estimator.options.resilience.noise_model = injected_noise_model

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -144,7 +144,7 @@ class TestEstimatorWithNoise(IBMTestCase):
         # Add noise to every unique layer, independent of its content (gates or measurements).
         simulated_noise_model = {
             annotation.ref: PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.005)])
-            for layer in base_level_estimator.find_unique_layers([pub])
+            for layer in base_level_estimator.find_unique_layers([pub], types="all")
             if (annotation := get_annotation(layer.operation, Tag))
         }
         base_level_estimator.options.experimental["simulator_options"] = (

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -112,7 +112,7 @@ class TestEstimatorWithNoise(IBMTestCase):
         # Add noise to every unique layer, independent of its content (gates or measurements).
         simulated_noise_model = {
             annotation.ref: PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.005)])
-            for layer in base_level_estimator.find_unique_layers([pub], types="all")
+            for layer in base_level_estimator.find_unique_layers([pub])
             if (annotation := get_annotation(layer.operation, Tag))
         }
         base_level_estimator.options.experimental["simulator_options"] = (
@@ -138,7 +138,7 @@ class TestEstimatorWithNoise(IBMTestCase):
             inject_noise_annotation.ref: simulated_noise_model[
                 get_annotation(layer.operation, Tag).ref
             ]
-            for layer in estimator.find_unique_layers([pub], types="all")
+            for layer in estimator.find_unique_layers([pub])
             if (inject_noise_annotation := get_annotation(layer.operation, InjectNoise))
         }
         estimator.options.resilience.noise_model = injected_noise_model

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -173,7 +173,7 @@ class TestEstimatorWithNoise(IBMTestCase):
             inject_noise_annotation.ref: simulated_noise_model[
                 get_annotation(layer.operation, Tag).ref
             ]
-            for layer in estimator.find_unique_layers([pub])
+            for layer in estimator.find_unique_layers([pub], types="gates")
             if (inject_noise_annotation := get_annotation(layer.operation, InjectNoise))
         }
         estimator.options.resilience.noise_model = injected_noise_model

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -142,11 +142,7 @@ def create_estimator_test_data_extended(backend, preset_pass_manager):
 
 def create_noise_model_without_noise(estimator, pub):
     """Creates a noise-model, mapping each layer to the identity (no noise)."""
-    layers = [
-        layer
-        for layer in estimator.find_unique_layers([pub])
-        if get_annotation(layer.operation, InjectNoise)
-    ]
+    layers = estimator.find_unique_layers([pub], types="gates")
 
     # In a noise-less simulation we do not expect noise. So we can construct the noise_model
     # with empty noise for all layers:

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -26,6 +26,7 @@ from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_estimator.utils import (
     box_circuit,
     compute_samplex_arguments,
+    find_box_type,
     get_pauli_basis,
     pauli_to_ints,
     resolve_precision,
@@ -478,3 +479,36 @@ class TestBoxCircuit(IBMTestCase):
                 0,
                 msg=f"Expected at least one tagged box for add_tags={add_tags!r}, but found none.",
             )
+
+
+class TestFindBoxType(IBMTestCase):
+    """Tests for ``find_box_type``."""
+
+    def test_gates(self):
+        """Test that ``find_box_type`` returns "gates" as the type."""
+        circuit = QuantumCircuit(2)
+        with circuit.box():
+            circuit.h(0)
+            circuit.barrier()
+            circuit.cx(0, 1)
+
+        self.assertEqual(find_box_type(circuit.data[0]), "gates")
+
+    def test_measurement(self):
+        """Test that ``find_box_type`` returns "measurement" as the type."""
+        circuit = QuantumCircuit(2, 2)
+        with circuit.box():
+            circuit.barrier()
+            circuit.measure(0, 0)
+            circuit.measure(1, 1)
+
+        self.assertEqual(find_box_type(circuit.data[0]), "measurement")
+
+    def test_unknown(self):
+        """Test that ``find_box_type`` returns "unknown" as the type."""
+        circuit = QuantumCircuit(2, 1)
+        with circuit.box():
+            circuit.h(0)
+            circuit.measure(0, 0)
+
+        self.assertEqual(find_box_type(circuit.data[0]), "unknown")


### PR DESCRIPTION
### Summary
Adding a `types` argument to `find_unique_layers` to make filtering layers convenient for the user 

### Details and comments

Closes #3219

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Bob for test and cleanup
