### PR TITLE
Estimator sim-test cleanup: Use constants for options

### DIFF
--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -39,6 +39,44 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
 
+RESILIENCE_LEVEL_0 = {"resilience_level": 0}
+
+RESILIENCE_LEVEL_1 = {"resilience_level": 1}
+
+RESILIENCE_LEVEL_2_LINEAR = {
+    "resilience_level": 2,
+    "resilience": {"zne": {"extrapolator": "linear"}},
+}
+
+TWIRLING_TREX_PEC = {
+    "twirling": {"enable_gates": True, "enable_measure": True},
+    "resilience": {"pec_mitigation": True, "measure_mitigation": True},
+}
+
+TWIRLING_TREX_PEA = {
+    "twirling": {"enable_gates": True, "enable_measure": True},
+    "resilience": {
+        "zne_mitigation": True,
+        "zne": {"amplifier": "pea"},
+        "measure_mitigation": True,
+    },
+}
+
+TWIRLING_TREX_PEA_LINEAR = {
+    "twirling": {"enable_gates": True, "enable_measure": True},
+    "resilience": {
+        "zne_mitigation": True,
+        "zne": {"amplifier": "pea", "extrapolator": "linear"},
+        "measure_mitigation": True,
+    },
+}
+
+TWIRLING_TREX = {
+    "twirling": {"enable_gates": True, "enable_measure": True},
+    "resilience": {"measure_mitigation": True},
+}
+
+
 @ddt
 class TestEstimatorWithNoise(IBMTestCase):
     """Tests Executor based EstimatorV2 using simulator with noise through local mode."""
@@ -46,25 +84,28 @@ class TestEstimatorWithNoise(IBMTestCase):
     def setUp(self):
         """Test level setup."""
         super().setUp()
-        self.backend = FakeManilaV2()
-        self.preset_pass_manager = generate_preset_pass_manager(
-            optimization_level=1, backend=self.backend
-        )
 
     def test_result_quality_for_different_resilience_levels(self):
         """Tests the effect of resilience on EstimatorV2 results.
 
         Estimator result quality is expected to increase with increasing resilience level.
         """
-        pub, ideal_evs = create_estimator_test_data(self.backend, self.preset_pass_manager)
+        backend = FakeManilaV2()
+        preset_pass_manager = generate_preset_pass_manager(optimization_level=1, backend=backend)
+
+        pub, ideal_evs = create_estimator_test_data(backend, preset_pass_manager)
 
         # maps resilience level to error (compared to statevector simulation) for each observable
         errors: dict[int, npt.NDArray[np.float64]] = {}
 
         # Run Estimator with different resilience levels:
         for resilience_level in (0, 1, 2):
-            estimator = create_local_mode_estimator(self.backend)
-            estimator.options.resilience_level = resilience_level
+            estimator = create_local_mode_estimator(
+                backend,
+                num_randomizations=100,
+                shots_per_randomization=200,
+                options_overrides={"resilience_level": resilience_level},
+            )
 
             result = estimator.run([pub]).result()
             # We get one expectation value per observable:
