### PR TITLE
Simtest: Improve test data: Better TREX bug circumvention and more observables close to 1

### DIFF
--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -50,12 +50,7 @@ class TestEstimatorWithNoise(IBMTestCase):
 
         Estimator result quality is expected to increase with increasing resilience level.
         """
-        # FIXME: add_projector_observables=False is only needed,
-        # due to a bug in TREX post-processing:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        pub, ideal_evs = create_estimator_test_data(
-            self.backend, self.preset_pass_manager, add_projector_observables=False
-        )
+        pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
 
         # maps resilience level to error (compared to statevector simulation) for each observable
         errors: dict[int, npt.NDArray[np.float64]] = {}
@@ -95,15 +90,9 @@ class TestEstimatorWithoutNoise(IBMTestCase):
 
         Parametrized to run with all three estimator resilience levels.
         """
-        # FIXME: add_projector_observables=False is only needed,
-        # due to a bug in TREX post-processing affecting resilience levels > 0:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        add_projector_observables = True if resilience_level == 0 else False
-
         pub, ideal_evs = create_estimator_test_data(
             self.backend,
             self.preset_pass_manager,
-            add_projector_observables=add_projector_observables,
         )
 
         estimator = create_local_mode_estimator(self.backend)
@@ -125,10 +114,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         estimator.options.resilience.pec_mitigation = True
         estimator.options.twirling.enable_gates = True
         estimator.options.twirling.enable_measure = True
-
-        # FIXME: TREX currently not possible for the projector observables we use here:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        # estimator.options.resilience.measure_mitigation = True
+        estimator.options.resilience.measure_mitigation = True
 
         # TODO: no DD possible on AER without gate durations.
         # Need to test this for a fake backend (e.g. in noisy test).

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -28,7 +28,11 @@ from qiskit_ibm_runtime.fake_provider import FakeManilaV2
 from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ....ibm_test_case import IBMTestCase
-from .utils import create_estimator_test_data, create_local_mode_estimator
+from .utils import (
+    create_estimator_test_data_big,
+    create_estimator_test_data_small,
+    create_local_mode_estimator,
+)
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -51,7 +55,7 @@ class TestEstimatorWithNoise(IBMTestCase):
 
         Estimator result quality is expected to increase with increasing resilience level.
         """
-        pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
+        pub, ideal_evs = create_estimator_test_data_small(self.backend, self.preset_pass_manager)
 
         # maps resilience level to error (compared to statevector simulation) for each observable
         errors: dict[int, npt.NDArray[np.float64]] = {}
@@ -90,12 +94,7 @@ class TestEstimatorWithNoise(IBMTestCase):
         # maps bool (whether we applied PEC or not) to errors for each observable
         errors: dict[bool, npt.NDArray[np.float64]] = {}
 
-        # FIXME: add_projector_observables=False is only needed,
-        # due to a bug in TREX post-processing:
-        # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-        pub, ideal_evs = create_estimator_test_data(
-            backend, preset_pass_manager, add_projector_observables=False
-        )
+        pub, ideal_evs = create_estimator_test_data_small(backend, preset_pass_manager)
 
         # Add noise to every unique layer, independent of its content (gates or measurements).
         simulated_noise_model = {
@@ -146,7 +145,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
 
         Parametrized to run with all three estimator resilience levels.
         """
-        pub, ideal_evs = create_estimator_test_data(
+        pub, ideal_evs = create_estimator_test_data_big(
             self.backend,
             self.preset_pass_manager,
         )
@@ -164,7 +163,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
 
     def test_correct_estimates_with_pec(self):
         """Tests that EstimatorV2 with PEC produces correct results in a noise-less environment."""
-        pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
+        pub, ideal_evs = create_estimator_test_data_big(self.backend, self.preset_pass_manager)
 
         estimator = create_local_mode_estimator(self.backend)
         estimator.options.resilience.pec_mitigation = True

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -48,6 +48,7 @@ def create_estimator_test_data(backend, preset_pass_manager):
     y_q1 = np.sin(phi)
     l_q0 = (1 + np.sin(theta)) / 2
     z_q0 = np.cos(theta)
+    x_q2 = sq2_half
     proj_q2 = (1 + sq2_half) / 2
     z0_q0 = (1 + np.cos(theta)) / 2
 
@@ -58,6 +59,7 @@ def create_estimator_test_data(backend, preset_pass_manager):
         ("-IYI", proj_q2 * y_q1),
         ("IIY0", y_q1 * z0_q0),
         ("I1YI", proj_q2 * y_q1),
+        ("IXII", x_q2),
     ]
 
     # Prepare a PUB with multiple observables to estimate expectation values on.

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -24,7 +24,7 @@ from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
 from ....utils import make_mirror_circuit_with_phases
 
 
