### PR TITLE
Remove legacy package extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,43 +205,6 @@ issues = "https://github.com/Qiskit/qiskit-ibm-runtime/issues"
 
 [project.optional-dependencies]
 
-# Legacy developer extras.
-
-common = [
-    "mypy==2.3.0",
-    "pproxy==2.7.8",
-    "nbqa==1.5.3",
-    "matplotlib>=2.1",
-    "jupyter",
-    "nbformat>=4.4.0",
-    "nbconvert>=5.3.1",
-    "qiskit-aer>=0.17.0",
-    "ruff~=0.14.10",
-    "coverage>=6.3",
-    "pylatexenc",
-    "scikit-learn",
-    "setuptools",
-]
-
-documentation = [
-    "nbsphinx",
-    "Sphinx>=8,<9",
-    "sphinx-automodapi",
-    "sphinx-autodoc-typehints<=1.19.2",
-    "jupyter-sphinx",
-    "sphinxcontrib-katex==0.9.9",
-    "autodoc_pydantic==2.2.0",
-    "packaging",
-]
-
-dev_legacy = [
-    "qiskit-ibm-runtime[test]",
-    "qiskit-ibm-runtime[common]",
-    "qiskit-ibm-runtime[style]",
-    "qiskit-ibm-runtime[documentation]",
-    "qiskit-ibm-runtime[visualization]",
-]
-
 # User-facing extras.
 
 visualization = [

--- a/release-notes/unreleased/3286.other.rst
+++ b/release-notes/unreleased/3286.other.rst
@@ -1,0 +1,1 @@
+The deprecated Python package ``extras`` (``common`` and ``documentation``) have been removed.


### PR DESCRIPTION
### Summary

Remove the extras that have been marked as deprecated in `0.47.0`.

### Details and comments

Related to #2738

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
