### PR TITLE
Executor-based Primitives can execute circuits with RZZ gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ dependencies = [
     "pydantic>=2.13.0",
     "qiskit>=2.3.0",
     "pybase64>=1.4.0",
-    "samplomatic>=0.18.0"
+    "samplomatic>=0.19.0"
 ]
 
 [project.entry-points."qiskit.transpiler.translation"]

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -281,7 +281,6 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None,
     inject_noise: bool,
-    twirling_group: str = "local_pauli",
     add_tags: bool = False,
 ) -> dict[str, Any]:
     """A helper to map options to kwargs for the boxing passmanager.
@@ -306,7 +305,7 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
         if twirling_options.enable_measure or (measure_noise_learning is not None)
         else "change_basis",
         "twirling_strategy": twirling_options.strategy.replace("-", "_"),
-        "twirling_group": twirling_group,
+        "twirling_group": twirling_options.group,
         "inject_noise": inject_noise,
         "add_tags": "unique_box" if add_tags else "none",
     }

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -281,7 +281,7 @@ def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None,
     inject_noise: bool,
-    twirling_group: str = "balanced_pauli",
+    twirling_group: str = "local_pauli",
     add_tags: bool = False,
 ) -> dict[str, Any]:
     """A helper to map options to kwargs for the boxing passmanager.

--- a/qiskit_ibm_runtime/executor_sampler/prepare.py
+++ b/qiskit_ibm_runtime/executor_sampler/prepare.py
@@ -213,6 +213,7 @@ def _build_quantum_program(
             twirling_strategy=finalized_options.twirling.strategy.replace("-", "_"),
             inject_noise_site="after",
             add_tags="unique_box" if add_tags else "none",
+            twirling_group=finalized_options.twirling.group,
         )
 
         for i, pub in enumerate(coerced_pubs):

--- a/qiskit_ibm_runtime/options_models/twirling.py
+++ b/qiskit_ibm_runtime/options_models/twirling.py
@@ -45,6 +45,18 @@ class TwirlingOptions(BaseOptionsModel):
       ``False`` for resilience level ``0``, and ``True`` for resilience levels ``1`` and ``2``.
     """
 
+    group: Literal["pauli", "balanced_pauli", "local_c1", "local_pauli"] = "pauli"
+    """The group used to twirl the content of the identified layers.
+
+      * ``'pauli'`` uses the Pauli group.
+      * ``'balanced_pauli'`` uses the Pauli group with a balanced distribution.
+      * ``'local_c1'`` uses the subgroup of single-qubit Cliffords that are conjugated to
+        single-qubit Cliffords on any entangling gates in the box, and the Pauli group
+        everywhere else.
+      * ``'local_pauli'`` uses the Pauli subgroup that commutes with an entangler for
+        non-Clifford gates, and the Pauli group everywhere else.
+    """
+
     num_randomizations: Annotated[int, Field(ge=1)] | Literal["auto"] = "auto"
     """The number of random samples to use when twirling or performing sampled mitigation.
 

--- a/test/unit/executor_estimator/test_estimator_v2_prepare.py
+++ b/test/unit/executor_estimator/test_estimator_v2_prepare.py
@@ -12,10 +12,12 @@
 
 """Unit tests for EstimatorV2 prepare method."""
 
+import numpy as np
 from ddt import data, ddt
-from qiskit import QuantumCircuit
+from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.quantum_info import PauliLindbladMap, SparsePauliOp
 from samplomatic import Tag
+from samplomatic.exceptions import BuildError
 from samplomatic.utils import find_unique_box_instructions, get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
@@ -239,3 +241,26 @@ class TestPrepare(IBMTestCase):
             "Measurement mitigation is currently not supported when observables contain projection",
         ):
             prepare(pubs, options, precision=0.1)
+
+    @data("pauli", "balanced_pauli", "local_c1", "local_pauli")
+    def test_circuit_with_parametric_rzz_and_twirling(self, group):
+        """Test the ``prepare`` function for PUBs that contain parametric RZZ gates.
+
+        ``prepare`` should not raise when ``group`` is ``"local_pauli``.
+        """
+        options = EstimatorOptions()
+        options.twirling.enable_gates = True
+        options.twirling.group = group
+
+        circuit = QuantumCircuit(2)
+        circuit.rzz(Parameter("theta"), 0, 1)
+        params = np.random.random((1,))
+        observable = SparsePauliOp.from_list([("ZZ", 1)])
+
+        pubs = [(circuit, observable, params)]
+
+        if group in {"pauli", "balanced_pauli", "local_c1"}:
+            with self.assertRaisesRegex(BuildError, "GroupMode LOCAL_PAULI"):
+                prepare(pubs, options)
+        else:
+            prepare(pubs, options)

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -302,7 +302,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=enable_gates,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
         )
 
         pm = generate_boxing_pass_manager(
@@ -310,7 +310,7 @@ class TestBoxCircuit(IBMTestCase):
             measure_annotations="all",
             twirling_strategy="all",
             inject_noise_site="after",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -334,7 +334,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations=measure_annotations,
             twirling_strategy="all",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
         )
 
         pm = generate_boxing_pass_manager(
@@ -342,7 +342,7 @@ class TestBoxCircuit(IBMTestCase):
             measure_annotations=measure_annotations,
             twirling_strategy="all",
             inject_noise_site="after",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -366,7 +366,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy=twirling_strategy,
-            twirling_group="local_pauli",
+            twirling_group="pauli",
         )
 
         pm = generate_boxing_pass_manager(
@@ -374,7 +374,7 @@ class TestBoxCircuit(IBMTestCase):
             measure_annotations="all",
             twirling_strategy=twirling_strategy,
             inject_noise_site="after",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -398,7 +398,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
             inject_noise=inject_noise,
         )
 
