### PR TITLE
Add `LayerNoiseModel` to `ResilenceOptions`

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -144,10 +144,10 @@ class EstimatorV2(BaseEstimatorV2):
             layers = est.find_unique_layers(pubs, types="gates")
 
             results = NoiseLearnerV3(mode).run(layers).result()
-            noise_model = results.to_dict(layers)
+            pauli_linblad_maps = results.to_pauli_lindblad_maps()
 
             # Assign the learned model so PEC uses it on the next run.
-            est.options.resilience.noise_model = noise_model
+            est.options.resilience.layer_noise_model = list(zip(layers, pauli_linblad_maps))
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -147,7 +147,7 @@ class EstimatorV2(BaseEstimatorV2):
             pauli_linblad_maps = results.to_pauli_lindblad_maps()
 
             # Assign the learned model so PEC uses it on the next run.
-            est.options.resilience.layer_noise_model = list(zip(layers, pauli_linblad_maps))
+            est.options.resilience.layer_noise_model = zip(layers, pauli_linblad_maps)
 
         Args:
             pubs: The list of PUBs to return a list of unique boxes for.

--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from samplomatic import InjectNoise
+from samplomatic.utils import get_annotation
 
 from ..exceptions import IBMInputValueError
 from ..executor.dynamical_decoupling import apply_dynamical_decoupling
@@ -185,6 +187,12 @@ def _build_quantum_program(
         else None
     )
 
