### PR TITLE
Add noisy local mode simulation test to Executor

### DIFF
--- a/test/unit/executor/simulations/test_executor.py
+++ b/test/unit/executor/simulations/test_executor.py
@@ -31,10 +31,7 @@ from ....utils import make_mirror_circuit_with_phases
 
 
 class TestExecutor(IBMTestCase):
-    """Executor tests centered around qiskit-aer simulations.
-
-    All the tests in this class perform noiseless simulations.
-    """
+    """Executor tests centered around qiskit-aer simulations."""
 
     def setUp(self):
         """Test level setup."""

--- a/test/unit/executor/simulations/test_executor.py
+++ b/test/unit/executor/simulations/test_executor.py
@@ -119,8 +119,7 @@ class TestExecutor(IBMTestCase):
 
         parameter_values = np.random.random((circuit.num_parameters,))
 
-        shots = 4_000
-        program = QuantumProgram(shots=shots)
+        program = QuantumProgram(shots=4_000)
         program.append_samplex_item(
             isa_template, samplex=samplex, samplex_arguments={"parameter_values": parameter_values}
         )
@@ -173,6 +172,5 @@ class TestExecutor(IBMTestCase):
                 )
             )
 
-        self.assertTrue(
-            all((a > b) and (a < 1 and b < 1) for a, b in zip(fidelities, fidelities[1:]))
-        )
+        self.assertGreater(fidelities[0], fidelities[1])
+        self.assertGreater(fidelities[1], fidelities[2])

--- a/test/unit/executor/simulations/test_executor.py
+++ b/test/unit/executor/simulations/test_executor.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 
 import numpy as np
 from qiskit.primitives.containers import BitArray
-from qiskit.quantum_info import Statevector, hellinger_fidelity
+from qiskit.quantum_info import PauliLindbladMap, Statevector, hellinger_fidelity
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_aer import AerSimulator
-from samplomatic import build
+from samplomatic import Tag, build
 from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import find_unique_box_instructions, get_annotation
 
 from qiskit_ibm_runtime import Executor, QuantumProgram
+from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ....ibm_test_case import IBMTestCase
 from ....utils import make_mirror_circuit_with_phases
@@ -96,3 +98,82 @@ class TestExecutor(IBMTestCase):
                 msg=f"Fidelity: {fidelity}",
                 delta=self.tolerance,
             )
+
+    def test_noisy_simulation(self):
+        """Test noisy local mode simulations with the executor.
+
+        Checks that:
+        * The result shape is correct.
+        * The results diverge from the expected via Hellinger distance.
+          Probabilities of each outcome are computed exactly using Qiskit's StateVector class.
+        """
+        circuit = make_mirror_circuit_with_phases(self.backend)
+
+        pm = generate_preset_pass_manager(backend=self.backend, optimization_level=0)
+        pm.post_scheduling = generate_boxing_pass_manager(
+            enable_gates=True,
+            enable_measures=True,
+            add_tags="unique_box",
+            inject_noise_site="after",
+        )
+
+        boxed_isa_circuit = pm.run(circuit)
+        isa_template, samplex = build(boxed_isa_circuit)
+
+        parameter_values = np.random.random((circuit.num_parameters,))
+
+        shots = 4_000
+        program = QuantumProgram(shots=shots)
+        program.append_samplex_item(
+            isa_template, samplex=samplex, samplex_arguments={"parameter_values": parameter_values}
+        )
+
+        unique_instructions = find_unique_box_instructions(
+            boxed_isa_circuit,
+            normalize_annotations=None,
+            undress_boxes=True,
+        )
+
+        tag_refs = [
+            anno.ref
+            for inst in unique_instructions
+            if (anno := get_annotation(inst.operation, Tag)) is not None
+        ]
+
+        pauli_maps = [
+            PauliLindbladMap.from_list([("XY", 0.001)]),
+            PauliLindbladMap.from_list([("XY", 0.01)]),
+            PauliLindbladMap.from_list([("XY", 0.1)]),
+        ]
+
+        noise_models = [dict.fromkeys(tag_refs, pauli_map) for pauli_map in pauli_maps]
+
+        executor = Executor(
+            mode=AerSimulator(),
+            options={
+                "experimental": {
+                    "local_mode": True,
+                    "simulator_options": ExperimentalSimulatorOptions(),
+                }
+            },
+        )
+
+        circuit_cp = circuit.copy()
+        circuit_cp.remove_final_measurements()
+        bound_circuit = circuit_cp.assign_parameters(parameter_values)
+        probabilities = Statevector(bound_circuit).probabilities_dict()
+
+        fidelities = []
+        for noise_model in noise_models:
+            executor.options.experimental["simulator_options"].noise_model = noise_model
+            job = executor.run(program)
+            result = job.result()
+
+            array = result[0]["meas"] ^ result[0]["measurement_flips.meas"]
+
+            fidelity = hellinger_fidelity(
+                BitArray.from_bool_array(array, order="little").get_counts(), probabilities
+            )
+            fidelities.append(fidelity)
+
+        self.assertTrue(all(a > b for a, b in zip(fidelities, fidelities[1:])))

