### PR TITLE
Rename bit_flip_checks module, other tidy-up tweaks

### DIFF
--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -277,7 +277,7 @@ def box_circuit(
     return boxed_circuit
 
 
-def options_to_boxing_pm_kwargs(  # type: ignore[no-untyped-def]
+def options_to_boxing_pm_kwargs(
     twirling_options: TwirlingOptions,
     measure_noise_learning: MeasureNoiseLearningOptions | None,
     inject_noise: bool,

--- a/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
+++ b/qiskit_ibm_runtime/fake_provider/backends/nighthawk/fake_nighthawk.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ...fake_backend import FakeBackendV2
 
@@ -71,7 +71,7 @@ class FakeNighthawk(FakeBackendV2):
     props_filename = "props_nighthawk.json"
     backend_name = "fake_nighthawk"
 
-    def __init__(self, *args, **kwargs) -> None:  # type: ignore
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         # Only display the warning statement once
         global DISPLAY_WARNING
         if DISPLAY_WARNING:

--- a/qiskit_ibm_runtime/ibm_backend.py
+++ b/qiskit_ibm_runtime/ibm_backend.py
@@ -487,7 +487,7 @@ class IBMBackend(Backend):
         cpy._options = deepcopy(self._options, _memo)
         return cpy
 
-    def run(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def run(self, *args: Any, **kwargs: Any) -> None:
         """Run a job in the backend.
 
         Raises:

--- a/qiskit_ibm_runtime/options_models/__init__.py
+++ b/qiskit_ibm_runtime/options_models/__init__.py
@@ -50,7 +50,7 @@ Suboptions
 
 """
 
-from .bit_flip_checks_options import (
+from .bit_flip_checks import (
     BitFlipChecksOptions,
     PostCircuitBitFlipChecksOptions,
     PreCircuitBitFlipChecksOptions,

--- a/qiskit_ibm_runtime/options_models/bit_flip_checks.py
+++ b/qiskit_ibm_runtime/options_models/bit_flip_checks.py
@@ -32,7 +32,7 @@ class PostCircuitBitFlipChecksOptions(BaseOptionsModel):
     strategy: Literal["node", "edge"] = "node"
     """The strategy used to decide if a shot should be kept or discarded.
 
-    The available startegies are:
+    The available strategies are:
 
     * ``'node'``: Discard every shot where one or more bits failed to flip. Keep every other shot.
     * ``'edge'``: Discard every shot where there exists a pair of neighbouring qubits for which
@@ -55,7 +55,7 @@ class PreCircuitBitFlipChecksOptions(BaseOptionsModel):
     strategy: Literal["node", "edge"] = "node"
     """The strategy used to decide if a shot should be kept or discarded.
 
-    The available startegies are:
+    The available strategies are:
 
     * ``'node'``: Discard every shot where one or more bits failed to flip. Keep every other shot.
     * ``'edge'``: Discard every shot where there exists a pair of neighbouring qubits for which

--- a/qiskit_ibm_runtime/options_models/noise_learner_v3.py
+++ b/qiskit_ibm_runtime/options_models/noise_learner_v3.py
@@ -19,7 +19,7 @@ from typing import Annotated
 from pydantic import Field
 
 from .base import BaseOptionsModel
-from .bit_flip_checks_options import BitFlipChecksOptions
+from .bit_flip_checks import BitFlipChecksOptions
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
 from .post_selection import PostSelectionOptions

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -192,13 +192,13 @@ class QiskitRuntimeService:
         IBMInputValueError: If an input is invalid.
     """
 
-    def __new__(cls, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def __new__(cls, *args: Any, **kwargs: Any) -> QiskitRuntimeService:
         """Construct a ``QiskitRuntimeService`` instance."""
         channel = kwargs.get("channel", None)
         if channel == "local":
             from .fake_provider.local_service import QiskitRuntimeLocalService
 
-            return super().__new__(QiskitRuntimeLocalService)
+            return super().__new__(QiskitRuntimeLocalService)  # type: ignore[return-value]
         else:
             return super().__new__(cls)
 

--- a/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
+++ b/qiskit_ibm_runtime/quantum_program/converters/converters_0_2.py
@@ -161,7 +161,7 @@ def quantum_program_to_0_2(program: QuantumProgram, options: ExecutorOptions) ->
         model_items.append(model_item)
 
     # Build options dict starting with execution options
-    options_dict = options.execution.model_dump()  # type: ignore[call-overload]
+    options_dict = options.execution.model_dump()
 
     # Add experimental options if provided
     if options.experimental:

--- a/qiskit_ibm_runtime/session.py
+++ b/qiskit_ibm_runtime/session.py
@@ -28,18 +28,18 @@ from .utils.converters import hms_to_seconds
 from .utils.default_session import set_cm_session
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from types import TracebackType
 
     from .decoders.result_decoder import ResultDecoder
     from .runtime_job_v2 import RuntimeJobV2
 
 
-def _active_session(func):  # type: ignore
+def _active_session(func: Callable) -> Callable:
     """Decorator used to ensure the session is active."""
 
     @wraps(func)
-    def _wrapper(self, *args, **kwargs):  # type: ignore
+    def _wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         if not self._active:
             raise IBMRuntimeError("The session is closed.")
         return func(self, *args, **kwargs)

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -79,10 +79,6 @@ TWIRLING_TREX = {
 class TestEstimatorWithNoise(IBMTestCase):
     """Tests Executor based EstimatorV2 using simulator with noise through local mode."""
 
-    def setUp(self):
-        """Test level setup."""
-        super().setUp()
-
     def test_result_quality_for_different_resilience_levels(self):
         """Tests the effect of resilience on EstimatorV2 results.
 


### PR DESCRIPTION
### Summary

Round of some tweaks:
* Rename `bit_flips_checks_model` to `bit_flip_checks`, for consistency
* Revise some mypy ignores (focused on kwargs, decorators)
* Remove some unneeded `setUp` in test

### Details and comments

Related to #2514

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
