### PR TITLE
Only support `cz` entangler for mirror circuit

### DIFF
--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -22,7 +22,7 @@ from qiskit.quantum_info import PauliLindbladMap
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_aer import AerSimulator
 
-from qiskit_ibm_runtime.fake_provider import FakeManilaV2
+from qiskit_ibm_runtime.fake_provider import FakeMarrakesh
 from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ....ibm_test_case import IBMTestCase
@@ -88,7 +88,7 @@ class TestEstimatorWithNoise(IBMTestCase):
 
         Estimator result quality is expected to increase with increasing resilience level.
         """
-        backend = FakeManilaV2()
+        backend = FakeMarrakesh()
         preset_pass_manager = generate_preset_pass_manager(optimization_level=1, backend=backend)
 
         pub, ideal_evs = create_estimator_test_data(backend, preset_pass_manager, False)

--- a/test/utils.py
+++ b/test/utils.py
@@ -305,15 +305,9 @@ def make_mirror_circuit_with_phases(
 
     The mirror circuit contains entanglers between nearest neighbours.
     """
-    if "cz" in (basis_gates := backend.configuration().basis_gates):
-        entangler = "cz"
-    elif "cx" in basis_gates:
-        entangler = "cx"
-    elif "ecr" in basis_gates:
-        entangler = "ecr"
-    else:
-        # This should not be reachable
-        raise ValueError("No entangler found.")
+    entangler = "cz"
+    if "cz" not in backend.configuration().basis_gates:
+        raise ValueError(f"Mirror circuit only supports {entangler} entangler.")
 
     even_pairs = zip(range(0, backend.num_qubits, 2), range(1, backend.num_qubits, 2))
     layer1_pairs = [

--- a/test/utils.py
+++ b/test/utils.py
@@ -306,7 +306,7 @@ def make_mirror_circuit_with_phases(
     The mirror circuit contains entanglers between nearest neighbours.
     """
     entangler = "cz"
-    if "cz" not in backend.configuration().basis_gates:
+    if entangler not in backend.configuration().basis_gates:
         raise ValueError(f"Mirror circuit only supports {entangler} entangler.")
 
     even_pairs = zip(range(0, backend.num_qubits, 2), range(1, backend.num_qubits, 2))


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using towncrier if the change needs to
  be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follow up, inspired by https://github.com/Qiskit/qiskit-ibm-runtime/pull/3261#discussion_r3855814306

The mirror circuit does not make much sense for small qubit counts on most backends without `cz` in basis gates.

### Details and comments

Fixes #

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