@@ -406,7 +406,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
             inject_noise_targets="gates" if inject_noise else "none",
             inject_noise_strategy="uniform_modification" if inject_noise else "no_modification",
             inject_noise_site="after",
@@ -439,7 +439,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
             add_tags=add_tags,
         )
 
@@ -449,7 +449,7 @@ class TestBoxCircuit(IBMTestCase):
             twirling_strategy="all",
             add_tags=add_tags,
             inject_noise_site="after",
-            twirling_group="local_pauli",
+            twirling_group="pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -302,7 +302,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=enable_gates,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="pauli",
+            twirling_group="local_pauli",
         )
 
         pm = generate_boxing_pass_manager(
@@ -310,7 +310,7 @@ class TestBoxCircuit(IBMTestCase):
             measure_annotations="all",
             twirling_strategy="all",
             inject_noise_site="after",
-            twirling_group="pauli",
+            twirling_group="local_pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -334,7 +334,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations=measure_annotations,
             twirling_strategy="all",
-            twirling_group="pauli",
+            twirling_group="local_pauli",
         )
 
         pm = generate_boxing_pass_manager(
@@ -342,7 +342,7 @@ class TestBoxCircuit(IBMTestCase):
             measure_annotations=measure_annotations,
             twirling_strategy="all",
             inject_noise_site="after",
-            twirling_group="pauli",
+            twirling_group="local_pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -366,7 +366,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy=twirling_strategy,
-            twirling_group="pauli",
+            twirling_group="local_pauli",
         )
 
         pm = generate_boxing_pass_manager(
@@ -374,7 +374,7 @@ class TestBoxCircuit(IBMTestCase):
             measure_annotations="all",
             twirling_strategy=twirling_strategy,
             inject_noise_site="after",
-            twirling_group="pauli",
+            twirling_group="local_pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)
@@ -398,7 +398,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="pauli",
+            twirling_group="local_pauli",
             inject_noise=inject_noise,
         )
 
@@ -406,7 +406,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="pauli",
+            twirling_group="local_pauli",
             inject_noise_targets="gates" if inject_noise else "none",
             inject_noise_strategy="uniform_modification" if inject_noise else "no_modification",
             inject_noise_site="after",
@@ -449,6 +449,7 @@ class TestBoxCircuit(IBMTestCase):
             twirling_strategy="all",
             add_tags=add_tags,
             inject_noise_site="after",
+            twirling_group="local_pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -439,7 +439,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="balanced_pauli",
+            twirling_group="local_pauli",
             add_tags=add_tags,
         )
 

--- a/test/unit/executor_estimator/test_estimator_v2_utils.py
+++ b/test/unit/executor_estimator/test_estimator_v2_utils.py
@@ -439,7 +439,7 @@ class TestBoxCircuit(IBMTestCase):
             enable_gates=True,
             measure_annotations="all",
             twirling_strategy="all",
-            twirling_group="pauli",
+            twirling_group="balanced_pauli",
             add_tags=add_tags,
         )
 
@@ -449,7 +449,7 @@ class TestBoxCircuit(IBMTestCase):
             twirling_strategy="all",
             add_tags=add_tags,
             inject_noise_site="after",
-            twirling_group="pauli",
+            twirling_group="balanced_pauli",
         )
 
         expected_circuit = circuit.remove_final_measurements(inplace=False)

--- a/test/unit/executor_sampler/test_prepare.py
+++ b/test/unit/executor_sampler/test_prepare.py
@@ -19,6 +19,7 @@ from ddt import data, ddt
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from samplomatic import Tag
+from samplomatic.exceptions import BuildError
 from samplomatic.utils import find_unique_box_instructions, get_annotation
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
@@ -31,6 +32,7 @@ from qiskit_ibm_runtime.quantum_program.quantum_program import CircuitItem, Samp
 from ...ibm_test_case import IBMTestCase
 
 
+@ddt
 class TestPrepare(IBMTestCase):
     """Tests for prepare method."""
 
@@ -196,6 +198,28 @@ class TestPrepare(IBMTestCase):
 
         self.assertIn("BoxOp", str(context.exception))
         self.assertIn("not supported", str(context.exception))
+
+    @data("pauli", "balanced_pauli", "local_c1", "local_pauli")
+    def test_circuit_with_parametric_rzz_and_twirling(self, group):
+        """Test the ``prepare`` function for PUBs that contain parametric RZZ gates.
+
+        ``prepare`` should not raise when ``group`` is ``"local_pauli``.
+        """
+        options = SamplerOptions()
+        options.twirling.enable_gates = True
+        options.twirling.group = group
+
+        circuit = QuantumCircuit(2)
+        circuit.rzz(Parameter("theta"), 0, 1)
+        params = np.random.random((1,))
+
+        pubs = [(circuit, params)]
+
+        if group in {"pauli", "balanced_pauli", "local_c1"}:
+            with self.assertRaisesRegex(BuildError, "GroupMode LOCAL_PAULI"):
+                prepare(pubs, options)
+        else:
+            prepare(pubs, options)
 
 
 class TestPrepareOptionsHandling(IBMTestCase):


### PR DESCRIPTION
### Summary
Right now, executor-based primitives raise an error when a circuit contains an RZZ gate with an unset `Parameter`. This PR fixes it.

Fixes #3242 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
