### PR TITLE
Wrapper Primitives: Move semantic role assignment into `run()`

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -262,6 +262,9 @@ class EstimatorV2(BaseEstimatorV2):
             pubs, self.options, precision, add_tags=local_mode, backend=self._backend
         )
 
+        # Set semantic role for post-processing dispatch
+        quantum_program._semantic_role = "estimator_v2"
+
         executor = Executor(mode=self._backend, options=executor_options)
 
         logger.info(

--- a/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
+++ b/qiskit_ibm_runtime/executor_estimator/pec/prepare_pec.py
@@ -227,7 +227,4 @@ def prepare_pec(
         logger.info("TREX calibration circuit added (%d randomizations).", trex_num_randomizations)
         passthrough_data["post_processor"]["measure_mitigation"] = True
 
-    # Set semantic role for post-processing dispatch
-    quantum_program._semantic_role = "estimator_v2"
-
     return quantum_program

--- a/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_pea.py
@@ -210,7 +210,4 @@ def prepare_pea(
         logger.info("TREX calibration circuit added (%d randomizations).", trex_num_randomizations)
         passthrough_data["post_processor"]["measure_mitigation"] = True
 
-    # Set semantic role for post-processing dispatch
-    quantum_program._semantic_role = "estimator_v2"
-
     return quantum_program

--- a/qiskit_ibm_runtime/executor_estimator/prepare_vanilla.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare_vanilla.py
@@ -164,7 +164,4 @@ def prepare_vanilla(
         logger.info("TREX calibration circuit added (%d randomizations).", trex_num_randomizations)
         passthrough_data["post_processor"]["measure_mitigation"] = True
 
-    # Set semantic role for post-processing dispatch
-    quantum_program._semantic_role = "estimator_v2"
-
     return quantum_program

--- a/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
+++ b/qiskit_ibm_runtime/executor_estimator/zne/prepare_zne.py
@@ -207,7 +207,4 @@ def prepare_zne(
         logger.info("TREX calibration circuit added (%d randomizations).", trex_num_randomizations)
         passthrough_data["post_processor"]["measure_mitigation"] = True
 
-    # Set semantic role for post-processing dispatch
-    quantum_program._semantic_role = "estimator_v2"
-
     return quantum_program

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -259,7 +259,6 @@ def _build_quantum_program(
         passthrough_data=passthrough_data,
         meas_level=finalized_options.execution.meas_type,
     )
-    quantum_program._semantic_role = "sampler_v2"
 
     if finalized_options.dynamical_decoupling.enable:
         logger.info("Apply dynamical decoupling")

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -224,6 +224,9 @@ class SamplerV2(BaseSamplerV2):
             pubs, self.options, shots, add_tags=local_mode, backend=self._backend
         )
 
+        # Set semantic role for post-processing dispatch
+        quantum_program._semantic_role = "sampler_v2"
+
         executor = Executor(mode=self._backend, options=executor_options)
 
         logger.info(

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -85,6 +85,9 @@ class TestEstimatorV2Run(IBMTestCase):
         # precision=0.03125 -> shots = ceil(1/0.03125^2) = 1024
         self.assertEqual(quantum_program.shots, 1024)
 
+        # Verify that information needed for post-processing dispatch were attached
+        self.assertEqual(quantum_program._semantic_role, "estimator_v2")
+
         # Verify job was returned
         self.assertEqual(job, self.mock_job)
 

--- a/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pea_utils.py
@@ -217,7 +217,6 @@ class TestPreparePea(IBMEstimatorPrepareTestCase):
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, 64)
-        self.assertEqual(quantum_program._semantic_role, "estimator_v2")
         self.assertEqual(len(quantum_program.items), 1)
 
         item = cast("SamplexItem", quantum_program.items[0])

--- a/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_pec_utils.py
@@ -379,7 +379,6 @@ class TestPreparePec(IBMEstimatorPrepareTestCase):
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, 64)
-        self.assertEqual(quantum_program._semantic_role, "estimator_v2")
         self.assertEqual(len(quantum_program.items), 1)
 
         item = cast("SamplexItem", quantum_program.items[0])

--- a/test/unit/executor_estimator/test_estimator_v2_prepare_vanilla.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare_vanilla.py
@@ -231,7 +231,6 @@ class TestPrepareVanilla(IBMEstimatorPrepareTestCase):
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, shots)
         self.assertEqual(quantum_program.meas_level, "classified")
-        self.assertEqual(quantum_program._semantic_role, "estimator_v2")
         self.assertEqual(len(quantum_program.items), 2)
 
         item1 = cast("SamplexItem", quantum_program.items[0])

--- a/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_zne_utils.py
@@ -180,7 +180,6 @@ class TestPrepareZne(IBMEstimatorPrepareTestCase):
 
         self.assertIsInstance(quantum_program, QuantumProgram)
         self.assertEqual(quantum_program.shots, shots)
-        self.assertEqual(quantum_program._semantic_role, "estimator_v2")
         # Should have len(noise_factors) items for the single pub
         self.assertEqual(len(quantum_program.items), len(noise_factors))
 

--- a/test/unit/executor_sampler/test_prepare.py
+++ b/test/unit/executor_sampler/test_prepare.py
@@ -609,7 +609,6 @@ class TestPreparePassthroughData(IBMTestCase):
 
         # Verify passthrough_data contains post-processor info
         self.assertIn("post_processor", qp.passthrough_data)
-        self.assertEqual(qp._semantic_role, "sampler_v2")
         self.assertEqual(qp.passthrough_data["post_processor"]["version"], "v0.1")
         self.assertEqual(qp.passthrough_data["post_processor"]["meas_type"], "classified")
         self.assertEqual(qp.passthrough_data["post_processor"]["twirling"], enable_gates)
@@ -632,7 +631,6 @@ class TestPreparePassthroughData(IBMTestCase):
         # Verify options dictionary is present in passthrough_data
         self.assertIn("post_processor", qp.passthrough_data)
         self.assertIn("post_processor", qp.passthrough_data)
-        self.assertEqual(qp._semantic_role, "sampler_v2")
         self.assertEqual(qp.passthrough_data["post_processor"]["version"], "v0.1")
         self.assertEqual(qp.passthrough_data["post_processor"]["twirling"], True)
         self.assertEqual(qp.passthrough_data["post_processor"]["meas_type"], "kerneled")

--- a/test/unit/executor_sampler/test_sampler.py
+++ b/test/unit/executor_sampler/test_sampler.py
@@ -70,6 +70,9 @@ class TestSamplerV2SimpleCircuits(IBMTestCase):
 
         self.assertEqual(quantum_program.items[2].circuit, circuit3)
 
+        # Verify that information needed for post-processing dispatch were attached
+        self.assertEqual(quantum_program._semantic_role, "sampler_v2")
+
     @patch("qiskit_ibm_runtime.executor_sampler.sampler.Executor.run")
     def test_default_shots(self, mock_run):
         """Test that default shots (4096) are used when not specified."""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This makes `prepare()` usable for advanced users who want to execute the resulting `QuantumProgram` without post-processing or with manual post-processing.

### Details and comments

Fixes #

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