+    noise_model = {}
+    if layer_noise_model := finalized_options.resilience.layer_noise_model:
+        for instr, pauli_map in layer_noise_model:
+            if annotation := get_annotation(instr.operation, InjectNoise):
+                noise_model[annotation.ref] = pauli_map
+
     if finalized_options.resilience.pec_mitigation:
         logger.info("Running ``prepare_pec``.")
         quantum_program = prepare_pec(
@@ -192,7 +200,7 @@ def _build_quantum_program(
             twirling_options=finalized_options.twirling,
             shots=shots,
             pec_options=finalized_options.resilience.pec,
-            noise_model=finalized_options.resilience.noise_model,
+            noise_model=noise_model,
             measure_noise_learning=measure_noise_learning,
             add_tags=add_tags,
         )
@@ -204,7 +212,7 @@ def _build_quantum_program(
                 twirling_options=finalized_options.twirling,
                 shots=shots,
                 zne_options=finalized_options.resilience.zne,
-                noise_model=finalized_options.resilience.noise_model,
+                noise_model=noise_model,
                 measure_noise_learning=measure_noise_learning,
                 add_tags=add_tags,
             )

--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-
 from .base import BaseOptionsModel
 from .measure_noise_learning import MeasureNoiseLearningOptions
 from .pec import PecOptions
@@ -67,5 +65,5 @@ class ResilienceOptions(BaseOptionsModel):
     zne: ZneOptions = ZneOptions()
     """Additional zero noise extrapolation mitigation options."""
 
-    layer_noise_model: Sequence[LayerNoiseModel] | None = None
+    layer_noise_model: list[LayerNoiseModel] | None = None
     """Noise model specified by a collection of instructions and the noise that affects them."""

--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -16,9 +16,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from pydantic import field_validator
-from qiskit.circuit import BoxOp
-
 from .base import BaseOptionsModel
 from .measure_noise_learning import MeasureNoiseLearningOptions
 from .pec import PecOptions
@@ -72,19 +69,3 @@ class ResilienceOptions(BaseOptionsModel):
 
     layer_noise_model: Sequence[LayerNoiseModel] | None = None
     """Noise model specified by a collection of instructions and the noise that affects them."""
-
-    @field_validator("layer_noise_model", mode="after")
-    @classmethod
-    def _validate_layer_noise_model(
-        cls, value: Sequence[LayerNoiseModel] | None
-    ) -> Sequence[LayerNoiseModel] | None:
-        if value:
-            for instruction, noise in value:
-                if not isinstance(instruction.operation, BoxOp):
-                    raise ValueError("Found an instruction that does not contain a box.")
-                if len(instruction.qubits) != noise.num_qubits:
-                    raise ValueError(
-                        f"Found instruction with {len(instruction.qubits)}",
-                        f"qubits but a noise model with {noise.num_qubits}.",
-                    )
-        return value

--- a/qiskit_ibm_runtime/options_models/resilience.py
+++ b/qiskit_ibm_runtime/options_models/resilience.py
@@ -14,14 +14,15 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from collections.abc import Sequence
 
-from pydantic import InstanceOf
-from qiskit.quantum_info import PauliLindbladMap
+from pydantic import field_validator
+from qiskit.circuit import BoxOp
 
 from .base import BaseOptionsModel
 from .measure_noise_learning import MeasureNoiseLearningOptions
 from .pec import PecOptions
+from .simulator import LayerNoiseModel
 from .zne import ZneOptions
 
 
@@ -69,10 +70,21 @@ class ResilienceOptions(BaseOptionsModel):
     zne: ZneOptions = ZneOptions()
     """Additional zero noise extrapolation mitigation options."""
 
-    noise_model: dict[str, Annotated[PauliLindbladMap, InstanceOf]] = {}
-    """A noise model mapping for PEC mitigation.
+    layer_noise_model: Sequence[LayerNoiseModel] | None = None
+    """Noise model specified by a collection of instructions and the noise that affects them."""
 
-    Maps layer references (strings) to :class:`~qiskit.quantum_info.PauliLindbladMap` objects that
-    describe the noise characteristics of that layer. The dict contains layers from all PUBs. This
-    is required when using PEC mitigation, or ZNE with PEA amplifier.
-    """
+    @field_validator("layer_noise_model", mode="after")
+    @classmethod
+    def _validate_layer_noise_model(
+        cls, value: Sequence[LayerNoiseModel] | None
+    ) -> Sequence[LayerNoiseModel] | None:
+        if value:
+            for instruction, noise in value:
+                if not isinstance(instruction.operation, BoxOp):
+                    raise ValueError("Found an instruction that does not contain a box.")
+                if len(instruction.qubits) != noise.num_qubits:
+                    raise ValueError(
+                        f"Found instruction with {len(instruction.qubits)}",
+                        f"qubits but a noise model with {noise.num_qubits}.",
+                    )
+        return value

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Annotated, TypeAlias
 
-from pydantic import Field, InstanceOf, field_validator
+from pydantic import AfterValidator, Field, InstanceOf
 from qiskit.circuit import BoxOp, CircuitInstruction
 from qiskit.exceptions import MissingOptionalLibraryError
 from qiskit.providers import BackendV2
@@ -36,8 +36,24 @@ if optionals.HAS_AER:
 else:
     noise_model_type: TypeAlias = dict | None  # type: ignore[no-redef, misc]
 
-LayerNoiseModel: TypeAlias = tuple[
-    Annotated[CircuitInstruction, InstanceOf], Annotated[PauliLindbladMap, InstanceOf]
+
+def _validate_layer_noise_model(value: LayerNoiseModel | None) -> LayerNoiseModel | None:
+    """Validate the ``LayerNoiseModel``."""
+    if value:
+        instruction, noise = value
+        if not isinstance(instruction.operation, BoxOp):
+            raise ValueError("Found an instruction that does not contain a box.")
+        if len(instruction.qubits) != noise.num_qubits:
+            raise ValueError(
+                f"Found instruction with {len(instruction.qubits)}",
+                f"qubits but a noise model with {noise.num_qubits}.",
+            )
+    return value
+
+
+LayerNoiseModel: TypeAlias = Annotated[
+    tuple[Annotated[CircuitInstruction, InstanceOf], Annotated[PauliLindbladMap, InstanceOf]],
+    AfterValidator(_validate_layer_noise_model),
 ]
 
 
@@ -60,22 +76,6 @@ class ExperimentalSimulatorOptions(BaseOptionsModel):
 
     warn_absent: bool = True
     """Whether to emit a warning when an entry is missing in :attr:`layer_noise_dict`."""
-
-    @field_validator("layer_noise_model", mode="after")
-    @classmethod
-    def _validate_layer_noise_model(
-        cls, value: Sequence[LayerNoiseModel] | None
-    ) -> Sequence[LayerNoiseModel] | None:
-        if value:
-            for instruction, noise in value:
-                if not isinstance(instruction.operation, BoxOp):
-                    raise ValueError("Found an instruction that does not contain a box.")
-                if len(instruction.qubits) != noise.num_qubits:
-                    raise ValueError(
-                        f"Found instruction with {len(instruction.qubits)}",
-                        f"qubits but a noise model with {noise.num_qubits}.",
-                    )
-        return value
 
 
 class SimulatorOptions(BaseOptionsModel):

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Annotated, TypeAlias
 
 from pydantic import AfterValidator, Field, InstanceOf
@@ -68,7 +67,7 @@ class ExperimentalSimulatorOptions(BaseOptionsModel):
     angles are nominally Clifford.
     """
 
-    layer_noise_model: Sequence[LayerNoiseModel] | None = None
+    layer_noise_model: list[LayerNoiseModel] | None = None
     """Noise model specified by a collection of instructions and the noise that affects them."""
 
     seed_simulator: int | None = None

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -44,8 +44,8 @@ def _validate_layer_noise_model(value: LayerNoiseModel | None) -> LayerNoiseMode
             raise ValueError("Found an instruction that does not contain a box.")
         if len(instruction.qubits) != noise.num_qubits:
             raise ValueError(
-                f"Found instruction with {len(instruction.qubits)}",
-                f"qubits but a noise model with {noise.num_qubits}.",
+                f"Found instruction with {len(instruction.qubits)}"
+                f"qubits but a noise model with {noise.num_qubits}."
             )
     return value
 

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -18,8 +18,6 @@ import numpy as np
 from ddt import data, ddt
 from qiskit.quantum_info import PauliLindbladMap, SparsePauliOp
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from samplomatic import InjectNoise
-from samplomatic.utils import get_annotation
 
 from qiskit_ibm_runtime.executor_estimator import EstimatorV2
 from qiskit_ibm_runtime.options_models.zne import DEFAULT_NOISE_FACTORS
@@ -100,11 +98,10 @@ class TestEstimator(IBMIntegrationTestCase):
         estimator.options.resilience.pec_mitigation = True
 
         layers = estimator.find_unique_layers(self.pubs, types="gates")
-        estimator.options.resilience.noise_model = {
-            annotation.ref: PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.001)])
+        estimator.options.resilience.layer_noise_model = [
+            (layer, PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.001)]))
             for layer in layers
-            if (annotation := get_annotation(layer.operation, InjectNoise))
-        }
+        ]
 
         results = estimator.run(self.pubs).result()
 
@@ -136,13 +133,11 @@ class TestEstimator(IBMIntegrationTestCase):
 
         if amplifier == "pea":
             layers = estimator.find_unique_layers(self.pubs, types="gates")
-            estimator.options.resilience.noise_model = {
-                annotation.ref: PauliLindbladMap.from_list(
-                    [("X" * layer.operation.num_qubits, 0.001)]
-                )
+            estimator.options.resilience.layer_noise_model = [
+                (layer, PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.001)]))
                 for layer in layers
-                if (annotation := get_annotation(layer.operation, InjectNoise))
-            }
+            ]
+
         expected_num_noise_factors = len(DEFAULT_NOISE_FACTORS)
         # ``extrapolated_noise_factors`` defaults to ``[0, *noise_factors]``
         expected_num_extrapolated = expected_num_noise_factors + 1

--- a/test/unit/executor/simulations/test_executor.py
+++ b/test/unit/executor/simulations/test_executor.py
@@ -152,8 +152,8 @@ class TestExecutor(IBMTestCase):
         ]
         fidelities = []
         for pauli_map in pauli_maps:
-            executor.options.experimental["simulator_options"].layer_noise_model = list(
-                zip(unique_instructions, (pauli_map,) * len(unique_instructions))
+            executor.options.experimental["simulator_options"].layer_noise_model = zip(
+                unique_instructions, (pauli_map,) * len(unique_instructions)
             )
             job = executor.run(program)
             result = job.result()

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -21,8 +21,6 @@ from ddt import data, ddt
 from qiskit.quantum_info import PauliLindbladMap
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_aer import AerSimulator
-from samplomatic import InjectNoise
-from samplomatic.utils import get_annotation
 
 from qiskit_ibm_runtime.fake_provider import FakeManilaV2
 from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
@@ -170,14 +168,10 @@ class TestEstimatorWithNoise(IBMTestCase):
             layer_noise_model=simulated_noise_model,
         )
         # Run a noisy simulation, injecting the same noise as in the simulation
-        injected_noise_model = {
-            inject_noise_annotation.ref: PauliLindbladMap.from_list(
-                [("X" * layer.operation.num_qubits, 0.005)]
-            )
+        estimator.options.resilience.layer_noise_model = [
+            (layer, PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.005)]))
             for layer in estimator.find_unique_layers([pub], types="gates")
-            if (inject_noise_annotation := get_annotation(layer.operation, InjectNoise))
-        }
-        estimator.options.resilience.noise_model = injected_noise_model
+        ]
         result = estimator.run([pub]).result()
         errors = np.abs(result[0].data.evs - ideal_evs)
 
@@ -225,7 +219,7 @@ class TestEstimatorWithoutNoise(IBMTestCase):
         if "resilience_level" not in option_overrides:
             # resilience_level defaults do not need a noise-model.
             # Only adding this for PEC / PEA:
-            estimator.options.resilience.noise_model = create_noise_model_without_noise(
+            estimator.options.resilience.layer_noise_model = create_noise_model_without_noise(
                 estimator, pub
             )
 

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -19,8 +19,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 from qiskit.circuit import Parameter
 from qiskit.quantum_info import Operator, PauliLindbladMap, SparsePauliOp
-from samplomatic import InjectNoise
-from samplomatic.utils import get_annotation
 
 from qiskit_ibm_runtime.executor_estimator import EstimatorV2
 from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
@@ -146,13 +144,9 @@ def create_noise_model_without_noise(estimator, pub):
 
     # In a noise-less simulation we do not expect noise. So we can construct the noise_model
     # with empty noise for all layers:
-    noise_model = {
-        get_annotation(layer.operation, InjectNoise).ref: PauliLindbladMap.identity(
-            layer.operation.num_qubits
-        )
-        for layer in layers
-    }
-
+    noise_model = [
+        (layer, PauliLindbladMap.identity(layer.operation.num_qubits)) for layer in layers
+    ]
     return noise_model
 
 

--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -41,6 +41,12 @@ class TestPrepare(IBMTestCase):
 
         pubs = [(circuit, observable)]
 
+        layers = find_unique_box_instructions(
+            circuit,
+            normalize_annotations=None,
+            undress_boxes=True,
+        )
+
         options = EstimatorOptions()
         options.twirling.enable_gates = True
         match path:
@@ -48,9 +54,9 @@ class TestPrepare(IBMTestCase):
                 options.twirling.enable_measure = True
             case "pec":
                 options.resilience.pec_mitigation = True
-                options.resilience.noise_model = {
-                    "layer_0": PauliLindbladMap.identity(num_qubits=2)
-                }
+                options.resilience.layer_noise_model = [
+                    (layer, PauliLindbladMap.identity(num_qubits=2)) for layer in layers
+                ]
             case "zne":
                 options.resilience.zne_mitigation = True
             case "pea":
@@ -84,16 +90,24 @@ class TestPrepare(IBMTestCase):
 
     def test_pec_path(self):
         """Test the ``prepare`` function when PEC is requested."""
-        options = EstimatorOptions()
-        options.twirling.enable_gates = True
-        options.resilience.pec_mitigation = True
-        options.resilience.noise_model = {"layer_0": PauliLindbladMap.identity(num_qubits=2)}
-
         circuit = QuantumCircuit(2)
         circuit.h(0)
         observable = SparsePauliOp.from_list([("ZZ", 1)])
 
         pubs = [(circuit, observable)]
+
+        layers = find_unique_box_instructions(
+            circuit,
+            normalize_annotations=None,
+            undress_boxes=True,
+        )
+
+        options = EstimatorOptions()
+        options.twirling.enable_gates = True
+        options.resilience.pec_mitigation = True
+        options.resilience.layer_noise_model = [
+            (layer, PauliLindbladMap.identity(num_qubits=2)) for layer in layers
+        ]
 
         program, executor_options = prepare(pubs, options, precision=0.1)
 

--- a/test/unit/options_models/test_resilience.py
+++ b/test/unit/options_models/test_resilience.py
@@ -44,8 +44,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         circuit = QuantumCircuit(2)
         with circuit.box():
             circuit.cx(0, 1)
-        _, box = circuit.data
-        layer_noise_model = [(box, PauliLindbladMap.identity(num_qubits=1))]
+        layer_noise_model = [(layer, PauliLindbladMap.identity(2)) for layer in circuit.data]
         opts = ResilienceOptions(
             measure_mitigation=False,
             measure_noise_learning={"num_randomizations": 64},

--- a/test/unit/options_models/test_resilience.py
+++ b/test/unit/options_models/test_resilience.py
@@ -12,8 +12,9 @@
 
 """Tests for ResilienceOptions."""
 
-from ddt import data, ddt
+from ddt import ddt
 from pydantic import ValidationError
+from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import PauliLindbladMap
 
 from qiskit_ibm_runtime.options_models.resilience import ResilienceOptions
@@ -36,10 +37,15 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         self.assertFalse(opts.zne_mitigation)
         self.assertEqual(opts.zne.amplifier, "gate_folding")
         self.assertEqual(opts.zne.noise_factors, "auto")
-        self.assertEqual(opts.noise_model, {})
+        self.assertEqual(opts.layer_noise_model, None)
 
     def test_set_all_options(self):
         """All fields accept explicit non-default values."""
+        circuit = QuantumCircuit(2)
+        with circuit.box():
+            circuit.cx(0, 1)
+        _, box = circuit.data
+        layer_noise_model = [(box, PauliLindbladMap.identity(num_qubits=1))]
         opts = ResilienceOptions(
             measure_mitigation=False,
             measure_noise_learning={"num_randomizations": 64},
@@ -47,10 +53,7 @@ class TestResilienceOptionsDefaults(IBMTestCase):
             pec={"max_overhead": 50, "noise_gain": 0.5},
             zne_mitigation=True,
             zne={"amplifier": "gate_folding_front", "noise_factors": [1, 3, 5]},
-            noise_model={
-                "layer_0": PauliLindbladMap.identity(num_qubits=1),
-                "layer_1": PauliLindbladMap.identity(num_qubits=1),
-            },
+            layer_noise_model=layer_noise_model,
         )
         self.assertFalse(opts.measure_mitigation)
         self.assertEqual(opts.measure_noise_learning.num_randomizations, 64)
@@ -60,16 +63,21 @@ class TestResilienceOptionsDefaults(IBMTestCase):
         self.assertTrue(opts.zne_mitigation)
         self.assertEqual(opts.zne.amplifier, "gate_folding_front")
         self.assertEqual(list(opts.zne.noise_factors), [1, 3, 5])
-        self.assertEqual(set(opts.noise_model.keys()), {"layer_0", "layer_1"})
+        self.assertEqual(opts.layer_noise_model, layer_noise_model)
 
-    @data(
-        "not_a_dict",
-        42,
-        {0: PauliLindbladMap.identity(num_qubits=1)},  # non-string key
-        {"layer_0": "bad_value"},  # non-PauliLindbladMap value
-        {"layer_0": None},  # None as a value
-    )
-    def test_invalid_noise_model(self, value):
-        """Invalid noise_model values raise ValidationError."""
-        with self.assertRaisesRegex(ValidationError, "noise_model"):
-            ResilienceOptions(noise_model=value)
+    def test_invalid_layer_noise_model(self):
+        """Invalid layer_noise_model values raise ValidationError."""
+        circuit = QuantumCircuit(2)
+        circuit.x(0)
+        with circuit.box():
+            circuit.cx(0, 1)
+        not_box, box = circuit.data
+
+        options = ResilienceOptions(layer_noise_model=[(box, PauliLindbladMap.identity(2))])
+        self.assertEqual(options.layer_noise_model, [(box, PauliLindbladMap.identity(2))])
+
+        with self.assertRaisesRegex(ValidationError, "does not contain a box"):
+            ResilienceOptions(layer_noise_model=[(not_box, PauliLindbladMap.identity(2))])
+
+        with self.assertRaisesRegex(ValidationError, "Found instruction with 2"):
+            ResilienceOptions(layer_noise_model=[(box, PauliLindbladMap.identity(1))])


### PR DESCRIPTION
### Summary
Updating `ResilenceOptions` to replace `noise_model` with `layer_noise_model`, a sequence of `CircuitInstruction` and `PauliLindbladMap` tuples.

### Details and comments

Part of #3255

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