@@ -78,10 +119,8 @@ class TestEstimatorWithNoise(IBMTestCase):
         np.testing.assert_array_less(errors[1], errors[0], err_msg=debug_message)
 
     @data(
-        # PEC
-        {"resilience": {"pec_mitigation": True}},
-        # ZNE (PEA)
-        {"resilience": {"zne_mitigation": True, "zne": {"amplifier": "pea"}}},
+        TWIRLING_TREX_PEC,
+        TWIRLING_TREX_PEA,
     )
     def test_result_quality_with_noise_injection(self, option_overrides):
         """Tests the effect of resilience on EstimatorV2 results.
@@ -95,19 +134,12 @@ class TestEstimatorWithNoise(IBMTestCase):
 
         # -- Run using base level Estimator with minor mitigation only:
 
-        base_level_option_overrides = {
-            "twirling": {
-                "enable_gates": True,
-                "enable_measure": True,
-                "num_randomizations": 1000,
-                "shots_per_randomization": 200,
-            },
-            "resilience": {
-                "measure_mitigation": True,
-            },
-        }
-        base_level_estimator = create_local_mode_estimator(backend)
-        base_level_estimator.options.update(**base_level_option_overrides)
+        base_level_estimator = create_local_mode_estimator(
+            backend,
+            num_randomizations=1000,
+            shots_per_randomization=200,
+            options_overrides=TWIRLING_TREX,
+        )
 
         # Add noise to every unique layer, independent of its content (gates or measurements).
         simulated_noise_model = {
@@ -127,12 +159,15 @@ class TestEstimatorWithNoise(IBMTestCase):
 
         # -- Run using the Estimator in the test configuration (defined by test parametrization):
 
-        estimator = create_local_mode_estimator(backend)
+        estimator = create_local_mode_estimator(
+            backend,
+            num_randomizations=1000,
+            shots_per_randomization=200,
+            options_overrides=option_overrides,
+        )
         estimator.options.experimental["simulator_options"] = ExperimentalSimulatorOptions(
             noise_model=simulated_noise_model,
         )
-        estimator.options.update(**base_level_option_overrides)
-        estimator.options.update(**option_overrides)
         # Run a noisy simulation, injecting the same noise as in the simulation
         injected_noise_model = {
             inject_noise_annotation.ref: simulated_noise_model[
@@ -165,33 +200,22 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         )
 
     @data(
-        # Vanilla
-        {"resilience_level": 0},
-        # Measurement Twirling + TREX
-        {"resilience_level": 1},
-        # ZNE (Gate folding)
-        {"resilience_level": 2, "resilience": {"zne": {"extrapolator": "linear"}}},
-        # PEC
-        {
-            "twirling": {"enable_gates": True, "enable_measure": True},
-            "resilience": {"pec_mitigation": True, "measure_mitigation": True},
-        },
-        # ZNE (PEA)
-        {
-            "twirling": {"enable_gates": True, "enable_measure": True},
-            "resilience": {
-                "zne_mitigation": True,
-                "zne": {"amplifier": "pea", "extrapolator": "linear"},
-                "measure_mitigation": True,
-            },
-        },
+        RESILIENCE_LEVEL_0,
+        RESILIENCE_LEVEL_1,
+        RESILIENCE_LEVEL_2_LINEAR,
+        TWIRLING_TREX_PEC,
+        TWIRLING_TREX_PEA,
     )
     def test_correct_estimates_with_noise_injection(self, option_overrides):
         """Tests Estimator configurations to produce correct results in a noise-less environment."""
         pub, ideal_evs = create_estimator_test_data_extended(self.backend, self.preset_pass_manager)
 
-        estimator = create_local_mode_estimator(self.backend)
-        estimator.options.update(**option_overrides)
+        estimator = create_local_mode_estimator(
+            self.backend,
+            num_randomizations=100,
+            shots_per_randomization=200,
+            options_overrides=option_overrides,
+        )
 
         # TODO: no DD possible on AER without gate durations.
         # Need to test this for a fake backend (e.g. in noisy test).

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from qiskit.circuit import Parameter
 from qiskit.quantum_info import Operator, PauliLindbladMap, SparsePauliOp
@@ -24,6 +26,11 @@ from qiskit_ibm_runtime.executor_estimator import EstimatorV2
 from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
 
 from ....utils import make_mirror_circuit_with_phases
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from qiskit.providers import BackendV2
 
 
 def create_estimator_test_data(backend, preset_pass_manager):
@@ -153,7 +160,12 @@ def create_noise_model_without_noise(estimator, pub):
     return noise_model
 
 
-def create_local_mode_estimator(backend):
+def create_local_mode_estimator(
+    backend: BackendV2,
+    num_randomizations: int,
+    shots_per_randomization: int,
+    options_overrides: dict[str, Any] = {},
+) -> EstimatorV2:
     """Creates an estimator instance running local mode simulation.
 
     The returned instance has all mitigation disabled (resilience_level 0)
@@ -167,10 +179,11 @@ def create_local_mode_estimator(backend):
             "local_mode": True,
         },
     )
+    options.update(**options_overrides)
 
     # Increase number of shots to have better statistics:
-    options.twirling.num_randomizations = 100
-    options.twirling.shots_per_randomization = 200
-    options.default_shots = 100 * 200
+    options.twirling.num_randomizations = num_randomizations
+    options.twirling.shots_per_randomization = shots_per_randomization
+    options.default_shots = num_randomizations * shots_per_randomization
 
     return EstimatorV2(mode=backend, options=options)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
part of #3208

@SamFerracin This adds the indirection for the estimator options. I cleaned up a bit around the estimator factory to make it more natural.
We use different shot counts in noise and noise-less tests. Do we want to keep it this way? If we want to sync on this, we could simplify the arguments a bit.

Also there is still a TODO about DD. Not sure if this is worth an extra test, as it is hard to plug it into one of the others.

### Details and comments

Fixes #

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
