### PR TITLE
Add selected extrapolators to pub metadata when using ZNE

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -620,10 +620,12 @@ def create_pub_result_pea(
         extrapolator,
         measure_noise_data,
     )
-    # TODO: save selected_extrapolators_per_obs in the metadata
-    # selected_extrapolators_per_obs = combine_selected_extrapolators_per_observable(
-    #     selected_extrapolators, np.broadcast_shapes(param_shape, observables.shape)
-    # )
+    selected_extrapolators_per_obs = combine_selected_extrapolators_per_observable(
+        selected_extrapolators, np.broadcast_shapes(param_shape, observables.shape)
+    )
+
+    pub_metadata = {}
+    pub_metadata["resilience"] = {"zne": {"extrapolators": selected_extrapolators_per_obs}}
 
     data_bin = DataBin(
         evs=zero_noise_exp_vals,
@@ -635,7 +637,7 @@ def create_pub_result_pea(
         stds_extrapolated=extrapolated_stds,
         shape=zero_noise_exp_vals.shape,
     )
-    return EstimatorPubResult(data=data_bin)
+    return EstimatorPubResult(data=data_bin, metadata=pub_metadata)
 
 
 def _process_expectation_values_pea(
@@ -789,10 +791,12 @@ def create_pub_result_zne(
         extrapolator,
         measure_noise_data,
     )
-    # TODO: save selected_extrapolators_per_obs in the metadata
-    # selected_extrapolators_per_obs = combine_selected_extrapolators_per_observable(
-    #     selected_extrapolators, np.broadcast_shapes(param_shape, observables.shape)
-    # )
+    selected_extrapolators_per_obs = combine_selected_extrapolators_per_observable(
+        selected_extrapolators, np.broadcast_shapes(param_shape, observables.shape)
+    )
+
+    pub_metadata = {}
+    pub_metadata["resilience"] = {"zne": {"extrapolators": selected_extrapolators_per_obs}}
 
     data_bin = DataBin(
         evs=zero_noise_exp_vals,
@@ -804,7 +808,7 @@ def create_pub_result_zne(
         stds_extrapolated=extrapolated_stds,
         shape=zero_noise_exp_vals.shape,
     )
-    return EstimatorPubResult(data=data_bin)
+    return EstimatorPubResult(data=data_bin, metadata=pub_metadata)
 
 
 def _process_expectation_values_zne(

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -126,6 +126,9 @@ class TestEstimator(IBMIntegrationTestCase):
               ``ensemble_stds_noise_factors``: ``(*pub_shape, num_noise_factors)``
             * ``evs_extrapolated``, ``stds_extrapolated``:
               ``(*pub_shape, num_extrapolators, num_extrapolated_noise_factors)``
+
+        - Correct shape and make-up for all ZNE-specific pub metadata fields:
+            * ``extrapolators``: pub shape, only requested extrapolators or `multiple`.
         """
         estimator = EstimatorV2(self.backend)
         estimator.options.resilience.zne_mitigation = True
@@ -172,3 +175,7 @@ class TestEstimator(IBMIntegrationTestCase):
             )
             self.assertEqual(data_bin.evs_extrapolated.shape, expected_extrap_shape)
             self.assertEqual(data_bin.stds_extrapolated.shape, expected_extrap_shape)
+
+            # Selected extrapolators must be one the requested extrapolators or `multiple`
+            allowed = {*estimator.options.resilience.zne.extrapolator, "multiple"}
+            self.assertTrue(set(metadata["resilience"]["zne"]["extrapolators"]).issubset(allowed))

--- a/test/integration/test_executor_estimator.py
+++ b/test/integration/test_executor_estimator.py
@@ -150,10 +150,14 @@ class TestEstimator(IBMIntegrationTestCase):
 
         for pub_idx, expected_pub_shape in enumerate([(2, 2), (2,)]):
             data_bin = results[pub_idx].data
+            metadata = results[pub_idx].metadata
 
-            # evs and stds: pub shape only
+            # evs, stds and selected extrapolators metadata: pub shape only
             self.assertEqual(data_bin.evs.shape, expected_pub_shape)
             self.assertEqual(data_bin.stds.shape, expected_pub_shape)
+            self.assertEqual(
+                metadata["resilience"]["zne"]["extrapolators"].shape, expected_pub_shape
+            )
 
             # noise-factor arrays: (*pub_shape, num_noise_factors)
             expected_nf_shape = expected_pub_shape + (expected_num_noise_factors,)


### PR DESCRIPTION
### Summary
Closes #3144 

The selected extrapolators are added to the pub metadata using the same convention as legacy estimator.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.