-def create_estimator_test_data(backend, preset_pass_manager, add_projector_observables=True):
+def create_estimator_test_data(backend, preset_pass_manager):
     """Create a pub and ideal expectation values for it."""
     # Use standard mirror circuit.
     # - No measurements, as StatevectorEstimator does not support them.
@@ -45,20 +45,21 @@ def create_estimator_test_data(backend, preset_pass_manager, add_projector_obser
         ("IIZ", np.cos(theta)),
         ("IYZ", np.cos(theta)),
         ("XIZ", np.cos(theta)),
+        ("1IZ", 0.5 * np.cos(theta)),
+        ("IrZ", np.cos(theta)),
+        ("X+I", 0.5),
+        ("0IZ", 0.5 * np.cos(theta)),
+        ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
+        ("X-I", 0.5),
     ]
-    if add_projector_observables:
-        observable_ideal_ev_pairs.extend(
-            [
-                ("1IZ", 0.5 * np.cos(theta)),
-                ("IYr", np.sin(np.pi / 4 - theta / 2) ** 2),
-                ("X+I", 0.5),
-                ("0IZ", 0.5 * np.cos(theta)),
-                ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
-                ("X-I", 0.5),
-            ]
-        )
 
     # Prepare a PUB with multiple observables to estimate expectation values on.