--- a/test/unit/executor/simulations/test_executor.py
+++ b/test/unit/executor/simulations/test_executor.py
@@ -103,9 +103,9 @@ class TestExecutor(IBMTestCase):
         """Test noisy local mode simulations with the executor.
 
         Checks that:
-        * The result shape is correct.
-        * The results diverge from the expected via Hellinger distance.
-          Probabilities of each outcome are computed exactly using Qiskit's StateVector class.
+        * The results increasingly diverge from the expected with increasing levels of noise.
+          Probabilities of each outcome are computed exactly using Qiskit's StateVector class
+          and fidelities are computed via Hellinger distance.
         """
         circuit = make_mirror_circuit_with_phases(self.backend)
 
@@ -140,13 +140,10 @@ class TestExecutor(IBMTestCase):
             if (anno := get_annotation(inst.operation, Tag)) is not None
         ]
 
-        pauli_maps = [
-            PauliLindbladMap.from_list([("XY", 0.001)]),
-            PauliLindbladMap.from_list([("XY", 0.01)]),
-            PauliLindbladMap.from_list([("XY", 0.1)]),
-        ]
-
-        noise_models = [dict.fromkeys(tag_refs, pauli_map) for pauli_map in pauli_maps]
+        circuit_cp = circuit.copy()
+        circuit_cp.remove_final_measurements()
+        bound_circuit = circuit_cp.assign_parameters(parameter_values)
+        probabilities = Statevector(bound_circuit).probabilities_dict()
 
         executor = Executor(
             mode=AerSimulator(),
@@ -158,22 +155,27 @@ class TestExecutor(IBMTestCase):
             },
         )
 
-        circuit_cp = circuit.copy()
-        circuit_cp.remove_final_measurements()
-        bound_circuit = circuit_cp.assign_parameters(parameter_values)
-        probabilities = Statevector(bound_circuit).probabilities_dict()
-
+        pauli_maps = [
+            PauliLindbladMap.from_list([("XY", 0.001)]),
+            PauliLindbladMap.from_list([("XY", 0.01)]),
+            PauliLindbladMap.from_list([("XY", 0.1)]),
+        ]
         fidelities = []
-        for noise_model in noise_models:
-            executor.options.experimental["simulator_options"].noise_model = noise_model
+        for pauli_map in pauli_maps:
+            executor.options.experimental["simulator_options"].noise_model = dict.fromkeys(
+                tag_refs, pauli_map
+            )
             job = executor.run(program)
             result = job.result()
 
             array = result[0]["meas"] ^ result[0]["measurement_flips.meas"]
 
-            fidelity = hellinger_fidelity(
-                BitArray.from_bool_array(array, order="little").get_counts(), probabilities
+            fidelities.append(
+                hellinger_fidelity(
+                    BitArray.from_bool_array(array, order="little").get_counts(), probabilities
+                )
             )
-            fidelities.append(fidelity)
 
-        self.assertTrue(all(a > b for a, b in zip(fidelities, fidelities[1:])))
+        self.assertTrue(
+            all((a > b) and (a < 1 and b < 1) for a, b in zip(fidelities, fidelities[1:]))
+        )


### PR DESCRIPTION
### Summary
Adding a simulation test to the Executor where we simulate noisy results and compare to the expected via Hellinger fidelity. We check that fidelity is less than 1 and decreases with increasing noise.

### Details and comments

Part of #3218 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
