### PR TITLE
Add `to_pauli_lindblad_maps` to `NoiseLearnerV3Results`

### DIFF
--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -197,7 +197,7 @@ class NoiseLearnerV3Results:
         return noise_source
 
     def to_pauli_lindblad_maps(self) -> list[PauliLindbladMap]:
-        """Return the Pauli-Lindblad maps of the items stored in this :class:`NoiseLearnerV3Results` object."""
+        """Return the :class:`PauliLindbladMap`s of the items stored in this results object."""
         return [datum.to_pauli_lindblad_map() for datum in self.data]
 
     def __getitem__(self, idx: int) -> NoiseLearnerV3Result:

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -178,12 +178,13 @@ class NoiseLearnerV3Results:
         noise_source = {}
         num_instr = 0
         annotation_type = Tag if mode == "simulation" else InjectNoise
-        for instr, datum in zip(instructions, self.data):
+        pauli_maps = self.to_pauli_lindblad_maps()
+        for instr, pauli_map in zip(instructions, pauli_maps):
             if not isinstance(instr.operation, BoxOp):
                 raise ValueError("Found an instruction that does not contain a box.")
             if annotation := get_annotation(instr.operation, annotation_type):
                 num_instr += 1
-                noise_source[annotation.ref] = datum.to_pauli_lindblad_map()
+                noise_source[annotation.ref] = pauli_map
             elif require_refs:
                 raise ValueError(
                     "Found an instruction without an inject noise annotation. "
@@ -194,6 +195,10 @@ class NoiseLearnerV3Results:
             raise ValueError("Found multiple instructions with the same ``ref``.")
 
         return noise_source
+
+    def to_pauli_lindblad_maps(self) -> Iterable[PauliLindbladMap]:
+        """The :class:`~.PauliLindbladMap`s stored in this :class:`NoiseLearnerV3Results` object."""
+        return [datum.to_pauli_lindblad_map() for datum in self.data]
 
     def __getitem__(self, idx: int) -> NoiseLearnerV3Result:
         return self.data[idx]

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -197,7 +197,7 @@ class NoiseLearnerV3Results:
         return noise_source
 
     def to_pauli_lindblad_maps(self) -> list[PauliLindbladMap]:
-        """The :class:`~.PauliLindbladMap`s stored in this :class:`NoiseLearnerV3Results` object."""
+        """Return the Pauli-Lindblad maps of the items stored in this :class:`NoiseLearnerV3Results` object."""
         return [datum.to_pauli_lindblad_map() for datum in self.data]
 
     def __getitem__(self, idx: int) -> NoiseLearnerV3Result:

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -196,7 +196,7 @@ class NoiseLearnerV3Results:
 
         return noise_source
 
-    def to_pauli_lindblad_maps(self) -> Iterable[PauliLindbladMap]:
+    def to_pauli_lindblad_maps(self) -> list[PauliLindbladMap]:
         """The :class:`~.PauliLindbladMap`s stored in this :class:`NoiseLearnerV3Results` object."""
         return [datum.to_pauli_lindblad_map() for datum in self.data]
 

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -197,7 +197,7 @@ class NoiseLearnerV3Results:
         return noise_source
 
     def to_pauli_lindblad_maps(self) -> list[PauliLindbladMap]:
-        """Return the :class:`PauliLindbladMap`s of the items stored in this results object."""
+        """Return the :class:`PauliLindbladMap` of the items stored in this results object."""
         return [datum.to_pauli_lindblad_map() for datum in self.data]
 
     def __getitem__(self, idx: int) -> NoiseLearnerV3Result:

--- a/release-notes/unreleased/3257.feat.rst
+++ b/release-notes/unreleased/3257.feat.rst
@@ -1,0 +1,3 @@
+Added :meth:`~qiskit_ibm_runtime.results.noise_learner_v3.NoiseLearnerV3Results.to_pauli_lindblad_maps`,
+a method to return the list of :class:`qiskit.quantum_info.PauliLindbladMap` of the items stored in a
+:class:`~qiskit_ibm_runtime.results.noise_learner_v3.NoiseLearnerV3Results`.

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -247,3 +247,8 @@ class TestNoiseLearnerV3Results(IBMTestCase):
 
         with self.assertRaisesRegex(ValueError, "multiple instructions with the same ``ref``"):
             NoiseLearnerV3Results(self.results).to_dict(circuit.data, mode=mode)
+
+    def test_to_pauli_lindblad_maps(self):
+        """Test ``.to_pauli_lindblad_maps``."""
+        results = NoiseLearnerV3Results(self.results)
+        self.assertEqual(results.to_pauli_lindblad_maps(), self.pauli_lindblad_maps)


### PR DESCRIPTION
### Summary
This PR adds a convenience method `to_pauli_lindblad_maps` to `NoiseLearnerV3Results` which returns the list of underlying `PauliLindbladMap` objects

### Details and comments

Closes #3256 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