+
+    # FIXME: Composing observables from plain `Operator` instead of directly passing strings,
+    # due to a bug in TREX post-processing affecting resilience levels > 0:
+    # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
+    # Once this is fixed, we can do:
+    # observables = [obs_string for obs_string, _ in observable_ideal_ev_pairs]
     observables = [
         SparsePauliOp.from_operator(Operator.from_label(obs_string)).apply_layout(
             isa_circuit.layout

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -24,11 +24,12 @@ from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
 from ....utils import make_mirror_circuit_with_phases
 
 
-def create_estimator_test_data(backend, preset_pass_manager):
-    """Create a pub and ideal expectation values for it."""
-    # Use standard mirror circuit.
-    # - No measurements, as StatevectorEstimator does not support them.
-    # - No trailing Rx gates, as we want to add our own rotations
+def create_estimator_test_data_big(backend, preset_pass_manager):
+    """Create a pub and ideal expectation values for it.
+
+    The circuit will use 4 qubits and try to use an extensive list of observables to provide
+    coverage.
+    """
     circuit = make_mirror_circuit_with_phases(
         backend, num_qubits=4, add_measurement=False, add_rx=False
     )
@@ -53,16 +54,63 @@ def create_estimator_test_data(backend, preset_pass_manager):
     z0_q0 = (1 + np.cos(theta)) / 2
 
     observable_ideal_ev_pairs: list[tuple[str, float]] = [
-        ("IIrl", r_q1 * l_q0),
-        ("IIrZ", r_q1 * z_q0),
-        ("I+YI", proj_q2 * y_q1),
-        ("-IYI", proj_q2 * y_q1),
-        ("IIY0", y_q1 * z0_q0),
-        ("I1YI", proj_q2 * y_q1),
-        ("IXII", x_q2),
+        ("IIrl", r_q1 * l_q0),  # ≈ 0.741
+        ("IIrZ", r_q1 * z_q0),  # ≈ 0.755
+        ("I+YI", proj_q2 * y_q1),  # ≈ 0.740
+        ("-IYI", proj_q2 * y_q1),  # ≈ 0.740
+        ("IIY0", y_q1 * z0_q0),  # ≈ 0.783
+        ("I1YI", proj_q2 * y_q1),  # ≈ 0.740
+        ("IXII", x_q2),  # ≈ 0.707
     ]
 
     # Prepare a PUB with multiple observables to estimate expectation values on.
+
+    # FIXME: Composing observables from plain `Operator` instead of directly passing strings,
+    # due to a bug in TREX post-processing affecting resilience levels > 0:
+    # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
+    # Once this is fixed, we can do:
+    # observables = [obs_string for obs_string, _ in observable_ideal_ev_pairs]
+    observables = [
+        SparsePauliOp.from_operator(Operator.from_label(obs_string)).apply_layout(
+            isa_circuit.layout
+        )
+        for obs_string, _ in observable_ideal_ev_pairs
+    ]
+
+    pub = (isa_circuit, observables, parameters)
+
+    return pub, [ev for _, ev in observable_ideal_ev_pairs]
+
+
+def create_estimator_test_data_small(backend, preset_pass_manager):
+    """Create a pub and ideal expectation values for it.
+
+    The circuit will use 3 qubits and only a subset of observable combinations.
+    """
+    circuit = make_mirror_circuit_with_phases(
+        backend, num_qubits=3, add_measurement=False, add_rx=False
+    )
+
+    circuit.rx(Parameter("rx_0"), 0)
+    circuit.rx(Parameter("rx_1"), 1)
+    circuit.ry(Parameter("ry_2"), 2)
+    isa_circuit = preset_pass_manager.run(circuit)
+
+    theta = np.pi / 5
+    phi = np.pi / 3
+    parameters = [theta, -phi, 3 * np.pi / 4]
+
+    y_q1 = np.sin(phi)
+    z_q0 = np.cos(theta)
+    r_q1 = (1 + np.sin(phi)) / 2
+    l_q0 = (1 + np.sin(theta)) / 2
+    x_q2 = np.sqrt(2) / 2
+
+    observable_ideal_ev_pairs: list[tuple[str, float]] = [
+        ("IYZ", y_q1 * z_q0),  # ≈ 0.701
+        ("Irl", r_q1 * l_q0),  # ≈ 0.741
+        ("XII", x_q2),  # ≈ 0.707
+    ]
 
     # FIXME: Composing observables from plain `Operator` instead of directly passing strings,
     # due to a bug in TREX post-processing affecting resilience levels > 0:

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -33,26 +33,6 @@ def create_estimator_test_data(backend, preset_pass_manager):
         backend, num_qubits=4, add_measurement=False, add_rx=False
     )
 
-    ## Add rotations to produce eigenstates of X, Y and Z:
-    # circuit.rx(Parameter("rx_0"), 0)
-    # circuit.rx(Parameter("rx_1"), 1)
-    # circuit.ry(Parameter("ry_2"), 2)
-    # isa_circuit = preset_pass_manager.run(circuit)
-    # theta = np.pi / 8
-    # parameters = [theta, -np.pi / 2, np.pi / 2]
-
-    # observable_ideal_ev_pairs: list[tuple[str, float]] = [
-    #    ("IIZ", np.cos(theta)),
-    #    ("IYZ", np.cos(theta)),
-    #    ("XIZ", np.cos(theta)),
-    #    ("IrZ", np.cos(theta)),
-    #    ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
-    #    ("1IZ", 0.5 * np.cos(theta)),
-    #    ("X+I", 0.5),
-    #    ("0IZ", 0.5 * np.cos(theta)),
-    #    ("X-I", 0.5),
-    # ]
-
     circuit.rx(Parameter("rx_0"), 0)
     circuit.rx(Parameter("rx_1"), 1)
     circuit.ry(Parameter("ry_2"), 2)

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -30,27 +30,54 @@ def create_estimator_test_data(backend, preset_pass_manager):
     # - No measurements, as StatevectorEstimator does not support them.
     # - No trailing Rx gates, as we want to add our own rotations
     circuit = make_mirror_circuit_with_phases(
-        backend, num_qubits=3, add_measurement=False, add_rx=False
+        backend, num_qubits=4, add_measurement=False, add_rx=False
     )
 
-    # Add rotations to produce eigenstates of X, Y and Z:
+    ## Add rotations to produce eigenstates of X, Y and Z:
+    # circuit.rx(Parameter("rx_0"), 0)
+    # circuit.rx(Parameter("rx_1"), 1)
+    # circuit.ry(Parameter("ry_2"), 2)
+    # isa_circuit = preset_pass_manager.run(circuit)
+    # theta = np.pi / 8
+    # parameters = [theta, -np.pi / 2, np.pi / 2]
+
+    # observable_ideal_ev_pairs: list[tuple[str, float]] = [
+    #    ("IIZ", np.cos(theta)),
+    #    ("IYZ", np.cos(theta)),
+    #    ("XIZ", np.cos(theta)),
+    #    ("IrZ", np.cos(theta)),
+    #    ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
+    #    ("1IZ", 0.5 * np.cos(theta)),
+    #    ("X+I", 0.5),
+    #    ("0IZ", 0.5 * np.cos(theta)),
+    #    ("X-I", 0.5),
+    # ]
+
     circuit.rx(Parameter("rx_0"), 0)
     circuit.rx(Parameter("rx_1"), 1)
     circuit.ry(Parameter("ry_2"), 2)
+    circuit.ry(Parameter("ry_3"), 3)
     isa_circuit = preset_pass_manager.run(circuit)
-    theta = np.pi / 8
-    parameters = [theta, -np.pi / 2, np.pi / 2]
+
+    theta = np.pi / 5
+    phi = np.pi / 3
+    parameters = [theta, -phi, 3 * np.pi / 4, -3 * np.pi / 4]
+
+    sq2_half = np.sqrt(2) / 2
+    r_q1 = (1 + np.sin(phi)) / 2
+    y_q1 = np.sin(phi)
+    l_q0 = (1 + np.sin(theta)) / 2
+    z_q0 = np.cos(theta)
+    proj_q2 = (1 + sq2_half) / 2
+    z0_q0 = (1 + np.cos(theta)) / 2
 
     observable_ideal_ev_pairs: list[tuple[str, float]] = [
-        ("IIZ", np.cos(theta)),
-        ("IYZ", np.cos(theta)),
-        ("XIZ", np.cos(theta)),
-        ("1IZ", 0.5 * np.cos(theta)),
-        ("IrZ", np.cos(theta)),
-        ("X+I", 0.5),
-        ("0IZ", 0.5 * np.cos(theta)),
-        ("IYl", np.cos(np.pi / 4 - theta / 2) ** 2),
-        ("X-I", 0.5),
+        ("IIrl", r_q1 * l_q0),
+        ("IIrZ", r_q1 * z_q0),
+        ("I+YI", proj_q2 * y_q1),
+        ("-IYI", proj_q2 * y_q1),
+        ("IIY0", y_q1 * z0_q0),
+        ("I1YI", proj_q2 * y_q1),
     ]
 
     # Prepare a PUB with multiple observables to estimate expectation values on.

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -53,31 +53,31 @@ def create_estimator_test_data_big(backend, preset_pass_manager):
     proj_q2 = (1 + sq2_half) / 2
     z0_q0 = (1 + np.cos(theta)) / 2
 
-    observable_ideal_ev_pairs: list[tuple[str, float]] = [
-        ("IIrl", r_q1 * l_q0),  # ≈ 0.741
-        ("IIrZ", r_q1 * z_q0),  # ≈ 0.755
-        ("I+YI", proj_q2 * y_q1),  # ≈ 0.740
-        ("-IYI", proj_q2 * y_q1),  # ≈ 0.740
-        ("IIY0", y_q1 * z0_q0),  # ≈ 0.783
-        ("I1YI", proj_q2 * y_q1),  # ≈ 0.740
-        ("IXII", x_q2),  # ≈ 0.707
-    ]
-
-    # Prepare a PUB with multiple observables to estimate expectation values on.
-
     # FIXME: Composing observables from plain `Operator` instead of directly passing strings,
     # due to a bug in TREX post-processing affecting resilience levels > 0:
     # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-    # Once this is fixed, we can do:
-    # observables = [obs_string for obs_string, _ in observable_ideal_ev_pairs]
-    observables = [
-        SparsePauliOp.from_operator(Operator.from_label(obs_string)).apply_layout(
+    # Once this is fixed, we can pass the label strings directly.
+    def _obs(label):
+        return SparsePauliOp.from_operator(Operator.from_label(label)).apply_layout(
             isa_circuit.layout
         )
-        for obs_string, _ in observable_ideal_ev_pairs
+
+    observable_ideal_ev_pairs: list[tuple[SparsePauliOp, float]] = [
+        (_obs("IIrl"), r_q1 * l_q0),  # ≈ 0.741
+        (_obs("IIrZ"), r_q1 * z_q0),  # ≈ 0.755
+        (_obs("I+YI"), proj_q2 * y_q1),  # ≈ 0.740
+        (_obs("-IYI"), proj_q2 * y_q1),  # ≈ 0.740
+        (_obs("IIY0"), y_q1 * z0_q0),  # ≈ 0.783
+        (_obs("I1YI"), proj_q2 * y_q1),  # ≈ 0.740
+        (_obs("IXII"), x_q2),  # ≈ 0.707
+        # Weighted linear combination:
+        (
+            2.0 * _obs("-IrI") - 1.0 * _obs("1IYI"),
+            2.0 * proj_q2 * r_q1 - 1.0 * proj_q2 * y_q1,
+        ),  # ≈ 0.854
     ]
 
-    pub = (isa_circuit, observables, parameters)
+    pub = (isa_circuit, [obs for obs, _ in observable_ideal_ev_pairs], parameters)
 
     return pub, [ev for _, ev in observable_ideal_ev_pairs]
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Actually we had the TREX circumvention in place accidentally already. this PR just makes it explicit and enables projector observables for all tests.

Note, I needed to re-design the test-circuit and observables, otherwise multiple quality assertions became flaky (mostly in projectors where EVs were < 0.5). I guess this could be explained by the small value of the EV, now it should be close to 1.
The test-circuit re-write was assisted by Bob AI assistant.

part of #3208 

### Details and comments

Fixes #

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Bob
