### PR TITLE
Decompose observables into Paulis when TREX is on

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import logging
+import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -33,8 +35,10 @@ from ...executor_estimator.utils import get_pauli_basis, unbroadcast_index
 from ...executor_estimator.zne.extrapolation import process_extrapolated_expectation_values
 from ...results.estimator_pub import EstimatorPubResult
 from ...results.quantum_program import QuantumProgramResult
-from .trex_utils import calculate_trex_factor, get_processed_calibration_data
+from .trex_utils import calculate_trex_factor, expand_obs_dict, get_processed_calibration_data
 from .utils import compute_exp_val, identify_measure_basis
+
+logger = logging.getLogger(__name__)
 
 
 def _build_program_result_metadata(post_processor_data: dict) -> dict:
@@ -72,6 +76,54 @@ def _build_program_result_metadata(post_processor_data: dict) -> dict:
     program_metadata["target_precision"] = post_processor_data.get("precision", None)
     program_metadata["shots"] = post_processor_data.get("shots", None)
     return program_metadata
+
+
+def _expand_observables_lists(observables_lists: list) -> list:
+    """Walk the nested list-of-dicts from ``ObservablesArray.tolist()`` and expand projectors.
+
+    Replaces every observable dict with its projector-expanded equivalent.
+
+    The structure mirrors the shape of the ``ObservablesArray``: a nested list whose leaf
+    elements are dicts mapping observable term strings to coefficients. Non-dict nodes are
+    lists and are recursed into.
+
+    Args:
+        observables_lists: The ``"observables"`` value from the passthrough data — a list
+            whose elements are either nested lists (for multi-dimensional observable arrays)
+            or dicts (scalar / innermost cells).
+
+    Returns:
+        A new nested list with the same shape where every leaf dict has been passed through
+        :func:`expand_obs_dict`.
+    """
+    original_count = 0
+    expanded_count = 0
+
+    def _recurse(node: dict | list) -> dict | list:
+        nonlocal original_count, expanded_count
+        if isinstance(node, dict):
+            original_count += len(node)
+            expanded = expand_obs_dict(node)
+            expanded_count += len(expanded)
+            return expanded
+        return [_recurse(child) for child in node]
+
+    result = [_recurse(pub_obs) for pub_obs in observables_lists]
+
+    logger.debug(
+        "TREX observable expansion: %d original terms → %d expanded terms.",
+        original_count,
+        expanded_count,
+    )
+    if expanded_count > 2 * original_count:
+        warnings.warn(
+            f"TREX observable expansion increased the number of observable terms from "
+            f"{original_count} to {expanded_count}. Post-processing may take longer than usual.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    return result
 
 
 def estimator_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveResult:
@@ -144,6 +196,10 @@ def estimator_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveR
             metadata=result.metadata,
             passthrough_data=result.passthrough_data,
         )
+
+        # When TREX is active, expand projector terms in every observable dict into pure-Pauli
+        # components before any further processing.
+        observables_lists = _expand_observables_lists(observables_lists)
 
     # In case each pub is associated with several items - create a list in which each element
     # is a list containing all relevant items for that pub

--- a/qiskit_ibm_runtime/decoders/executor_estimator/trex_utils.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/trex_utils.py
@@ -24,6 +24,75 @@ if TYPE_CHECKING:
 import numpy as np
 from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauli
 
