### PR TITLE
Change zne.noise_factors validator to annotated pattern

### DIFF
--- a/qiskit_ibm_runtime/options_models/post_selection.py
+++ b/qiskit_ibm_runtime/options_models/post_selection.py
@@ -20,7 +20,7 @@ from ..utils.deprecation import issue_deprecation_msg
 from .base import BaseOptionsModel
 
 
-def _warn_post_selection(value: bool) -> bool:
+def warn_post_selection(value: bool) -> bool:
     """Warn that the post selection options are deprecated."""
     if value:
         issue_deprecation_msg(
@@ -35,7 +35,7 @@ def _warn_post_selection(value: bool) -> bool:
 class PostSelectionOptions(BaseOptionsModel):
     """Options for post selecting results."""
 
-    enable: Annotated[bool, AfterValidator(_warn_post_selection)] = False
+    enable: Annotated[bool, AfterValidator(warn_post_selection)] = False
     """Whether to enable Post Selection when performing learning experiments.
 
     If ``True``, Post Selection is applied to all the learning circuits. In particular, the

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -36,7 +36,7 @@ else:
     noise_model_type: TypeAlias = dict | None  # type: ignore[no-redef, misc]
 
 
-def _validate_layer_noise_model(value: LayerNoiseModel | None) -> LayerNoiseModel | None:
+def validate_layer_noise_model(value: LayerNoiseModel | None) -> LayerNoiseModel | None:
     """Validate the ``LayerNoiseModel``."""
     if value:
         instruction, noise = value
@@ -52,7 +52,7 @@ def _validate_layer_noise_model(value: LayerNoiseModel | None) -> LayerNoiseMode
 
 LayerNoiseModel: TypeAlias = Annotated[
     tuple[Annotated[CircuitInstruction, InstanceOf], Annotated[PauliLindbladMap, InstanceOf]],
-    AfterValidator(_validate_layer_noise_model),
+    AfterValidator(validate_layer_noise_model),
 ]
 
 

--- a/qiskit_ibm_runtime/options_models/zne.py
+++ b/qiskit_ibm_runtime/options_models/zne.py
@@ -39,7 +39,7 @@ DEFAULT_NOISE_FACTORS = (1, 3, 5)
 """The values of ``noise_factors`` used by default when ZNE is selected."""
 
 
-def _at_least_two_noise_factors(
+def at_least_two_noise_factors(
     value: Sequence[float],
 ) -> Sequence[float]:
     """Validate that `noise_factors` contains at least two factors.
@@ -126,7 +126,7 @@ class ZneOptions(BaseOptionsModel):
     noise_factors: (
         Annotated[
             Sequence[Annotated[float, Field(ge=1)]],
-            AfterValidator(_at_least_two_noise_factors),
+            AfterValidator(at_least_two_noise_factors),
         ]
         | Literal["auto"]
     ) = "auto"

--- a/qiskit_ibm_runtime/options_models/zne.py
+++ b/qiskit_ibm_runtime/options_models/zne.py
@@ -130,11 +130,10 @@ class ZneOptions(BaseOptionsModel):
         ]
         | Literal["auto"]
     ) = "auto"
-    """ noise_factors: Noise factors to use for noise amplification.
+    """Noise factors to use for noise amplification.
 
-    The default is
-    :data:`~.DEFAULT_NOISE_FACTORS`.
-    Must contain more values than DOF in all requested extrapolators.
+    The default is :data:`~.DEFAULT_NOISE_FACTORS`. Must contain more values than DOF in all
+    requested extrapolators.
     """
 
     extrapolator: ExtrapolatorType | Sequence[ExtrapolatorType] = ("exponential", "linear")

--- a/qiskit_ibm_runtime/options_models/zne.py
+++ b/qiskit_ibm_runtime/options_models/zne.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Annotated, Literal
 
-from pydantic import Field, field_validator
+from pydantic import AfterValidator, Field
 
 from .base import BaseOptionsModel
 
@@ -37,6 +37,19 @@ ExtrapolatorType = Literal[
 
 DEFAULT_NOISE_FACTORS = (1, 3, 5)
 """The values of ``noise_factors`` used by default when ZNE is selected."""
+
+
+def _at_least_two_noise_factors(
+    value: Sequence[float],
+) -> Sequence[float]:
+    """Validate that `noise_factors` contains at least two factors.
+
+    This is used instead of `pydantic` `Field(..., min_length=2)` in order to provide a more
+    meaningful error message.
+    """
+    if len(value) < 2:
+        raise ValueError("Must have at least two noise factors in order to do an extrapolation.")
+    return value
 
 
 class ZneOptions(BaseOptionsModel):
@@ -110,7 +123,13 @@ class ZneOptions(BaseOptionsModel):
             proportional to the corresponding learned noise model.
     """
 
-    noise_factors: Sequence[Annotated[float, Field(ge=1)]] | Literal["auto"] = "auto"
+    noise_factors: (
+        Annotated[
+            Sequence[Annotated[float, Field(ge=1)]],
+            AfterValidator(_at_least_two_noise_factors),
+        ]
+        | Literal["auto"]
+    ) = "auto"
     """ noise_factors: Noise factors to use for noise amplification.
 
     The default is
@@ -147,16 +166,3 @@ class ZneOptions(BaseOptionsModel):
     points at which the ``extrapolator``\s are evaluated to be returned in the data
     fields called ``evs_extrapolated`` and ``stds_extrapolated``.
     """
-
-    @field_validator("noise_factors", mode="plain")
-    @classmethod
-    def _validate_noise_factors(
-        cls, value: Sequence[Annotated[float, Field(ge=1)]] | Literal["auto"]
-    ) -> Sequence[Annotated[float, Field(ge=1)]] | Literal["auto"]:
-        if value == "auto":
-            return value
-        if len(value) < 2:
-            raise ValueError(
-                "Must have at least two noise factors in order to do an extrapolation."
-            )
-        return value


### PR DESCRIPTION
### Summary

Update the validator for `ZneOptions.noise_factors` in order to use the annotated pattern, for consistency with the rest of the module.

### Details and comments

Related to #2850

### AI/LLM disclosure

- [x] I used the following tool to generate or modify code: Claude Opus 4.8
