### PR TITLE
Revert `mode` changes to `NoiseLearnerV3Results.to_dict`

### DIFF
--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -14,12 +14,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 from qiskit.circuit import BoxOp
 from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauliList
-from samplomatic import InjectNoise, Tag
+from samplomatic import InjectNoise
 from samplomatic.utils import get_annotation
 
 if TYPE_CHECKING:
@@ -142,25 +142,20 @@ class NoiseLearnerV3Results:
         self,
         instructions: Sequence[CircuitInstruction],
         require_refs: bool = True,
-        group_by: Literal["inject_noise", "tag"] = "inject_noise",
     ) -> dict[str, PauliLindbladMap]:
-        """Convert to a dictionary from references to :class:`PauliLindbladMap` objects.
-
-        References can be one of :attr:`InjectNoise.ref` or :attr:`Tag.ref` depending on
-        ``group_by`` selection.
+        """Convert to dictionary from :attr:`InjectNoise.ref` to :class:`PauliLindbladMap` objects.
 
         This function iterates over a sequence of instructions, extracts the ``ref`` value
-        from the annotation of each instruction, and returns a dictionary mapping
+        from the inject noise annotation of each instruction, and returns a dictionary mapping
         those refs to the corresponding noise data (in :class:`PauliLindbladMap` format) stored in
         this :class:`NoiseLearnerV3Results` object.
 
         Args:
             instructions: The instructions to get the refs from.
             require_refs: Whether to raise if some of the instructions do not own an
-                annotation. If ``False``, all the instructions that do not contain an
-                annotation are simply skipped when constructing the returned dictionary.
-            group_by: If ``"tag"``, it groups by :class:`~.Tag` annotations. Otherwise, by
-                :class:`~.InjectNoise` annotations.
+                inject noise annotation. If ``False``, all the instructions that do not contain an
+                inject noise annotation are simply skipped when constructing the returned
+                dictionary.
 
         Raise:
             ValueError: If ``instructions`` contains a number of elements that is not equal to the
@@ -177,12 +172,11 @@ class NoiseLearnerV3Results:
 
         noise_source = {}
         num_instr = 0
-        annotation_type = Tag if group_by == "tag" else InjectNoise
         pauli_maps = self.to_pauli_lindblad_maps()
         for instr, pauli_map in zip(instructions, pauli_maps):
             if not isinstance(instr.operation, BoxOp):
                 raise ValueError("Found an instruction that does not contain a box.")
-            if annotation := get_annotation(instr.operation, annotation_type):
+            if annotation := get_annotation(instr.operation, InjectNoise):
                 num_instr += 1
                 noise_source[annotation.ref] = pauli_map
             elif require_refs:

--- a/qiskit_ibm_runtime/results/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/results/noise_learner_v3.py
@@ -142,12 +142,12 @@ class NoiseLearnerV3Results:
         self,
         instructions: Sequence[CircuitInstruction],
         require_refs: bool = True,
