### PR TITLE
Error when TREX is requested with projection observables

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -24,6 +24,7 @@ from ..utils.utils import validate_no_boxes
 from .pec.prepare_pec import prepare_pec
 from .prepare_pea import prepare_pea
 from .prepare_vanilla import prepare_vanilla
+from .utils import has_projection_operators
 from .zne.prepare_zne import prepare_zne
 
 if TYPE_CHECKING:
@@ -80,6 +81,13 @@ def prepare(
 
     for pub in pubs:
         validate_no_boxes(pub.circuit)
+
+        if options.resilience.measure_mitigation and has_projection_operators(pub):
+            raise IBMInputValueError(
+                "Measurement mitigation is currently not supported when observables contain "
+                "projection operators. You can decompose into pauli operators if the "
+                "exponential cost is acceptable."
+            )
 
         if options.dynamical_decoupling.enable:
             if pub.circuit.has_control_flow_op():

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -105,6 +105,16 @@ def get_pauli_basis(basis: str) -> Pauli:
     return Pauli(basis)
 
 
+def has_projection_operators(pub: EstimatorPub) -> bool:
+    """Return whether an estimator pub contains projection operators in its observables."""
+    projection_set = set("01rl+-")
+    for observable in pub.observables.ravel():
+        for observable_term in observable:
+            if bool(set(observable_term) & projection_set):
+                return True
+    return False
+
+
 def pauli_to_ints(pauli: Pauli) -> list[int]:
     """Convert Pauli to list of ints following samplomatic convention.
 

--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -214,3 +214,17 @@ class TestPrepare(IBMTestCase):
             "A backend must be provided when dynamical decoupling is enabled",
         ):
             prepare(pubs, options, shots=100)
+
+    def test_measure_mitigation_rejects_projection_operators(self):
+        """Test measurement mitigation raises when observables contain projectors."""
+        options = EstimatorOptions()
+        options.resilience.measure_mitigation = True
+
+        circuit = QuantumCircuit(3)
+        pubs = [EstimatorPub.coerce((circuit, "Z0Z"))]
+
+        with self.assertRaisesRegex(
+            IBMInputValueError,
+            "Measurement mitigation is currently not supported when observables contain projection",
+        ):
+            prepare(pubs, options, shots=100)


### PR DESCRIPTION
### Summary
Fixes #3225 

Following discussions it was decided to avoid the exponential cost of the solution in #3243 and for now error when TREX is requested with projection observables.

### AI/LLM disclosure

- [X] I used the following tool to generate or modify code:
