### PR TITLE
Exclude noise model from dump to passthrough data

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/prepare.py
+++ b/qiskit_ibm_runtime/executor_estimator/prepare.py
@@ -109,7 +109,7 @@ def prepare(
 
     # Annotate passthrough_data for post-processing
     quantum_program.passthrough_data["post_processor"]["options"] = finalized_options.model_dump(  # type: ignore[index, call-overload]
-        exclude={"resilience": {"noise_model"}}
+        exclude={"resilience": {"layer_noise_model"}}
     )
     quantum_program.passthrough_data["post_processor"]["shots"] = shots  # type: ignore[index, call-overload]
     quantum_program.passthrough_data["post_processor"]["precision"] = resolved_precision  # type: ignore[index, call-overload]


### PR DESCRIPTION
### Summary
#3262 changed the resilience options field `noise_model` to `layer_noise_model`. The corresponding exclusion was not updated, causing serialization to fail. Verified end-to-end.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.