-        mode: Literal["injection", "simulation"] = "injection",
+        group_by: Literal["inject_noise", "tag"] = "inject_noise",
     ) -> dict[str, PauliLindbladMap]:
         """Convert to a dictionary from references to :class:`PauliLindbladMap` objects.
 
         References can be one of :attr:`InjectNoise.ref` or :attr:`Tag.ref` depending on
-        ``mode`` selection.
+        ``group_by`` selection.
 
         This function iterates over a sequence of instructions, extracts the ``ref`` value
         from the annotation of each instruction, and returns a dictionary mapping
@@ -159,7 +159,7 @@ class NoiseLearnerV3Results:
             require_refs: Whether to raise if some of the instructions do not own an
                 annotation. If ``False``, all the instructions that do not contain an
                 annotation are simply skipped when constructing the returned dictionary.
-            mode: If ``"simulation"``, it groups by :class:`~.Tag` annotations. Otherwise, by
+            group_by: If ``"tag"``, it groups by :class:`~.Tag` annotations. Otherwise, by
                 :class:`~.InjectNoise` annotations.
 
         Raise:
@@ -177,7 +177,7 @@ class NoiseLearnerV3Results:
 
         noise_source = {}
         num_instr = 0
-        annotation_type = Tag if mode == "simulation" else InjectNoise
+        annotation_type = Tag if group_by == "tag" else InjectNoise
         pauli_maps = self.to_pauli_lindblad_maps()
         for instr, pauli_map in zip(instructions, pauli_maps):
             if not isinstance(instr.operation, BoxOp):

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -140,10 +140,12 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         self.assertEqual(results[1], self.results[1])
         self.assertEqual(len(results), 3)
 
-    @data("injection", "simulation")
-    def test_to_dict_valid_input_require_refs_true(self, mode):
+    @data("inject_noise", "tag")
+    def test_to_dict_valid_input_require_refs_true(self, group_by):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -151,7 +153,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         returned_dict = NoiseLearnerV3Results(self.results[:2]).to_dict(
-            circuit.data, True, mode=mode
+            circuit.data, True, group_by=group_by
         )
         self.assertDictEqual(
             {
@@ -163,10 +165,12 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("injection", "simulation")
-    def test_to_dict_valid_input_require_refs_false(self, mode):
+    @data("inject_noise", "tag")
+    def test_to_dict_valid_input_require_refs_false(self, group_by):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -175,7 +179,9 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
-        returned_dict = NoiseLearnerV3Results(self.results).to_dict(circuit.data, False, mode=mode)
+        returned_dict = NoiseLearnerV3Results(self.results).to_dict(
+            circuit.data, False, group_by=group_by
+        )
         self.assertDictEqual(
             {
                 annotation.ref: pauli_lindblad_map
@@ -187,10 +193,12 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("injection", "simulation")
-    def test_to_dict_wrong_num_of_instructions(self, mode):
+    @data("inject_noise", "tag")
+    def test_to_dict_wrong_num_of_instructions(self, group_by):
         """Test ``.to_dict`` raises if number of instructions does not match number of results."""
-        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -198,16 +206,18 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "Expected 3 instructions but found 2"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, mode=mode)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
 
-    @data("injection", "simulation")
-    def test_to_dict_invalid_for_require_refs_true(self, mode):
+    @data("inject_noise", "tag")
+    def test_to_dict_invalid_for_require_refs_true(self, group_by):
         """Test raising if an instruction does not contain annotations when requires_ref.
 
         Test that ``NoiseLearnerV3Results.to_dict`` raises if an instruction does not contain
         an annotation, when ``requires_ref`` is ``True``.
         """
-        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -217,12 +227,14 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "without an inject noise"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, mode=mode)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
 
-    @data("injection", "simulation")
-    def test_to_dict_unboxed_instruction(self, mode):
+    @data("inject_noise", "tag")
+    def test_to_dict_unboxed_instruction(self, group_by):
         """Test ``.to_dict`` raises if there is an instruction not in a box."""
-        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -231,12 +243,14 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "contain a box"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, mode=mode)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)
 
-    @data("injection", "simulation")
-    def test_to_dict_ref_used_twice(self, mode):
+    @data("inject_noise", "tag")
+    def test_to_dict_ref_used_twice(self, group_by):
         """Test ``.to_dict`` raises if an annotation reference is repeated."""
-        annotations = self.inject_noise_annotations if mode == "injection" else self.tag_annotations
+        annotations = (
+            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
+        )
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -246,7 +260,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "multiple instructions with the same ``ref``"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, mode=mode)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)
 
     def test_to_pauli_lindblad_maps(self):
         """Test ``.to_pauli_lindblad_maps``."""

--- a/test/unit/noise_learner_v3/test_result.py
+++ b/test/unit/noise_learner_v3/test_result.py
@@ -13,10 +13,9 @@
 """Tests the classes `NoiseLearnerV3Result` and `NoiseLearnerV3Results`."""
 
 import numpy as np
-from ddt import data, ddt
 from qiskit import QuantumCircuit
 from qiskit.quantum_info import PauliLindbladMap, QubitSparsePauliList
-from samplomatic import InjectNoise, Tag, Twirl
+from samplomatic import InjectNoise, Twirl
 
 from qiskit_ibm_runtime.results.noise_learner_v3 import NoiseLearnerV3Result, NoiseLearnerV3Results
 
@@ -110,7 +109,6 @@ class TestNoiseLearnerV3Result(IBMTestCase):
         )
 
 
-@ddt
 class TestNoiseLearnerV3Results(IBMTestCase):
     """Tests the ``NoiseLearnerV3Results`` class."""
 
@@ -128,7 +126,6 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         ]
         self.pauli_lindblad_maps = [result.to_pauli_lindblad_map() for result in self.results]
         self.inject_noise_annotations = [InjectNoise(ref, site="after") for ref in ["hi", "bye"]]
-        self.tag_annotations = [Tag(ref) for ref in ["ciao", "arrivederci"]]
 
     def test_properties_of_iterable(self):
         """Test elementary methods of ``NoiseLearnerV3Results``.
