### PR TITLE
Take `Executor` local mode out of experimental options

### DIFF
--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -74,7 +74,6 @@ class Executor:
 
     Raises:
         TypeError: If ``options`` is not a valid type.
-        ValueError: If local mode is used.
     """
 
     _PROGRAM_ID = "executor"
@@ -92,10 +91,6 @@ class Executor:
         self.options = options if options is not None else ExecutorOptions()  # type: ignore[assignment]
 
         self._session, self._service, self._backend = get_mode_service_backend(mode)
-
-        local_mode = self.options.experimental.get("local_mode", False)
-        if isinstance(self._service, QiskitRuntimeLocalService) and not local_mode:
-            raise ValueError("The executor is currently not supported in local mode.")
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Set attribute ``name`` to ``value``.

--- a/qiskit_ibm_runtime/executor/executor.py
+++ b/qiskit_ibm_runtime/executor/executor.py
@@ -21,7 +21,6 @@ from ..base_primitive import get_mode_service_backend
 from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.converters import to_runtime_options
 from ..options_models.executor import ExecutorOptions
-from ..options_models.simulator import ExperimentalSimulatorOptions
 from ..quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
 from ..utils.default_session import get_cm_session
 
@@ -98,11 +97,6 @@ class Executor:
         if isinstance(self._service, QiskitRuntimeLocalService) and not local_mode:
             raise ValueError("The executor is currently not supported in local mode.")
 
-        if local_mode:
-            self.options.experimental["simulator_options"] = self.options.experimental.get(
-                "simulator_options", ExperimentalSimulatorOptions()
-            )
-
     def __setattr__(self, name: str, value: Any) -> None:
         """Set attribute ``name`` to ``value``.
 
@@ -128,9 +122,7 @@ class Executor:
             A job.
         """
         if isinstance(self._service, QiskitRuntimeLocalService):
-            return self._service._run_executor(
-                self._backend, self.options.experimental["simulator_options"], program
-            )
+            return self._service._run_executor(self._backend, self.options.simulator, program)
 
         try:
             converter = QUANTUM_PROGRAM_PARAMS_CONVERTERS[self._SCHEMA_VERSION]

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -15,9 +15,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
-import numpy as np
 from qiskit.primitives.base import BaseEstimatorV2
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 
@@ -27,7 +26,7 @@ from ..fake_provider.local_service import QiskitRuntimeLocalService
 from ..options_models.estimator import EstimatorOptions
 from .finalize_options import finalize_estimator_options
 from .prepare import prepare
-from .utils import BoxType, find_box_type, find_unique_layers, resolve_precision
+from .utils import BoxType, find_box_type, find_unique_layers
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -192,38 +191,6 @@ class EstimatorV2(BaseEstimatorV2):
             The finalized :class:`~.EstimatorOptions` object.
         """
         return finalize_estimator_options(self.options)