+# Maps each projector character to (pauli_axis, sign_of_pauli_component).
+# A projector |v><v| = (I + sign * P) / 2.
+_PROJECTOR_TO_PAULI: dict[str, tuple[str, float]] = {
+    "0": ("Z", +1.0),  # |0><0| = (I + Z) / 2
+    "1": ("Z", -1.0),  # |1><1| = (I - Z) / 2
+    "+": ("X", +1.0),  # |+><+| = (I + X) / 2
+    "-": ("X", -1.0),  # |-><-| = (I - X) / 2
+    "r": ("Y", +1.0),  # |r><r| = (I + Y) / 2
+    "l": ("Y", -1.0),  # |l><l| = (I - Y) / 2
+}
+
+
+def expand_obs_dict(obs_dict: dict[str, float]) -> dict[str, float]:
+    """Expand an observable dict by decomposing projector terms into pure-Pauli components.
+
+    Every projector character in each term key is expanded using |v><v| = (I ± P) / 2:
+      - ``'0'`` → ``(I + Z) / 2``
+      - ``'1'`` → ``(I - Z) / 2``
+      - ``'+'`` → ``(I + X) / 2``
+      - ``'-'`` → ``(I - X) / 2``
+      - ``'r'`` → ``(I + Y) / 2``
+      - ``'l'`` → ``(I - Y) / 2``
+
+    Pauli characters ``I``, ``X``, ``Y``, ``Z`` pass through unchanged. Coefficients of
+    identical pure-Pauli terms that arise from different input entries are summed together.
+
+    If no term contains projector characters the dict is returned unchanged.
+
+    Args:
+        obs_dict: Observable dict mapping term strings to real coefficients,
+            e.g. ``{"0Z": 0.5, "IZ": 1.0}``.
+
+    Returns:
+        A new dict with only pure-Pauli keys (``I/X/Y/Z`` characters) and merged coefficients.
+
+    Examples:
+        >>> expand_obs_dict({"0Z": 0.5, "IZ": 1.0})
+        {"IZ": 1.25, "ZZ": 0.25}
+        >>> expand_obs_dict({"ZZZ": 2.0})
+        {"ZZZ": 2.0}
+    """
+    expanded: dict[str, float] = {}
+    for term, coeff in obs_dict.items():
+        for sub_term, sub_coeff in _decompose_term(term):
+            expanded[sub_term] = expanded.get(sub_term, 0.0) + coeff * sub_coeff
+    return expanded
+
+
+def _decompose_term(term: str) -> list[tuple[str, float]]:
+    """Decompose a single observable term string into pure-Pauli (string, coefficient) pairs.
+
+    Each projector character forks the current set of partial terms into two branches
+    (identity branch and Pauli branch). Pauli characters pass through unchanged.
+    """
+    components: list[tuple[str, float]] = [("", 1.0)]
+    for ch in term:
+        if ch in _PROJECTOR_TO_PAULI:
+            pauli_axis, sign = _PROJECTOR_TO_PAULI[ch]
+            new_components: list[tuple[str, float]] = []
+            for partial_term, partial_coeff in components:
+                new_components.append((partial_term + "I", partial_coeff * 0.5))
+                new_components.append((partial_term + pauli_axis, partial_coeff * sign * 0.5))
+            components = new_components
+        else:
+            components = [
+                (partial_term + ch, partial_coeff) for partial_term, partial_coeff in components
+            ]
+    return components
+
 
 def get_processed_calibration_data(calibration_result: QuantumProgramItemResult) -> np.ndarray:
     """Process data from TREX calibration circuit results.

--- a/test/unit/decoders/executor_estimator/test_trex_utils.py
+++ b/test/unit/decoders/executor_estimator/test_trex_utils.py
@@ -15,8 +15,12 @@
 import numpy as np
 from qiskit.quantum_info import Pauli, PauliLindbladMap
 
+from qiskit_ibm_runtime.decoders.executor_estimator.post_processor_v0_1 import (
+    _expand_observables_lists,
+)
 from qiskit_ibm_runtime.decoders.executor_estimator.trex_utils import (
     calculate_trex_factor,
+    expand_obs_dict,
     get_processed_calibration_data,
 )
 from qiskit_ibm_runtime.results.quantum_program import QuantumProgramItemResult
@@ -146,3 +150,79 @@ class TestCalculateTrexFactor(IBMTestCase):
         result = calculate_trex_factor(cal_data_flipped, "I")
 
         self.assertEqual(result, 1.0)
+
+
+class TestExpandObsDict(IBMTestCase):
+    """Tests for expand_obs_dict.
+
+    Each entry in TEST_CASES is:
+        (input_dict, expected_output_dict)
+    """
+
+    TEST_CASES = [
+        # --- Pure-Pauli dicts: returned unchanged ---
+        ({"ZZZ": 2.0}, {"ZZZ": 2.0}),
+        ({"IXYZ": 1.0, "ZZZ": 0.5}, {"IXYZ": 1.0, "ZZZ": 0.5}),
+        # --- Projector adjacent to a Pauli ---
+        ({"0Z": 1.0}, {"IZ": 0.5, "ZZ": 0.5}),
+        ({"1Z": 1.0}, {"IZ": 0.5, "ZZ": -0.5}),
+        ({"+Z": 1.0}, {"IZ": 0.5, "XZ": 0.5}),
+        ({"-Z": 1.0}, {"IZ": 0.5, "XZ": -0.5}),
+        ({"rZ": 1.0}, {"IZ": 0.5, "YZ": 0.5}),
+        ({"lZ": 1.0}, {"IZ": 0.5, "YZ": -0.5}),
+        ({"Z0": 1.0}, {"ZI": 0.5, "ZZ": 0.5}),
+        ({"I0": 1.0}, {"II": 0.5, "IZ": 0.5}),
+        # --- Merging: projector expansion collides with existing pure-Pauli term ---
+        ({"0Z": 0.5, "IZ": 1.0}, {"IZ": 1.25, "ZZ": 0.25}),
+        # --- Multiple projector terms, all merged ---
+        ({"0": 1.0, "1": 1.0}, {"I": 1.0, "Z": 0.0}),
+    ]
+
+    def test_expand_obs_dict(self):
+        """Parameterised test covering all projector characters and merging behaviour."""
+        for obs_dict, expected in self.TEST_CASES:
+            with self.subTest(obs_dict=obs_dict):
+                result = expand_obs_dict(obs_dict)
+
+                # Same set of keys
+                self.assertEqual(
+                    set(result.keys()),
+                    set(expected.keys()),
+                    f"input={obs_dict}: key mismatch\n  got:      {result}\n  expected: {expected}",
+                )
+
+                # Coefficients match within float tolerance
+                for key in expected:
+                    self.assertAlmostEqual(
+                        result[key],
+                        expected[key],
+                        places=14,
+                        msg=f"input={obs_dict}, key='{key}': got {result[key]}, "
+                        f"expected {expected[key]}",
+                    )
+
+
+class TestExpandObservablesLists(IBMTestCase):
+    """Tests for _expand_observables_lists."""
+
+    TEST_CASES = [
+        # Flat list (1D ObservablesArray shape): each element is a dict
+        (
+            [{"0Z": 1.0}, {"ZZ": 2.0}],
+            [{"IZ": 0.5, "ZZ": 0.5}, {"ZZ": 2.0}],
+        ),
+        # Nested list (2D ObservablesArray shape): outer list per pub, inner per cell
+        (
+            [[{"0Z": 1.0, "IZ": 1.0}, {"ZZ": 2.0}], [{"I0": 1.0}]],
+            [[{"IZ": 1.5, "ZZ": 0.5}, {"ZZ": 2.0}], [{"II": 0.5, "IZ": 0.5}]],
+        ),
+    ]
+
+    def test_expand_observables_lists(self):
+        """Parameterised test: shape is preserved and every leaf dict is expanded."""
+        for obs_lists, expected in self.TEST_CASES:
+            with self.subTest(obs_lists=obs_lists):
+                result = _expand_observables_lists(obs_lists)
+
+                # Shape (nesting structure) must be identical
+                self.assertEqual(result, expected)

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import numpy as np
 from qiskit.circuit import Parameter
-from qiskit.quantum_info import Operator, PauliLindbladMap, SparsePauliOp
+from qiskit.quantum_info import PauliLindbladMap, SparseObservable
 from samplomatic import InjectNoise
 from samplomatic.utils import get_annotation
 
@@ -56,15 +56,8 @@ def create_estimator_test_data(backend, preset_pass_manager):
         ("XII", x_q2),  # ≈ 0.707
     ]
 
-    # FIXME: Composing observables from plain `Operator` instead of directly passing strings,
-    # due to a bug in TREX post-processing affecting resilience levels > 0:
-    # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-    # Once this is fixed, we can do:
-    # observables = [obs_string for obs_string, _ in observable_ideal_ev_pairs]
     observables = [
-        SparsePauliOp.from_operator(Operator.from_label(obs_string)).apply_layout(
-            isa_circuit.layout
-        )
+        SparseObservable.from_list([(obs_string, 1.0)]).apply_layout(isa_circuit.layout)
         for obs_string, _ in observable_ideal_ev_pairs
     ]
 
@@ -104,16 +97,10 @@ def create_estimator_test_data_extended(backend, preset_pass_manager):
     proj_q2 = (1 + sq2_half) / 2
     z0_q0 = (1 + np.cos(theta)) / 2
 
-    # FIXME: Composing observables from plain `Operator` instead of directly passing strings,
-    # due to a bug in TREX post-processing affecting resilience levels > 0:
-    # https://github.com/Qiskit/qiskit-ibm-runtime/issues/3225
-    # Once this is fixed, we can pass the label strings directly.
     def _obs(label):
-        return SparsePauliOp.from_operator(Operator.from_label(label)).apply_layout(
-            isa_circuit.layout
-        )
+        return SparseObservable.from_list([(label, 1.0)]).apply_layout(isa_circuit.layout)
 
-    observable_ideal_ev_pairs: list[tuple[SparsePauliOp, float]] = [
+    observable_ideal_ev_pairs: list[tuple[SparseObservable, float]] = [
         (_obs("IIrl"), r_q1 * l_q0),  # ≈ 0.741
         (_obs("IIrZ"), r_q1 * z_q0),  # ≈ 0.755
         (_obs("I+YI"), proj_q2 * y_q1),  # ≈ 0.740


### PR DESCRIPTION
### Summary
Fixes #3225 

As far as I understand, decomposing the projection operators into paulis is the only way to get proper TREX. The cost is a (potentially) exponential post-processing compute time. Warning is issued when the number of decomposed terms more than doubles the original count. However, it is possible we want to add further guardrails - like an opt-in flag for the user and\or a prepare-side warning.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [X] I used the following tool to generate or modify code: IBM BOB
