### PR TITLE
Add pub metadata for the estimator

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -524,6 +524,18 @@ def _process_expectation_values_pec(
 
 
 def create_result_item_metadata(item_metadata: ItemMetadata | dict) -> dict[str, Any]:
+    """Build the metadata dict for a single result item.
+
+    For hardware results (``ItemMetadata``), extracts compilation-related fields
+    such as ``scheduler_timing`` and ``stretch_values`` under a ``"compilation"`` key.
+    For simulator results (plain ``dict``), stores the raw metadata under ``"executor"``.
+
+    Args:
+        item_metadata: Metadata from a single quantum program item result.
+
+    Returns:
+        A dict containing the relevant metadata fields for the pub result.
+    """
     result_item_metadata: dict[str, Any] = {}
     if isinstance(item_metadata, ItemMetadata):
         result_item_metadata["compilation"] = {}

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import numpy.typing as npt
+    from collections.abc import Iterable
     from qiskit.quantum_info import PauliLindbladMap
 
     from ...options_models.zne import ExtrapolatorType
@@ -30,6 +31,7 @@ import numpy as np
 from qiskit.primitives import DataBin, PrimitiveResult
 from qiskit.primitives.containers.estimator_pub import ObservablesArray
 from qiskit.quantum_info import Pauli
+
 from qiskit_ibm_runtime.results.quantum_program import ItemMetadata
 
 from ...executor_estimator.utils import get_pauli_basis, unbroadcast_index
@@ -521,7 +523,7 @@ def _process_expectation_values_pec(
     return exp_vals, stds, ensemble_stds
 
 
-def create_result_item_metadata(item_metadata: ItemMetadata | dict):
+def create_result_item_metadata(item_metadata: ItemMetadata | dict) -> dict[str, Any]:
     result_item_metadata: dict[str, Any] = {}
     if isinstance(item_metadata, ItemMetadata):
         result_item_metadata["compilation"] = {}
@@ -846,7 +848,9 @@ def create_pub_result_zne(
         shape=zero_noise_exp_vals.shape,
     )
 
-    result_item_metadata = [create_result_item_metadata(item_result.metadata) for item_result in item_results]
+    result_item_metadata = [
+        create_result_item_metadata(item_result.metadata) for item_result in item_results
+    ]
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -535,6 +535,8 @@ def create_result_item_metadata(item_metadata: ItemMetadata | dict):
                 asdict(stretch_value, dict_factory=expanded_values_to_lists)
                 for stretch_value in item_metadata.stretch_values
             ]
+    else:  # simulator
+        result_item_metadata["executor"] = item_metadata
 
     return result_item_metadata
 

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -861,9 +861,9 @@ def create_pub_result_zne(
         shape=zero_noise_exp_vals.shape,
     )
 
-    result_item_metadata = [
-        create_result_item_metadata(item_result.metadata) for item_result in item_results
-    ]
+    per_item = [create_result_item_metadata(item_result.metadata) for item_result in item_results]
+    key = next(iter(per_item[0]))  # either "compilation" or "executor"
+    result_item_metadata = {key: [item[key] for item in per_item]}
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -865,7 +865,9 @@ def create_pub_result_zne(
     )
 
     per_item = [create_pub_result_metadata(item_result.metadata) for item_result in item_results]
-    result_item_metadata = {key: [item[key] for item in per_item] for key in per_item[0]}
+    result_item_metadata: dict[str, Any] = {
+        key: [item[key] for item in per_item] for key in per_item[0]
+    }
     result_item_metadata["resilience"] = {"zne": {"extrapolators": selected_extrapolators_per_obs}}
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -862,8 +862,7 @@ def create_pub_result_zne(
     )
 
     per_item = [create_result_item_metadata(item_result.metadata) for item_result in item_results]
-    key = next(iter(per_item[0]))  # either "compilation" or "executor"
-    result_item_metadata = {key: [item[key] for item in per_item]}
+    result_item_metadata = {key: [item[key] for item in per_item] for key in per_item[0]}
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -527,7 +527,7 @@ def _process_expectation_values_pec(
 def create_pub_result_metadata(item_metadata: ItemMetadata | dict) -> dict[str, Any]:
     """Build the metadata dict for a single result item.
 
-    For hardware results (``ItemMetadata``), extracts compilation-related fields
+    For IBM backend results (``ItemMetadata``), extracts compilation-related fields
     such as ``scheduler_timing`` and ``stretch_values`` under a ``"compilation"`` key.
     For simulator results (plain ``dict``), stores the raw metadata under ``"executor"``.
 

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -29,6 +30,7 @@ import numpy as np
 from qiskit.primitives import DataBin, PrimitiveResult
 from qiskit.primitives.containers.estimator_pub import ObservablesArray
 from qiskit.quantum_info import Pauli
+from qiskit_ibm_runtime.results.quantum_program import ItemMetadata
 
 from ...executor_estimator.utils import get_pauli_basis, unbroadcast_index
 from ...executor_estimator.zne.extrapolation import process_extrapolated_expectation_values
@@ -38,6 +40,20 @@ from .trex_utils import calculate_trex_factor, get_processed_calibration_data
 from .utils import compute_exp_val, identify_measure_basis
 
 logger = logging.getLogger(__name__)
+
+
+def expanded_values_to_lists(key_value_pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    """Dict factory that converts `expanded_values` tuples to lists.
+
+    Args:
+        key_value_pairs: pairs of (key, value) items
+
+    Returns:
+        A dictionary built from `key_value_pairs`, with the key `expanded_values` containing lists.
+    """
+    stretch_value = dict(key_value_pairs)
+    stretch_value["expanded_values"] = [list(i) for i in stretch_value["expanded_values"]]
+    return stretch_value
 
 
 def _build_program_result_metadata(post_processor_data: dict) -> dict:
@@ -505,6 +521,24 @@ def _process_expectation_values_pec(
     return exp_vals, stds, ensemble_stds
 
 
+def create_result_item_metadata(item_metadata: ItemMetadata | dict):
+    result_item_metadata: dict[str, Any] = {}
+    if isinstance(item_metadata, ItemMetadata):
+        result_item_metadata["compilation"] = {}
+        if item_metadata.scheduler_timing:
+            result_item_metadata["compilation"]["scheduler_timing"] = {
+                "timing": item_metadata.scheduler_timing.timing,
+                "circuit_duration": item_metadata.scheduler_timing.circuit_duration,
+            }
+        if item_metadata.stretch_values:
+            result_item_metadata["compilation"]["stretch_values"] = [
+                asdict(stretch_value, dict_factory=expanded_values_to_lists)
+                for stretch_value in item_metadata.stretch_values
+            ]
+
+    return result_item_metadata
+
+
 def create_pub_result(
     item_result: QuantumProgramItemResult,
     observables: ObservablesArray,
@@ -530,7 +564,10 @@ def create_pub_result(
     data_bin = DataBin(
         evs=exp_vals, stds=stds, ensemble_standard_error=ensemble_stds, shape=exp_vals.shape
     )
-    return EstimatorPubResult(data=data_bin)
+
+    result_item_metadata = create_result_item_metadata(item_result.metadata)
+
+    return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 
 
 def create_pub_result_pec(
@@ -560,7 +597,10 @@ def create_pub_result_pec(
     data_bin = DataBin(
         evs=exp_vals, stds=stds, ensemble_standard_error=ensemble_stds, shape=exp_vals.shape
     )
-    return EstimatorPubResult(data=data_bin)
+
+    result_item_metadata = create_result_item_metadata(item_result.metadata)
+
+    return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 
 
 def create_pub_result_pea(
@@ -633,7 +673,10 @@ def create_pub_result_pea(
         stds_extrapolated=extrapolated_stds,
         shape=zero_noise_exp_vals.shape,
     )
-    return EstimatorPubResult(data=data_bin)
+
+    result_item_metadata = create_result_item_metadata(item_result.metadata)
+
+    return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 
 
 def _process_expectation_values_pea(
@@ -800,7 +843,10 @@ def create_pub_result_zne(
         stds_extrapolated=extrapolated_stds,
         shape=zero_noise_exp_vals.shape,
     )
-    return EstimatorPubResult(data=data_bin)
+
+    result_item_metadata = [create_result_item_metadata(item_result.metadata) for item_result in item_results]
+
+    return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 
 
 def _process_expectation_values_zne(

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -20,8 +20,9 @@ from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    import numpy.typing as npt
     from collections.abc import Iterable
+
+    import numpy.typing as npt
     from qiskit.quantum_info import PauliLindbladMap
 
     from ...options_models.zne import ExtrapolatorType

--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -524,7 +524,7 @@ def _process_expectation_values_pec(
     return exp_vals, stds, ensemble_stds
 
 
-def create_result_item_metadata(item_metadata: ItemMetadata | dict) -> dict[str, Any]:
+def create_pub_result_metadata(item_metadata: ItemMetadata | dict) -> dict[str, Any]:
     """Build the metadata dict for a single result item.
 
     For hardware results (``ItemMetadata``), extracts compilation-related fields
@@ -582,7 +582,7 @@ def create_pub_result(
         evs=exp_vals, stds=stds, ensemble_standard_error=ensemble_stds, shape=exp_vals.shape
     )
 
-    result_item_metadata = create_result_item_metadata(item_result.metadata)
+    result_item_metadata = create_pub_result_metadata(item_result.metadata)
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 
@@ -615,7 +615,7 @@ def create_pub_result_pec(
         evs=exp_vals, stds=stds, ensemble_standard_error=ensemble_stds, shape=exp_vals.shape
     )
 
-    result_item_metadata = create_result_item_metadata(item_result.metadata)
+    result_item_metadata = create_pub_result_metadata(item_result.metadata)
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 
@@ -691,7 +691,7 @@ def create_pub_result_pea(
         shape=zero_noise_exp_vals.shape,
     )
 
-    result_item_metadata = create_result_item_metadata(item_result.metadata)
+    result_item_metadata = create_pub_result_metadata(item_result.metadata)
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)
 
@@ -861,7 +861,7 @@ def create_pub_result_zne(
         shape=zero_noise_exp_vals.shape,
     )
 
-    per_item = [create_result_item_metadata(item_result.metadata) for item_result in item_results]
+    per_item = [create_pub_result_metadata(item_result.metadata) for item_result in item_results]
     result_item_metadata = {key: [item[key] for item in per_item] for key in per_item[0]}
 
     return EstimatorPubResult(data=data_bin, metadata=result_item_metadata)

--- a/qiskit_ibm_runtime/decoders/executor_sampler/converters.py
+++ b/qiskit_ibm_runtime/decoders/executor_sampler/converters.py
@@ -90,5 +90,7 @@ def quantum_program_item_result_to_sampler_pub_result(
                 asdict(stretch_value, dict_factory=expanded_values_to_lists)
                 for stretch_value in item.metadata.stretch_values
             ]
+    else:  # simulator
+        pub_metadata["executor"] = item.metadata
 
     return SamplerPubResult(data=data_bin, metadata=pub_metadata)

--- a/test/unit/decoders/executor_estimator/test_post_processor.py
+++ b/test/unit/decoders/executor_estimator/test_post_processor.py
@@ -237,9 +237,10 @@ class TestEstimatorV2PostProcessor(IBMTestCase):
         result._semantic_role = "estimator_v2"
 
         primitive_result = estimator_v2_post_processor_v0_1(result)
-        # ZNE returns a list of per-noise-factor metadata
-        for item_metadata in primitive_result[0].metadata:
-            self._assert_compilation_metadata(item_metadata, stretch_values, scheduler_timing)
+        pub_metadata = primitive_result[0].metadata
+        self.assertIn("compilation", pub_metadata)
+        for sub_result_metadata in pub_metadata["compilation"]:
+            self._assert_compilation_metadata({"compilation": sub_result_metadata}, stretch_values, scheduler_timing)
 
     def test_simulation_info_in_metadata(self):
         """For simulator results metadata is stored under ``executor``."""
@@ -298,11 +299,11 @@ class TestEstimatorV2PostProcessor(IBMTestCase):
         result._semantic_role = "estimator_v2"
 
         primitive_result = estimator_v2_post_processor_v0_1(result)
-        # ZNE returns a list of per-noise-factor metadata
-        for item_metadata in primitive_result[0].metadata:
-            self.assertIn("executor", item_metadata)
-            self.assertEqual(item_metadata["executor"], sim_metadata)
-            self.assertNotIn("compilation", item_metadata)
+        pub_metadata = primitive_result[0].metadata
+        self.assertIn("executor", pub_metadata)
+        self.assertNotIn("compilation", pub_metadata)
+        for sub_result_metadata in pub_metadata["executor"]:
+            self.assertEqual(sub_result_metadata, sim_metadata)
 
     def test_measure_mitigation_fix_expectation_values(self):
         """Test that measure_mitigation fix expectation values compared to no mitigation.

--- a/test/unit/decoders/executor_estimator/test_post_processor.py
+++ b/test/unit/decoders/executor_estimator/test_post_processor.py
@@ -240,7 +240,9 @@ class TestEstimatorV2PostProcessor(IBMTestCase):
         pub_metadata = primitive_result[0].metadata
         self.assertIn("compilation", pub_metadata)
         for sub_result_metadata in pub_metadata["compilation"]:
-            self._assert_compilation_metadata({"compilation": sub_result_metadata}, stretch_values, scheduler_timing)
+            self._assert_compilation_metadata(
+                {"compilation": sub_result_metadata}, stretch_values, scheduler_timing
+            )
 
     def test_simulation_info_in_metadata(self):
         """For simulator results metadata is stored under ``executor``."""

--- a/test/unit/decoders/executor_estimator/test_post_processor.py
+++ b/test/unit/decoders/executor_estimator/test_post_processor.py
@@ -12,6 +12,8 @@
 
 """Unit tests for EstimatorV2 post-processor."""
 
+from dataclasses import asdict
+
 import numpy as np
 from ddt import data, ddt, unpack
 from qiskit.primitives import PrimitiveResult
@@ -29,8 +31,11 @@ from qiskit_ibm_runtime.decoders.executor_estimator.post_processor_v0_1 import (
 from qiskit_ibm_runtime.executor_estimator.utils import get_pauli_basis, unbroadcast_index
 from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
 from qiskit_ibm_runtime.results.quantum_program import (
+    ItemMetadata,
     QuantumProgramItemResult,
     QuantumProgramResult,
+    SchedulerTiming,
+    StretchValues,
 )
 
 from ....ibm_test_case import IBMTestCase
@@ -149,6 +154,155 @@ class TestEstimatorV2PostProcessor(IBMTestCase):
         pub_result = primitive_result[0]
         self.assertIn("circuit_metadata", pub_result.metadata)
         self.assertEqual(pub_result.metadata["circuit_metadata"], circuit_metadata)
+
+    def _make_item_result(self, meas_data):
+        """Helper to build a ``QuantumProgramItemResult``."""
+        stretch_values = [StretchValues("name", 2, 3, [(0, 1)])]
+        scheduler_timing = SchedulerTiming("main,rz_0,Qubit 0,1365,0,shift_phase", 10)
+        item_metadata = ItemMetadata(
+            stretch_values=stretch_values, scheduler_timing=scheduler_timing
+        )
+        return (
+            QuantumProgramItemResult({"_meas": meas_data}, item_metadata),
+            stretch_values,
+            scheduler_timing,
+        )
+
+    def _assert_compilation_metadata(self, pub_metadata, stretch_values, scheduler_timing):
+        """Assert ``compilation`` key is populated correctly."""
+        self.assertIn("compilation", pub_metadata)
+        self.assertEqual(
+            pub_metadata["compilation"]["scheduler_timing"],
+            {
+                "timing": scheduler_timing.timing,
+                "circuit_duration": scheduler_timing.circuit_duration,
+            },
+        )
+        expected_stretch_values = [asdict(stretch_values[0])]
+        expected_stretch_values[0]["expanded_values"] = [
+            list(i) for i in expected_stretch_values[0]["expanded_values"]
+        ]
+        self.assertEqual(pub_metadata["compilation"]["stretch_values"], expected_stretch_values)
+
+    def test_populating_compilation_key(self):
+        """The `compilation` key of metadata must be populated if related fields are present."""
+        meas_data = np.zeros((1, 1, 10, 2), dtype=bool)
+        item, stretch_values, scheduler_timing = self._make_item_result(meas_data)
+
+        result_data = [item]
+        passthrough_data = {
+            "post_processor": {
+                "version": "v0.1",
+                "circuits_metadata": [None],
+                "observables": [[{"ZZ": 1.0}]],
+                "measure_bases": [["ZZ"]],
+                "param_basis_pairs": [[([], "ZZ")]],
+                "param_shapes": [[]],
+            },
+        }
+        result = QuantumProgramResult(
+            data=result_data, metadata=None, passthrough_data=passthrough_data
+        )
+        result._semantic_role = "estimator_v2"
+
+        primitive_result = estimator_v2_post_processor_v0_1(result)
+        self._assert_compilation_metadata(
+            primitive_result[0].metadata, stretch_values, scheduler_timing
+        )
+
+    def test_populating_compilation_key_zne(self):
+        """The `compilation` key of metadata must be populated for ZNE results."""
+        meas_data = np.zeros((1, 1, 10, 2), dtype=bool)
+        item1, stretch_values, scheduler_timing = self._make_item_result(meas_data)
+        item2, _, _ = self._make_item_result(meas_data)
+
+        result_data = [item1, item2]
+        passthrough_data = {
+            "post_processor": {
+                "version": "v0.1",
+                "circuits_metadata": [None],
+                "observables": [[{"ZZ": 1.0}]],
+                "measure_bases": [["ZZ"]],
+                "param_basis_pairs": [[([], "ZZ")]],
+                "param_shapes": [[]],
+                "mitigation": "zne",
+                "zne_noise_factors": [1.0, 2.0],
+                "extrapolated_noise_factors": [0.0],
+                "extrapolator": ["linear"],
+            },
+        }
+        result = QuantumProgramResult(
+            data=result_data, metadata=None, passthrough_data=passthrough_data
+        )
+        result._semantic_role = "estimator_v2"
+
+        primitive_result = estimator_v2_post_processor_v0_1(result)
+        # ZNE returns a list of per-noise-factor metadata
+        for item_metadata in primitive_result[0].metadata:
+            self._assert_compilation_metadata(item_metadata, stretch_values, scheduler_timing)
+
+    def test_simulation_info_in_metadata(self):
+        """For simulator results metadata is stored under ``executor``."""
+        meas_data = np.zeros((1, 1, 10, 2), dtype=bool)
+        sim_metadata = {"backend": "fake_sherbrooke", "shots": 1024}
+
+        result_data = [QuantumProgramItemResult({"_meas": meas_data}, sim_metadata)]
+        passthrough_data = {
+            "post_processor": {
+                "version": "v0.1",
+                "circuits_metadata": [None],
+                "observables": [[{"ZZ": 1.0}]],
+                "measure_bases": [["ZZ"]],
+                "param_basis_pairs": [[([], "ZZ")]],
+                "param_shapes": [[]],
+            },
+        }
+        result = QuantumProgramResult(
+            data=result_data, metadata=None, passthrough_data=passthrough_data
+        )
+        result._semantic_role = "estimator_v2"
+
+        primitive_result = estimator_v2_post_processor_v0_1(result)
+        pub_metadata = primitive_result[0].metadata
+
+        self.assertIn("executor", pub_metadata)
+        self.assertEqual(pub_metadata["executor"], sim_metadata)
+        self.assertNotIn("compilation", pub_metadata)
+
+    def test_simulation_info_in_metadata_zne(self):
+        """For ZNE simulator results, metadata is stored under ``executor``."""
+        meas_data = np.zeros((1, 1, 10, 2), dtype=bool)
+        sim_metadata = {"backend": "fake_sherbrooke", "shots": 1024}
+
+        result_data = [
+            QuantumProgramItemResult({"_meas": meas_data}, sim_metadata),
+            QuantumProgramItemResult({"_meas": meas_data}, sim_metadata),
+        ]
+        passthrough_data = {
+            "post_processor": {
+                "version": "v0.1",
+                "circuits_metadata": [None],
+                "observables": [[{"ZZ": 1.0}]],
+                "measure_bases": [["ZZ"]],
+                "param_basis_pairs": [[([], "ZZ")]],
+                "param_shapes": [[]],
+                "mitigation": "zne",
+                "zne_noise_factors": [1.0, 2.0],
+                "extrapolated_noise_factors": [0.0],
+                "extrapolator": ["linear"],
+            },
+        }
+        result = QuantumProgramResult(
+            data=result_data, metadata=None, passthrough_data=passthrough_data
+        )
+        result._semantic_role = "estimator_v2"
+
+        primitive_result = estimator_v2_post_processor_v0_1(result)
+        # ZNE returns a list of per-noise-factor metadata
+        for item_metadata in primitive_result[0].metadata:
+            self.assertIn("executor", item_metadata)
+            self.assertEqual(item_metadata["executor"], sim_metadata)
+            self.assertNotIn("compilation", item_metadata)
 
     def test_measure_mitigation_fix_expectation_values(self):
         """Test that measure_mitigation fix expectation values compared to no mitigation.

--- a/test/unit/decoders/executor_sampler/test_post_processor.py
+++ b/test/unit/decoders/executor_sampler/test_post_processor.py
@@ -155,6 +155,18 @@ class TestQuantumProgramItemResultToSamplerPubResult(IBMTestCase):
         )
         self.assertEqual(result.metadata["compilation"]["stretch_values"], expected_stretch_values)
 
+    def test_simulation_info_in_metadata(self):
+        """For simulator results (plain dict metadata), metadata is stored under ``executor``."""
+        meas = np.array([[False], [True]])
+        sim_metadata = {"backend": "fake_sherbrooke", "shots": 512}
+        item = QuantumProgramItemResult({"meas": meas}, sim_metadata)
+
+        result = quantum_program_item_result_to_sampler_pub_result(item, (), 0)
+
+        self.assertIn("executor", result.metadata)
+        self.assertEqual(result.metadata["executor"], sim_metadata)
+        self.assertNotIn("compilation", result.metadata)
+
 
 @ddt
 class TestSamplerV2PostProcessor(IBMTestCase):


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR does two things:
- It populates the estimator metadata at the pub level, both hardware and simulator
- It populates the sampler metadata at the pub level, for simulator (hardware was already done)

### Details and comments

Fixes #3247

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Bob