-
-    def _run_legacy_simulation(
-        self, pubs: Iterable[EstimatorPubLike], precision: float | None
-    ) -> LocalRuntimeJob:
-        """Run on the legacy local simulator (no Executor).
-
-        Args:
-            pubs: The raw PUB-like objects passed to :meth:`run`.
-            precision: The per-pub precision override, forwarded from :meth:`run`.
-
-        Returns:
-            The submitted job.
-        """
-        logger.info("Running in local simulator mode")
-        coerced_pubs = [EstimatorPub.coerce(pub, precision) for pub in pubs]
-        options = self.finalize_options()
-        options_dict = options.model_dump()
-        resolved_precision = resolve_precision(coerced_pubs, precision)
-        if resolved_precision is not None:
-            options_dict["default_shots"] = int(np.ceil(1.0 / (resolved_precision**2)))
-        elif options.default_shots is not None:
-            options_dict["default_shots"] = int(options.default_shots)
-        else:
-            options_dict["default_shots"] = int(np.ceil(1.0 / (options.default_precision**2)))
-
-        service = cast("QiskitRuntimeLocalService", self._service)
-        return service._run(
-            program_id="estimator",
-            inputs={"pubs": coerced_pubs, "options": options_dict},
-            options={"backend": self._backend},
-            calibration_id=None,
-        )
 
     def run(
         self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None

--- a/qiskit_ibm_runtime/executor_estimator/estimator.py
+++ b/qiskit_ibm_runtime/executor_estimator/estimator.py
@@ -253,16 +253,14 @@ class EstimatorV2(BaseEstimatorV2):
             IBMInputValueError: If no pubs are provided, if precision is not properly
                 specified, or if unsupported options are detected.
         """
-        # Legacy simulator path (no executor)
-        if not (local_mode := self.options.experimental.get("local_mode", False)) and isinstance(
-            self._service, QiskitRuntimeLocalService
-        ):
-            return self._run_legacy_simulation(pubs, precision)
-
         # Pre-process: Convert Estimator input into a QuantumProgram
         logger.info("Starting pre-processing")
         quantum_program, executor_options = prepare(
-            pubs, self.options, precision, add_tags=local_mode, backend=self._backend
+            pubs,
+            self.options,
+            precision,
+            add_tags=isinstance(self._service, QiskitRuntimeLocalService),
+            backend=self._backend,
         )
 
         # Set semantic role for post-processing dispatch

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -217,16 +217,14 @@ class SamplerV2(BaseSamplerV2):
         Returns:
             The submitted job.
         """
-        # Legacy simulator path (no executor)
-        if not (local_mode := self.options.experimental.get("local_mode", False)) and isinstance(
-            self._service, QiskitRuntimeLocalService
-        ):
-            return self._run_legacy_simulation(pubs, shots)
-
         # Pre-process: Convert Sampler input into a QuantumProgram
         logger.info("Starting pre-processing")
         quantum_program, executor_options = prepare(
-            pubs, self.options, shots, add_tags=local_mode, backend=self._backend
+            pubs,
+            self.options,
+            shots,
+            add_tags=isinstance(self._service, QiskitRuntimeLocalService),
+            backend=self._backend,
         )
 
         # Set semantic role for post-processing dispatch

--- a/qiskit_ibm_runtime/executor_sampler/sampler.py
+++ b/qiskit_ibm_runtime/executor_sampler/sampler.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal, cast, get_args
+from typing import TYPE_CHECKING, Literal, get_args
 
 from qiskit.primitives.base import BaseSamplerV2
 from qiskit.primitives.containers.sampler_pub import SamplerPub
@@ -167,32 +167,6 @@ class SamplerV2(BaseSamplerV2):
             The finalized :class:`~.SamplerOptions` object.
         """
         return finalize_sampler_options(self.options)
-
-    def _run_legacy_simulation(
-        self, pubs: Iterable[SamplerPubLike], shots: int | None
-    ) -> LocalRuntimeJob:
-        """Run on the legacy local simulator (no Executor).
-
-        Args:
-            pubs: The raw PUB-like objects passed to :meth:`run`.
-            shots: The per-run shots override, forwarded from :meth:`run`.
-
-        Returns:
-            The submitted job.
-        """
-        logger.info("Running in local simulator mode")
-        coerced_pubs = [SamplerPub.coerce(pub, shots) for pub in pubs]
-        options = self.finalize_options()
-        options_dict = options.model_dump()
-        options_dict["default_shots"] = shots
-
-        service = cast("QiskitRuntimeLocalService", self._service)
-        return service._run(
-            program_id="sampler",
-            inputs={"pubs": coerced_pubs, "options": options_dict},
-            options={"backend": self._backend},
-            calibration_id=None,
-        )
 
     def run(
         self, pubs: Iterable[SamplerPubLike], *, shots: int | None = None

--- a/qiskit_ibm_runtime/fake_provider/executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/fake_provider/executor/insert_noise_pass.py
@@ -14,7 +14,7 @@
 
 **Noise injection**
 
-When ``noise_model`` is provided in :class:`~.ExperimentalSimulatorOptions`, Pauli-Lindblad noise
+When ``noise_model`` is provided in :class:`~.SimulatorOptions`, Pauli-Lindblad noise
 is injected into circuits at tagged barriers via :class:`~.InsertNoisePass`.  Samplomatic inserts
 three barriers around each boxed gate — left (``L``), middle (``M``), and right (``R``) — with
 labels of the form ``<pos><idx>@tag=<tag>`` (e.g. ``R0@tag=r0``).  By default, noise is injected at

--- a/qiskit_ibm_runtime/fake_provider/executor/insert_noise_pass.py
+++ b/qiskit_ibm_runtime/fake_provider/executor/insert_noise_pass.py
@@ -14,14 +14,14 @@
 
 **Noise injection**
 
-When ``noise_model`` is provided in :class:`~.SimulatorOptions`, Pauli-Lindblad noise
+When ``layer_noise_model`` is provided in :class:`~.SimulatorOptions`, Pauli-Lindblad noise
 is injected into circuits at tagged barriers via :class:`~.InsertNoisePass`.  Samplomatic inserts
 three barriers around each boxed gate — left (``L``), middle (``M``), and right (``R``) — with
 labels of the form ``<pos><idx>@tag=<tag>`` (e.g. ``R0@tag=r0``).  By default, noise is injected at
 the ``R`` (right) barriers, i.e. *after* the gate.  Use ``noise_after=False`` on
 :class:`~.InsertNoisePass` to target ``M`` barriers instead (noise *before* the gate).
 
-The ``noise_model`` format is:
+The ``noise_dict`` format is:
 
 - **Keys** — layer name tags (strings, e.g. ``"r0"``, ``"my_tag"``).  Each key must match the
     ``ref`` of a ``Tag`` annotation used when building the ``QuantumProgram``. A warning is emitted

--- a/qiskit_ibm_runtime/fake_provider/executor/run_quantum_program.py
+++ b/qiskit_ibm_runtime/fake_provider/executor/run_quantum_program.py
@@ -33,7 +33,7 @@ from .insert_noise_pass import InsertNoisePass
 if TYPE_CHECKING:
     from qiskit.providers import BackendV2
 
-    from ...options_models.simulator import ExperimentalSimulatorOptions
+    from ...options_models.simulator import SimulatorOptions
     from ...quantum_program import QuantumProgram
 
 if HAS_AER:
@@ -54,7 +54,7 @@ def _round_to_clifford(values: np.ndarray, decimals: int) -> np.ndarray:
 def run_quantum_program(
     backend: BackendV2,
     program: QuantumProgram,
-    options: ExperimentalSimulatorOptions,
+    options: SimulatorOptions,
 ) -> QuantumProgramResult:
     """Run a quantum program on a simulator.
 

--- a/qiskit_ibm_runtime/fake_provider/local_runtime_job.py
+++ b/qiskit_ibm_runtime/fake_provider/local_runtime_job.py
@@ -42,7 +42,7 @@ class LocalRuntimeJob(PrimitiveJob):
     (
     backend: BackendV2,
     program: QuantumProgram,
-    options: ExperimentalSimulatorOptions,
+    options: SimulatorOptions,
     ) -> QuantumProgramResult:
     ```
 

--- a/qiskit_ibm_runtime/fake_provider/local_service.py
+++ b/qiskit_ibm_runtime/fake_provider/local_service.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
     from qiskit.providers.backend import BackendV2
 
-    from ..options_models.simulator import ExperimentalSimulatorOptions
+    from ..options_models.simulator import SimulatorOptions
     from ..quantum_program import QuantumProgram
     from ..runtime_options import RuntimeOptions
     from .fake_backend import FakeBackendV2
@@ -290,7 +290,7 @@ class QiskitRuntimeLocalService:
     def _run_executor(
         self,
         backend: BackendV2,
-        options: ExperimentalSimulatorOptions,
+        options: SimulatorOptions,
         inputs: QuantumProgram,
     ) -> LocalRuntimeJob:
         """Run an executor program.

--- a/qiskit_ibm_runtime/options_models/converters.py
+++ b/qiskit_ibm_runtime/options_models/converters.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
 from .executor import ExecutorOptions
+from .simulator import ExperimentalSimulatorOptions
 
 if TYPE_CHECKING:
     from ..ibm_backend import IBMBackend
@@ -53,8 +54,10 @@ def sampler_option_to_executor_options(options: SamplerOptions) -> ExecutorOptio
 
     environment_options = options.environment.model_dump()
     execution_options = options.execution.model_dump(exclude={"meas_type"})
+    simulator_options = options.simulator.model_dump()
     executor_options.environment = EnvironmentOptions(**environment_options)
     executor_options.execution = ExecutionOptions(**execution_options)
+    executor_options.simulator = ExperimentalSimulatorOptions(**simulator_options)
 
     executor_options.environment.max_execution_time = options.max_execution_time
     if options.experimental:
@@ -83,18 +86,17 @@ def estimator_options_to_executor_options(options: EstimatorOptions) -> Executor
 
     environment_options = options.environment.model_dump()
     execution_options = options.execution.model_dump()
+    simulator_options = options.simulator.model_dump()
     executor_options.environment = EnvironmentOptions(**environment_options)
     executor_options.execution = ExecutionOptions(**execution_options)
+    executor_options.simulator = ExperimentalSimulatorOptions(**simulator_options)
 
     executor_options.environment.max_execution_time = options.max_execution_time
     if options.experimental:
         executor_options.environment.image = options.experimental.get("image", None)
         executor_options.experimental.update(options.experimental)
 
-        # have the simulator layer noise model fallback onto the resilience layer noise model
-        if sim_options := executor_options.experimental.get("simulator_options", None):
-            if (layer_noise_model := sim_options.layer_noise_model) is None:
-                layer_noise_model = options.resilience.layer_noise_model
-            sim_options.layer_noise_model = layer_noise_model
+    if executor_options.simulator.layer_noise_model is None:
+        executor_options.simulator.layer_noise_model = options.resilience.layer_noise_model
 
     return executor_options

--- a/qiskit_ibm_runtime/options_models/converters.py
+++ b/qiskit_ibm_runtime/options_models/converters.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
 from .executor import ExecutorOptions
-from .simulator import ExperimentalSimulatorOptions
+from .simulator import SimulatorOptions
 
 if TYPE_CHECKING:
     from ..ibm_backend import IBMBackend
@@ -57,7 +57,7 @@ def sampler_option_to_executor_options(options: SamplerOptions) -> ExecutorOptio
     simulator_options = options.simulator.model_dump()
     executor_options.environment = EnvironmentOptions(**environment_options)
     executor_options.execution = ExecutionOptions(**execution_options)
-    executor_options.simulator = ExperimentalSimulatorOptions(**simulator_options)
+    executor_options.simulator = SimulatorOptions(**simulator_options)
 
     executor_options.environment.max_execution_time = options.max_execution_time
     if options.experimental:
@@ -89,7 +89,7 @@ def estimator_options_to_executor_options(options: EstimatorOptions) -> Executor
     simulator_options = options.simulator.model_dump()
     executor_options.environment = EnvironmentOptions(**environment_options)
     executor_options.execution = ExecutionOptions(**execution_options)
-    executor_options.simulator = ExperimentalSimulatorOptions(**simulator_options)
+    executor_options.simulator = SimulatorOptions(**simulator_options)
 
     executor_options.environment.max_execution_time = options.max_execution_time
     if options.experimental:

--- a/qiskit_ibm_runtime/options_models/estimator.py
+++ b/qiskit_ibm_runtime/options_models/estimator.py
@@ -23,7 +23,7 @@ from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
 from .resilience import ResilienceOptions
-from .simulator import SimulatorOptions
+from .simulator import ExperimentalSimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -64,8 +64,8 @@ class EstimatorOptions(BaseOptionsModel):
     dynamical_decoupling: DynamicalDecouplingOptions = DynamicalDecouplingOptions()
     """Dynamical decoupling options."""
 
-    simulator: SimulatorOptions = SimulatorOptions()
-    """Simulator options."""
+    simulator: ExperimentalSimulatorOptions = ExperimentalSimulatorOptions()
+    """Options related to local mode simulations."""
 
     experimental: dict = {}
     """Experimental options."""

--- a/qiskit_ibm_runtime/options_models/estimator.py
+++ b/qiskit_ibm_runtime/options_models/estimator.py
@@ -23,7 +23,7 @@ from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
 from .resilience import ResilienceOptions
-from .simulator import ExperimentalSimulatorOptions
+from .simulator import SimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -64,7 +64,7 @@ class EstimatorOptions(BaseOptionsModel):
     dynamical_decoupling: DynamicalDecouplingOptions = DynamicalDecouplingOptions()
     """Dynamical decoupling options."""
 
-    simulator: ExperimentalSimulatorOptions = ExperimentalSimulatorOptions()
+    simulator: SimulatorOptions = SimulatorOptions()
     """Options related to local mode simulations."""
 
     experimental: dict = {}

--- a/qiskit_ibm_runtime/options_models/executor.py
+++ b/qiskit_ibm_runtime/options_models/executor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from .base import BaseOptionsModel
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
-from .simulator import ExperimentalSimulatorOptions
+from .simulator import SimulatorOptions
 
 
 class ExecutorOptions(BaseOptionsModel):
@@ -32,5 +32,5 @@ class ExecutorOptions(BaseOptionsModel):
     experimental: dict = {}
     """Experimental options that are passed to the executor."""
 
-    simulator: ExperimentalSimulatorOptions = ExperimentalSimulatorOptions()
+    simulator: SimulatorOptions = SimulatorOptions()
     """Options related to local mode simulations."""

--- a/qiskit_ibm_runtime/options_models/executor.py
+++ b/qiskit_ibm_runtime/options_models/executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from .base import BaseOptionsModel
 from .environment import EnvironmentOptions
 from .execution import ExecutionOptions
+from .simulator import ExperimentalSimulatorOptions
 
 
 class ExecutorOptions(BaseOptionsModel):
@@ -30,3 +31,6 @@ class ExecutorOptions(BaseOptionsModel):
 
     experimental: dict = {}
     """Experimental options that are passed to the executor."""
+
+    simulator: ExperimentalSimulatorOptions = ExperimentalSimulatorOptions()
+    """Options related to local mode simulations."""

--- a/qiskit_ibm_runtime/options_models/sampler.py
+++ b/qiskit_ibm_runtime/options_models/sampler.py
@@ -18,7 +18,7 @@ from .base import BaseOptionsModel
 from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import SamplerEnvironmentOptions
 from .execution import SamplerExecutionOptions
-from .simulator import ExperimentalSimulatorOptions
+from .simulator import SimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -37,7 +37,7 @@ class SamplerOptions(BaseOptionsModel):
     twirling: TwirlingOptions = TwirlingOptions()
     """Pauli twirling options."""
 
-    simulator: ExperimentalSimulatorOptions = ExperimentalSimulatorOptions()
+    simulator: SimulatorOptions = SimulatorOptions()
     """Options related to local mode simulations."""
 
     experimental: dict = {}

--- a/qiskit_ibm_runtime/options_models/sampler.py
+++ b/qiskit_ibm_runtime/options_models/sampler.py
@@ -18,7 +18,7 @@ from .base import BaseOptionsModel
 from .dynamical_decoupling import DynamicalDecouplingOptions
 from .environment import SamplerEnvironmentOptions
 from .execution import SamplerExecutionOptions
-from .simulator import SimulatorOptions
+from .simulator import ExperimentalSimulatorOptions
 from .twirling import TwirlingOptions
 
 
@@ -37,8 +37,8 @@ class SamplerOptions(BaseOptionsModel):
     twirling: TwirlingOptions = TwirlingOptions()
     """Pauli twirling options."""
 
-    simulator: SimulatorOptions = SimulatorOptions()
-    """Simulator options."""
+    simulator: ExperimentalSimulatorOptions = ExperimentalSimulatorOptions()
+    """Options related to local mode simulations."""
 
     experimental: dict = {}
     """Experimental options."""

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -19,18 +19,8 @@ from typing import Annotated, TypeAlias
 from pydantic import AfterValidator, InstanceOf
 from qiskit.circuit import BoxOp, CircuitInstruction
 from qiskit.quantum_info import PauliLindbladMap
-from qiskit.utils import optionals
 
 from .base import BaseOptionsModel
-
-# Dynamically define the `noise_model` field type at runtime, as `NoiseModel`
-# is only a valid alternative if `qiskit_aer` is installed.
-if optionals.HAS_AER:
-    from qiskit_aer.noise import NoiseModel
-
-    noise_model_type: TypeAlias = dict | Annotated[NoiseModel, InstanceOf] | None
-else:
-    noise_model_type: TypeAlias = dict | None  # type: ignore[no-redef, misc]
 
 
 def validate_layer_noise_model(value: LayerNoiseModel | None) -> LayerNoiseModel | None:

--- a/qiskit_ibm_runtime/options_models/simulator.py
+++ b/qiskit_ibm_runtime/options_models/simulator.py
@@ -16,12 +16,9 @@ from __future__ import annotations
 
 from typing import Annotated, TypeAlias
 
-from pydantic import AfterValidator, Field, InstanceOf
+from pydantic import AfterValidator, InstanceOf
 from qiskit.circuit import BoxOp, CircuitInstruction
-from qiskit.exceptions import MissingOptionalLibraryError
-from qiskit.providers import BackendV2
 from qiskit.quantum_info import PauliLindbladMap
-from qiskit.transpiler import CouplingMap
 from qiskit.utils import optionals
 
 from .base import BaseOptionsModel
@@ -56,7 +53,7 @@ LayerNoiseModel: TypeAlias = Annotated[
 ]
 
 
-class ExperimentalSimulatorOptions(BaseOptionsModel):
+class SimulatorOptions(BaseOptionsModel):
     """Simulator options."""
 
     angle_decimals: int = 5
@@ -80,57 +77,3 @@ class ExperimentalSimulatorOptions(BaseOptionsModel):
 
     warn_absent: bool = True
     """Whether to emit a warning when an entry is missing in :attr:`layer_noise_dict`."""
-
-
-class SimulatorOptions(BaseOptionsModel):
-    """Legacy Simulator options.
-
-    Used to control local mode simulation.
-    """
-
-    noise_model: noise_model_type = None
-    """Noise model for the simulator."""
-
-    seed_simulator: int | None = None
-    """Random seed to control sampling."""
-
-    coupling_map: (
-        list[list[Annotated[int, Field(ge=0)]]] | Annotated[CouplingMap, InstanceOf] | None
-    ) = None
-    """Directed coupling map to target in mapping.
-
-    If the coupling map is symmetric, both directions need to be specified. Each entry in the list
-    specifies a directed two-qubit interaction, e.g:
-    ``[[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]``. ``None`` implies no connectivity
-    constraints.
-    """
-
-    basis_gates: list[str] | None = None
-    """List of basis gate names to unroll to.
-
-    For example, ``['u1', 'u2', 'u3', 'cx']``. Unrolling is not done if not set.
-    """
-
-    def set_backend(self, backend: BackendV2) -> None:
-        """Set backend for simulation.
-
-        This method changes noise_model, coupling_map, basis_gates according to given backend.
-
-        Args:
-            backend: backend to be set.
-
-        Raises:
-            MissingOptionalLibraryError: if qiskit-aer is not found.
-        """
-        if not optionals.HAS_AER:
-            raise MissingOptionalLibraryError(
-                "qiskit-aer", "Aer provider", "pip install qiskit-aer"
-            )
-
-        from qiskit_aer.noise import NoiseModel as AerNoiseModel
-
-        self.noise_model = AerNoiseModel.from_backend(backend)
-
-        if isinstance(backend, BackendV2):
-            self.coupling_map = backend.coupling_map
-            self.basis_gates = backend.operation_names

--- a/release-notes/unreleased/3288.feat.rst
+++ b/release-notes/unreleased/3288.feat.rst
@@ -1,2 +1,26 @@
-- Added a new `Executor` local mode simulation mode when specifying either a `FakeBackendV2` or `AerSimulator`` as the backend for any `Executor`-based primitive.
-- Added `SimulatorOptions` to `ExecutorOptions` via the `simulator` attribute and deprecated the legacy `SimulatorOptions`.
+Added local mode support to :class:`~qiskit_ibm_runtime.executor.Executor`.
+
+When specifying a :class:`~qiskit_ibm_runtime.fake_provider.FakeBackendV2` or
+:class:`~qiskit_aer.AerSimulator` as the backend; :meth:`~qiskit_ibm_runtime.executor.Executor.run`
+will operate as a `qiskit_aer` simulator. Behavior can be controlled by the new
+:class:`~qiskit_ibm_runtime.option_models.simulator.SimulatorOptions` class accessed via the
+:attr:`~qiskit_ibm_runtime.option_models.executor.ExecutorOptions.simulator` attribute.
+
+For example, the following code simulates a simple two-qubit circuit:
+
+.. code-block:: python
+
+    from qiskit import QuantumCircuit
+    from qiskit_aer import AerSimulator
+    from qiskit_ibm_runtime import Executor, QuantumProgram
+
+    circuit = QuantumCircuit(2)
+    circuit.cx(0, 1)
+    circuit.measure_all()
+
+    program = QuantumProgram(1)
+    program.append_circuit_item(circuit)
+
+    executor = Executor(AerSimulator())
+    job = executor.run(program)
+    job.result()

--- a/release-notes/unreleased/3288.feat.rst
+++ b/release-notes/unreleased/3288.feat.rst
@@ -1,0 +1,2 @@
+- Added a new `Executor` local mode simulation mode when specifying either a `FakeBackendV2` or `AerSimulator`` as the backend for any `Executor`-based primitive.
+- Added `SimulatorOptions` to `ExecutorOptions` via the `simulator` attribute and deprecated the legacy `SimulatorOptions`.

--- a/test/unit/executor/simulations/test_executor.py
+++ b/test/unit/executor/simulations/test_executor.py
@@ -24,7 +24,6 @@ from samplomatic.transpiler import generate_boxing_pass_manager
 from samplomatic.utils import find_unique_box_instructions
 
 from qiskit_ibm_runtime import Executor, QuantumProgram
-from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ....ibm_test_case import IBMTestCase
 from ....utils import make_mirror_circuit_with_phases
@@ -140,7 +139,6 @@ class TestExecutor(IBMTestCase):
             options={
                 "experimental": {
                     "local_mode": True,
-                    "simulator_options": ExperimentalSimulatorOptions(),
                 }
             },
         )
@@ -152,7 +150,7 @@ class TestExecutor(IBMTestCase):
         ]
         fidelities = []
         for pauli_map in pauli_maps:
-            executor.options.experimental["simulator_options"].layer_noise_model = zip(
+            executor.options.simulator.layer_noise_model = zip(
                 unique_instructions, (pauli_map,) * len(unique_instructions)
             )
             job = executor.run(program)

--- a/test/unit/executor/simulations/test_executor.py
+++ b/test/unit/executor/simulations/test_executor.py
@@ -72,7 +72,7 @@ class TestExecutor(IBMTestCase):
             isa_template, samplex=samplex, samplex_arguments={"parameter_values": parameter_values}
         )
 
-        executor = Executor(mode=AerSimulator(), options={"experimental": {"local_mode": True}})
+        executor = Executor(mode=AerSimulator())
 
         job = executor.run(program)
         result = job.result()
@@ -136,11 +136,6 @@ class TestExecutor(IBMTestCase):
 
         executor = Executor(
             mode=AerSimulator(),
-            options={
-                "experimental": {
-                    "local_mode": True,
-                }
-            },
         )
 
         pauli_maps = [

--- a/test/unit/executor_estimator/simulations/test_estimator.py
+++ b/test/unit/executor_estimator/simulations/test_estimator.py
@@ -23,7 +23,6 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_aer import AerSimulator
 
 from qiskit_ibm_runtime.fake_provider import FakeManilaV2
-from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ....ibm_test_case import IBMTestCase
 from .utils import (
@@ -141,12 +140,7 @@ class TestEstimatorWithNoise(IBMTestCase):
             (layer, PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.005)]))
             for layer in layers
         ]
-
-        base_level_estimator.options.experimental["simulator_options"] = (
-            ExperimentalSimulatorOptions(
-                layer_noise_model=simulated_noise_model,
-            )
-        )
+        base_level_estimator.options.simulator.layer_noise_model = simulated_noise_model
 
         # Run a noisy simulation using baselevel estimator:
         result = base_level_estimator.run([pub]).result()
@@ -160,9 +154,7 @@ class TestEstimatorWithNoise(IBMTestCase):
             shots_per_randomization=200,
             options_overrides=option_overrides,
         )
-        estimator.options.experimental["simulator_options"] = ExperimentalSimulatorOptions(
-            layer_noise_model=simulated_noise_model,
-        )
+        estimator.options.simulator.layer_noise_model = simulated_noise_model
         # Run a noisy simulation, injecting the same noise as in the simulation
         estimator.options.resilience.layer_noise_model = [
             (layer, PauliLindbladMap.from_list([("X" * layer.operation.num_qubits, 0.005)]))

--- a/test/unit/executor_estimator/simulations/utils.py
+++ b/test/unit/executor_estimator/simulations/utils.py
@@ -159,11 +159,6 @@ def create_local_mode_estimator(
     options = EstimatorOptions(
         # Select resilience level 0 by default, disabling all mitigation:
         resilience_level=0,
-        # Local mode means that the underlying Executor is running Aer simulation
-        # instead of connecting to a real backend.
-        experimental={
-            "local_mode": True,
-        },
     )
     options.update(**options_overrides)
 

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -28,7 +28,6 @@ from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor import Executor
 from qiskit_ibm_runtime.executor_estimator.estimator import EstimatorV2
 from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
-from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
 
@@ -416,13 +415,12 @@ class TestEstimatorV2SimulatorMode(IBMTestCase):
 
         observable = SparsePauliOp.from_list([("ZZ", 1)])
 
-        simulator_options = ExperimentalSimulatorOptions(seed_simulator=42)
-
         estimator = EstimatorV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
         estimator.options.default_shots = 10_000
+        estimator.options.simulator.seed_simulator = 42
         result = estimator.run([(transpiled, observable)]).result()
 
         self.assertEqual(len(result), 1)
@@ -441,20 +439,20 @@ class TestEstimatorV2SimulatorMode(IBMTestCase):
 
         observable = SparsePauliOp.from_list([("ZZ", 1)])
 
-        simulator_options = ExperimentalSimulatorOptions(seed_simulator=42)
-
         estimator1 = EstimatorV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
         estimator1.options.default_shots = 100
+        estimator1.options.simulator.seed_simulator = 42
         result1 = estimator1.run([(transpiled, observable)]).result()
 
         estimator2 = EstimatorV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
         estimator2.options.default_shots = 100
+        estimator2.options.simulator.seed_simulator = 42
         result2 = estimator2.run([(transpiled, observable)]).result()
 
         np.testing.assert_array_equal(result1[0].data.evs, result2[0].data.evs)
@@ -475,21 +473,19 @@ class TestEstimatorV2SimulatorMode(IBMTestCase):
 
         observable = SparsePauliOp.from_list([("ZZ", 1)])
 
-        simulator_options = ExperimentalSimulatorOptions(seed_simulator=42)
-
         estimator1 = EstimatorV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
         estimator1.options.default_shots = 100
+        estimator1.options.simulator.seed_simulator = 42
         result1 = estimator1.run([(transpiled, observable)]).result()
-
-        simulator_options = ExperimentalSimulatorOptions(seed_simulator=99)
 
         estimator2 = EstimatorV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
+        estimator2.options.simulator.seed_simulator = 99
         estimator2.options.default_shots = 100
         result2 = estimator2.run([(transpiled, observable)]).result()
 

--- a/test/unit/executor_estimator/test_estimator_v2.py
+++ b/test/unit/executor_estimator/test_estimator_v2.py
@@ -415,10 +415,7 @@ class TestEstimatorV2SimulatorMode(IBMTestCase):
 
         observable = SparsePauliOp.from_list([("ZZ", 1)])
 
-        estimator = EstimatorV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        estimator = EstimatorV2(mode=backend)
         estimator.options.default_shots = 10_000
         estimator.options.simulator.seed_simulator = 42
         result = estimator.run([(transpiled, observable)]).result()
@@ -439,18 +436,12 @@ class TestEstimatorV2SimulatorMode(IBMTestCase):
 
         observable = SparsePauliOp.from_list([("ZZ", 1)])
 
-        estimator1 = EstimatorV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        estimator1 = EstimatorV2(mode=backend)
         estimator1.options.default_shots = 100
         estimator1.options.simulator.seed_simulator = 42
         result1 = estimator1.run([(transpiled, observable)]).result()
 
-        estimator2 = EstimatorV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        estimator2 = EstimatorV2(mode=backend)
         estimator2.options.default_shots = 100
         estimator2.options.simulator.seed_simulator = 42
         result2 = estimator2.run([(transpiled, observable)]).result()
@@ -473,18 +464,12 @@ class TestEstimatorV2SimulatorMode(IBMTestCase):
 
         observable = SparsePauliOp.from_list([("ZZ", 1)])
 
-        estimator1 = EstimatorV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        estimator1 = EstimatorV2(mode=backend)
         estimator1.options.default_shots = 100
         estimator1.options.simulator.seed_simulator = 42
         result1 = estimator1.run([(transpiled, observable)]).result()
 
-        estimator2 = EstimatorV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        estimator2 = EstimatorV2(mode=backend)
         estimator2.options.simulator.seed_simulator = 99
         estimator2.options.default_shots = 100
         result2 = estimator2.run([(transpiled, observable)]).result()

--- a/test/unit/executor_sampler/simulations/test_sampler.py
+++ b/test/unit/executor_sampler/simulations/test_sampler.py
@@ -95,7 +95,6 @@ class TestSampler(IBMTestCase):
         pubs = [SamplerPub.coerce([circuit, parameters])]
 
         sampler = SamplerV2(self.backend)
-        sampler.options.experimental = {"local_mode": True}
 
         sampler.options.twirling.enable_gates = enable_gates
         sampler.options.twirling.enable_measure = enable_measure

--- a/test/unit/executor_sampler/test_sampler.py
+++ b/test/unit/executor_sampler/test_sampler.py
@@ -376,7 +376,7 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         pm = generate_preset_pass_manager(backend=backend, optimization_level=0)
         transpiled = pm.run(circuit)
 
-        sampler = SamplerV2(mode=backend, options={"experimental": {"local_mode": True}})
+        sampler = SamplerV2(mode=backend)
 
         # Run should work and return results
         job = sampler.run([transpiled], shots=100)
@@ -407,10 +407,7 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         transpiled = pm.run(circuit)
 
         # First sampler with seed
-        sampler1 = SamplerV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        sampler1 = SamplerV2(mode=backend)
         sampler1.options.default_shots = 200
         sampler1.options.simulator.seed_simulator = 42
 
@@ -419,10 +416,7 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         counts1 = result1[0].data.meas.get_counts()
 
         # Second sampler with same seed
-        sampler2 = SamplerV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        sampler2 = SamplerV2(mode=backend)
         sampler2.options.default_shots = 200
         sampler2.options.simulator.seed_simulator = 42
 
@@ -434,10 +428,7 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         self.assertEqual(counts1, counts2)
 
         # Third sampler with different seed should give different results
-        sampler3 = SamplerV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        sampler3 = SamplerV2(mode=backend)
         sampler3.options.default_shots = 200
         sampler3.options.simulator.seed_simulator = 123
 
@@ -483,10 +474,7 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         ]
 
         # Create sampler with all simulator options
-        sampler = SamplerV2(
-            mode=backend,
-            options={"experimental": {"local_mode": True}},
-        )
+        sampler = SamplerV2(mode=backend)
         sampler.options.simulator.seed_simulator = 42
 
         # Run with parameter sweep

--- a/test/unit/executor_sampler/test_sampler.py
+++ b/test/unit/executor_sampler/test_sampler.py
@@ -24,7 +24,6 @@ from qiskit.utils.optionals import HAS_AER
 
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
 from qiskit_ibm_runtime.executor_sampler import SamplerV2
-from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ...ibm_test_case import IBMTestCase
 from ...utils import get_mocked_backend
@@ -408,12 +407,12 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         transpiled = pm.run(circuit)
 
         # First sampler with seed
-        simulator_options = ExperimentalSimulatorOptions(seed_simulator=42)
         sampler1 = SamplerV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
         sampler1.options.default_shots = 200
+        sampler1.options.simulator.seed_simulator = 42
 
         job1 = sampler1.run([transpiled])
         result1 = job1.result()
@@ -422,9 +421,10 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         # Second sampler with same seed
         sampler2 = SamplerV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
         sampler2.options.default_shots = 200
+        sampler2.options.simulator.seed_simulator = 42
 
         job2 = sampler2.run([transpiled])
         result2 = job2.result()
@@ -434,12 +434,12 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         self.assertEqual(counts1, counts2)
 
         # Third sampler with different seed should give different results
-        simulator_options = ExperimentalSimulatorOptions(seed_simulator=123)
         sampler3 = SamplerV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
         sampler3.options.default_shots = 200
+        sampler3.options.simulator.seed_simulator = 123
 
         job3 = sampler3.run([transpiled])
         result3 = job3.result()
@@ -483,11 +483,11 @@ class TestSamplerV2SimulatorMode(IBMTestCase):
         ]
 
         # Create sampler with all simulator options
-        simulator_options = ExperimentalSimulatorOptions(seed_simulator=42)
         sampler = SamplerV2(
             mode=backend,
-            options={"experimental": {"local_mode": True, "simulator_options": simulator_options}},
+            options={"experimental": {"local_mode": True}},
         )
+        sampler.options.simulator.seed_simulator = 42
 
         # Run with parameter sweep
         job = sampler.run([(transpiled, param_values)], shots=1000)

--- a/test/unit/local_mode/executor/test_run_quantum_program.py
+++ b/test/unit/local_mode/executor/test_run_quantum_program.py
@@ -33,7 +33,7 @@ from samplomatic.utils import find_unique_box_instructions
 
 from qiskit_ibm_runtime.fake_provider.backends.fez import FakeFez
 from qiskit_ibm_runtime.fake_provider.executor.run_quantum_program import run_quantum_program
-from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
+from qiskit_ibm_runtime.options_models.simulator import SimulatorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.results import QuantumProgramItemResult
 
@@ -151,9 +151,7 @@ class TestRunQuantumProgram(IBMTestCase):
         program = QuantumProgram(shots=64)
         program.append_circuit_item(qc, circuit_arguments=circuit_arguments)
 
-        result = run_quantum_program(
-            AerSimulator(method="stabilizer"), program, ExperimentalSimulatorOptions()
-        )
+        result = run_quantum_program(AerSimulator(method="stabilizer"), program, SimulatorOptions())
 
         self.assertTrue((result[0]["c"] == [[True]]).all())
 
@@ -178,9 +176,7 @@ class TestRunQuantumProgram(IBMTestCase):
         program = QuantumProgram(shots=1024)
         program.append_circuit_item(transpiled)
 
-        result = run_quantum_program(
-            AerSimulator(method="stabilizer"), program, ExperimentalSimulatorOptions()
-        )
+        result = run_quantum_program(AerSimulator(method="stabilizer"), program, SimulatorOptions())
 
         # The result should have one item
         self.assertEqual(len(result), 1)
@@ -232,9 +228,7 @@ class TestRunQuantumProgram(IBMTestCase):
             shape=(num_randomizations,),
         )
 
-        result = run_quantum_program(
-            AerSimulator(method="stabilizer"), program, ExperimentalSimulatorOptions()
-        )
+        result = run_quantum_program(AerSimulator(method="stabilizer"), program, SimulatorOptions())
 
         self.assertEqual(len(result), 1)
         item_data = result[0]
@@ -273,9 +267,7 @@ class TestRunQuantumProgram(IBMTestCase):
         program = QuantumProgram(shots=shots)
         program.append_circuit_item(transpiled, circuit_arguments=circuit_arguments)
 
-        result = run_quantum_program(
-            AerSimulator(method="stabilizer"), program, ExperimentalSimulatorOptions()
-        )
+        result = run_quantum_program(AerSimulator(method="stabilizer"), program, SimulatorOptions())
 
         self.assertEqual(len(result), 1)
         item_data = result[0]
@@ -344,7 +336,7 @@ class TestRunQuantumProgram(IBMTestCase):
         result = run_quantum_program(
             AerSimulator(method="stabilizer"),
             program,
-            ExperimentalSimulatorOptions(layer_noise_model=noise_model),
+            SimulatorOptions(layer_noise_model=noise_model),
         )
 
         self.assertEqual(len(result), 1)
@@ -393,9 +385,7 @@ class TestRunQuantumProgram(IBMTestCase):
             samplex_arguments={"parameter_values": parameter_values},
         )
 
-        result = run_quantum_program(
-            AerSimulator(method="stabilizer"), program, ExperimentalSimulatorOptions()
-        )
+        result = run_quantum_program(AerSimulator(method="stabilizer"), program, SimulatorOptions())
 
         self.assertEqual(len(result), 1)
         item_data = result[0]
@@ -469,9 +459,7 @@ class TestRunQuantumProgram(IBMTestCase):
             shape=(r0, 2, 2, r1),
         )
 
-        result = run_quantum_program(
-            AerSimulator(method="stabilizer"), program, ExperimentalSimulatorOptions()
-        )
+        result = run_quantum_program(AerSimulator(method="stabilizer"), program, SimulatorOptions())
 
         self.assertEqual(len(result), 1)
         item_data = result[0]
@@ -515,6 +503,4 @@ class TestRunQuantumProgram(IBMTestCase):
         program.passthrough_data = None
 
         with self.assertRaisesRegex(TypeError, "Unsupported QuantumProgramItem type"):
-            run_quantum_program(
-                AerSimulator(method="stabilizer"), program, ExperimentalSimulatorOptions()
-            )
+            run_quantum_program(AerSimulator(method="stabilizer"), program, SimulatorOptions())

--- a/test/unit/local_mode/test_local_runtime_job.py
+++ b/test/unit/local_mode/test_local_runtime_job.py
@@ -20,7 +20,6 @@ from qiskit_ibm_runtime import SamplerV2
 from qiskit_ibm_runtime.executor import Executor
 from qiskit_ibm_runtime.fake_provider import FakeManilaV2
 from qiskit_ibm_runtime.fake_provider.local_runtime_job import LocalRuntimeJob
-from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.results import QuantumProgramResult
 
@@ -53,7 +52,6 @@ class TestLocalRuntimeJob(IBMTestCase):
             options={
                 "experimental": {
                     "local_mode": True,
-                    "simulator_options": ExperimentalSimulatorOptions(),
                 }
             },
         )

--- a/test/unit/local_mode/test_local_runtime_job.py
+++ b/test/unit/local_mode/test_local_runtime_job.py
@@ -47,14 +47,7 @@ class TestLocalRuntimeJob(IBMTestCase):
     @skipUnless(condition=optionals.HAS_AER, reason="qiskit-aer is required to run this test")
     def test_executor(self):
         """Test executor on a local backend."""
-        executor = Executor(
-            AerSimulator(method="stabilizer"),
-            options={
-                "experimental": {
-                    "local_mode": True,
-                }
-            },
-        )
+        executor = Executor(AerSimulator(method="stabilizer"))
         job = executor.run(QuantumProgram(1))
         self.assertIsInstance(job, LocalRuntimeJob)
         self.assertTrue(job.metrics())

--- a/test/unit/options_models/test_converters.py
+++ b/test/unit/options_models/test_converters.py
@@ -21,7 +21,6 @@ from qiskit_ibm_runtime.options_models.converters import (
 )
 from qiskit_ibm_runtime.options_models.estimator import EstimatorOptions
 from qiskit_ibm_runtime.options_models.sampler import SamplerOptions
-from qiskit_ibm_runtime.options_models.simulator import ExperimentalSimulatorOptions
 
 from ...ibm_test_case import IBMTestCase
 
@@ -124,30 +123,25 @@ class TestEstimatorOptionsToExecutorOptions(IBMTestCase):
     def test_to_executor_options_resilience_fallback(self):
         """Test the simulator ``layer_noise_model`` fallback to resilience ``layer_noise_model``."""
         options = EstimatorOptions()
-        simulator_options = ExperimentalSimulatorOptions()
-        options.experimental = {"simulator_options": simulator_options}
-
         options.resilience.layer_noise_model = []
 
         executor_options = estimator_options_to_executor_options(options)
 
-        self.assertIsNotNone(executor_options.experimental.get("simulator_options"))
         self.assertEqual(
-            executor_options.experimental["simulator_options"].layer_noise_model,
+            executor_options.simulator.layer_noise_model,
             options.resilience.layer_noise_model,
         )
 
         circuit = QuantumCircuit(2)
         with circuit.box():
             circuit.cx(0, 1)
-        options.experimental["simulator_options"].layer_noise_model = [
+        options.simulator.layer_noise_model = [
             (layer, PauliLindbladMap.identity(2)) for layer in circuit.data
         ]
 
         executor_options = estimator_options_to_executor_options(options)
 
-        self.assertIsNotNone(executor_options.experimental.get("simulator_options"))
         self.assertEqual(
-            executor_options.experimental["simulator_options"].layer_noise_model,
-            options.experimental["simulator_options"].layer_noise_model,
+            executor_options.simulator.layer_noise_model,
+            options.simulator.layer_noise_model,
         )

--- a/test/unit/options_models/test_simulator.py
+++ b/test/unit/options_models/test_simulator.py
@@ -21,7 +21,7 @@ from qiskit_ibm_runtime.options_models.simulator import SimulatorOptions
 from ...ibm_test_case import IBMTestCase
 
 
-class TestExperimentalSimulatorOptions(IBMTestCase):
+class TestSimulatorOptions(IBMTestCase):
     """Tests for SimulatorOptions."""
 
     def test_simulator_options_default(self):

--- a/test/unit/options_models/test_simulator.py
+++ b/test/unit/options_models/test_simulator.py
@@ -10,30 +10,23 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Tests for SimulatorOptions and ExperimentalSimulatorOptions."""
+"""Tests for SimulatorOptions."""
 
-from unittest.mock import patch
-
-from ddt import data, ddt
 from pydantic import ValidationError
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import PauliLindbladMap
-from qiskit.transpiler import CouplingMap
 
-from qiskit_ibm_runtime.options_models.simulator import (
-    ExperimentalSimulatorOptions,
-    SimulatorOptions,
-)
+from qiskit_ibm_runtime.options_models.simulator import SimulatorOptions
 
 from ...ibm_test_case import IBMTestCase
 
 
 class TestExperimentalSimulatorOptions(IBMTestCase):
-    """Tests for ExperimentalSimulatorOptions."""
+    """Tests for SimulatorOptions."""
 
     def test_simulator_options_default(self):
         """Test that simulator options have correct defaults."""
-        options = ExperimentalSimulatorOptions()
+        options = SimulatorOptions()
 
         self.assertEqual(options.angle_decimals, 5)
         self.assertIsNone(options.layer_noise_model)
@@ -48,54 +41,11 @@ class TestExperimentalSimulatorOptions(IBMTestCase):
             circuit.cx(0, 1)
         not_box, box = circuit.data
 
-        options = ExperimentalSimulatorOptions(
-            layer_noise_model=[(box, PauliLindbladMap.identity(2))]
-        )
+        options = SimulatorOptions(layer_noise_model=[(box, PauliLindbladMap.identity(2))])
         self.assertEqual(options.layer_noise_model, [(box, PauliLindbladMap.identity(2))])
 
         with self.assertRaisesRegex(ValidationError, "does not contain a box"):
-            ExperimentalSimulatorOptions(
-                layer_noise_model=[(not_box, PauliLindbladMap.identity(2))]
-            )
+            SimulatorOptions(layer_noise_model=[(not_box, PauliLindbladMap.identity(2))])
 
         with self.assertRaisesRegex(ValidationError, "Found instruction with 2"):
-            ExperimentalSimulatorOptions(layer_noise_model=[(box, PauliLindbladMap.identity(1))])
-
-
-@ddt
-class TestSimulatorOptions(IBMTestCase):
-    """Tests for SimulatorOptions."""
-
-    def test_simulator_options_default(self):
-        """Test that simulator options have correct defaults."""
-        options = SimulatorOptions()
-
-        self.assertIsNone(options.noise_model)
-        self.assertIsNone(options.seed_simulator)
-        self.assertIsNone(options.coupling_map)
-        self.assertIsNone(options.basis_gates)
-
-    @data([[0, 1], [1, 2]], CouplingMap([[0, 1], [1, 2]]))
-    def test_coupling_map_valid(self, coupling_map):
-        """Test setting coupling map."""
-        options = SimulatorOptions()
-        options.coupling_map = coupling_map
-
-        self.assertEqual(options.coupling_map, coupling_map)
-
-    @data("bad_input", [1, 2, 3], [[0, 1], [-1, 0]])
-    def test_coupling_map_invalid_type_raises(self, input):
-        """Non-list, non-CouplingMap, non-None value should raise ValidationError."""
-        with self.assertRaises(ValidationError):
-            SimulatorOptions(coupling_map=input)
-
-    def test_noise_model_invalid_type_no_aer_raises(self):
-        """Passing a non-dict noise_model raises when Aer is not installed."""
-        with patch("qiskit_ibm_runtime.options_models.simulator.optionals.HAS_AER", False):
-            with self.assertRaises(ValidationError):
-                SimulatorOptions(noise_model=object())
-
-    def test_noise_model_invalid_type_with_aer_raises(self):
-        """A non-dict, non-AerNoiseModel value raises ValidationError."""
-        with self.assertRaises(ValidationError):
-            SimulatorOptions(noise_model=12345)
+            SimulatorOptions(layer_noise_model=[(box, PauliLindbladMap.identity(1))])


### PR DESCRIPTION
### Summary
Taking local mode simulation out of experimental options. This involves:

1. Integrating `ExperimentalSimulatorOptions` with `ExecutorOptions`, `EstimatorOptions`, and `SamplerOptions`
2. Removing the old `SimulatorOptions`
3. Renaming `ExperimentalSimulatorOptions` to `SimulatorOptions`
4. Removing the legacy local mode path

### Details and comments

Fixes #3277 and closes #3053

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