@@ -140,21 +137,16 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         self.assertEqual(results[1], self.results[1])
         self.assertEqual(len(results), 3)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_valid_input_require_refs_true(self, group_by):
+    def test_to_dict_valid_input_require_refs_true(self):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
         with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
-        returned_dict = NoiseLearnerV3Results(self.results[:2]).to_dict(
-            circuit.data, True, group_by=group_by
-        )
+        returned_dict = NoiseLearnerV3Results(self.results[:2]).to_dict(circuit.data, True)
         self.assertDictEqual(
             {
                 annotation.ref: pauli_lindblad_map
@@ -165,12 +157,9 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("inject_noise", "tag")
-    def test_to_dict_valid_input_require_refs_false(self, group_by):
+    def test_to_dict_valid_input_require_refs_false(self):
         """Test ``NoiseLearnerV3Results.to_dict`` when ``require_refs`` is ``True``."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -179,9 +168,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
         with circuit.box(annotations=[annotations[1]]):
             circuit.cx(0, 1)
 
-        returned_dict = NoiseLearnerV3Results(self.results).to_dict(
-            circuit.data, False, group_by=group_by
-        )
+        returned_dict = NoiseLearnerV3Results(self.results).to_dict(circuit.data, False)
         self.assertDictEqual(
             {
                 annotation.ref: pauli_lindblad_map
@@ -193,12 +180,9 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             returned_dict,
         )
 
-    @data("inject_noise", "tag")
-    def test_to_dict_wrong_num_of_instructions(self, group_by):
+    def test_to_dict_wrong_num_of_instructions(self):
         """Test ``.to_dict`` raises if number of instructions does not match number of results."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -206,18 +190,15 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "Expected 3 instructions but found 2"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_invalid_for_require_refs_true(self, group_by):
+    def test_to_dict_invalid_for_require_refs_true(self):
         """Test raising if an instruction does not contain annotations when requires_ref.
 
         Test that ``NoiseLearnerV3Results.to_dict`` raises if an instruction does not contain
         an annotation, when ``requires_ref`` is ``True``.
         """
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -227,14 +208,11 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "without an inject noise"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data, True)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_unboxed_instruction(self, group_by):
+    def test_to_dict_unboxed_instruction(self):
         """Test ``.to_dict`` raises if there is an instruction not in a box."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -243,14 +221,11 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "contain a box"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data)
 
-    @data("inject_noise", "tag")
-    def test_to_dict_ref_used_twice(self, group_by):
+    def test_to_dict_ref_used_twice(self):
         """Test ``.to_dict`` raises if an annotation reference is repeated."""
-        annotations = (
-            self.inject_noise_annotations if group_by == "inject_noise" else self.tag_annotations
-        )
+        annotations = self.inject_noise_annotations
         circuit = QuantumCircuit(2)
         with circuit.box(annotations=[Twirl(), annotations[0]]):
             circuit.cx(0, 1)
@@ -260,7 +235,7 @@ class TestNoiseLearnerV3Results(IBMTestCase):
             circuit.cx(0, 1)
 
         with self.assertRaisesRegex(ValueError, "multiple instructions with the same ``ref``"):
-            NoiseLearnerV3Results(self.results).to_dict(circuit.data, group_by=group_by)
+            NoiseLearnerV3Results(self.results).to_dict(circuit.data)
 
     def test_to_pauli_lindblad_maps(self):
         """Test ``.to_pauli_lindblad_maps``."""


### PR DESCRIPTION
### Summary
Reverting the changes to `NoiseLearnerV3Results.to_dict` that added `Tag` support via the `mode` argument.

### Details and comments


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
