### PR TITLE
Revise QuantumProgram (and other bits) typing

### DIFF
--- a/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_estimator/post_processor_v0_1.py
@@ -76,7 +76,7 @@ def _build_program_result_metadata(post_processor_data: dict) -> dict:
     if options is None:
         return {}
 
-    metadata = {"options": dict(options)}
+    metadata: dict[str, Any] = {"options": dict(options)}
     if "resilience" in metadata["options"]:
         resilience = dict(metadata["options"]["resilience"])
         for flag_key, options_key in [
@@ -111,12 +111,13 @@ def estimator_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveR
     if len(result) == 0:
         return PrimitiveResult([])
 
-    if not isinstance(passthrough := result.passthrough_data, dict):
+    if not isinstance(result.passthrough_data, dict):
         raise ValueError(
             "Wrong type for passthrough data: Expected a 'dict', found "
             f"'{type(result.passthrough_data)}'."
         )
 
+    passthrough: dict[str, Any] = result.passthrough_data or {}
     if (post_processor_data := passthrough.get("post_processor", None)) is None:
         raise ValueError("Missing 'post_processor' in passthrough data.")
 

--- a/qiskit_ibm_runtime/decoders/executor_sampler/post_processor_v0_1.py
+++ b/qiskit_ibm_runtime/decoders/executor_sampler/post_processor_v0_1.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from qiskit.primitives import PrimitiveResult
 
@@ -51,7 +51,7 @@ def sampler_v2_post_processor_v0_1(result: QuantumProgramResult) -> PrimitiveRes
             f"'{type(result.passthrough_data)}'."
         )
 
-    passthrough = result.passthrough_data or {}
+    passthrough: dict[str, Any] = result.passthrough_data or {}
     if (post_processor_data := passthrough.get("post_processor", None)) is None:
         raise ValueError("Missing 'post_processor' in passthrough data.")
     if (twirling := post_processor_data.get("twirling", None)) is None:

--- a/qiskit_ibm_runtime/decoders/quantum_program/converters.py
+++ b/qiskit_ibm_runtime/decoders/quantum_program/converters.py
@@ -29,7 +29,22 @@ from ...results.quantum_program import (
 )
 
 if TYPE_CHECKING:
-    from ibm_quantum_schemas.executor.version_0_1 import QuantumProgramResultModel
+    from ibm_quantum_schemas.executor.version_0_1 import (
+        QuantumProgramResultModel as QuantumProgramResultModel_0_1,
+    )
+    from ibm_quantum_schemas.executor.version_0_2 import (
+        QuantumProgramResultModel as QuantumProgramResultModel_0_2,
+    )
+    from ibm_quantum_schemas.executor.version_1_0 import (
+        QuantumProgramResultModel as QuantumProgramResultModel_1_0,
+    )
+    from ibm_quantum_schemas.executor.version_1_1 import (
+        QuantumProgramResultModel as QuantumProgramResultModel_1_1,
+    )
+    from ibm_quantum_schemas.executor.version_2_0 import (
+        QuantumProgramResultModel as QuantumProgramResultModel_2_0,
+    )
+
 
 from ...quantum_program.converters.converters_0_2 import passthrough_data_from_0_2
 from ...quantum_program.converters.converters_1_0 import passthrough_data_from_1_0
@@ -37,7 +52,7 @@ from ...quantum_program.converters.converters_1_1 import passthrough_data_from_1
 from ...quantum_program.converters.converters_2_0 import passthrough_data_from_2_0
 
 
-def quantum_program_result_from_0_1(model: QuantumProgramResultModel) -> QuantumProgramResult:
+def quantum_program_result_from_0_1(model: QuantumProgramResultModel_0_1) -> QuantumProgramResult:
     """Convert a V0.1 model to a :class:`QuantumProgramResult`."""
     metadata = Metadata(
         chunk_timing=[
@@ -58,7 +73,7 @@ def quantum_program_result_from_0_1(model: QuantumProgramResultModel) -> Quantum
     )
 
 
-def quantum_program_result_from_0_2(model: QuantumProgramResultModel) -> QuantumProgramResult:
+def quantum_program_result_from_0_2(model: QuantumProgramResultModel_0_2) -> QuantumProgramResult:
     """Convert a V0.2 model to a :class:`QuantumProgramResult`."""
     metadata = Metadata(
         chunk_timing=[
@@ -95,7 +110,7 @@ def quantum_program_result_from_0_2(model: QuantumProgramResultModel) -> Quantum
     )
 
 
-def quantum_program_result_from_1_0(model: QuantumProgramResultModel) -> QuantumProgramResult:
+def quantum_program_result_from_1_0(model: QuantumProgramResultModel_1_0) -> QuantumProgramResult:
     """Convert a V1.0 model to a :class:`QuantumProgramResult`."""
     metadata = Metadata(
         chunk_timing=[
@@ -134,7 +149,7 @@ def quantum_program_result_from_1_0(model: QuantumProgramResultModel) -> Quantum
     return result
 
 
-def quantum_program_result_from_1_1(model: QuantumProgramResultModel) -> QuantumProgramResult:
+def quantum_program_result_from_1_1(model: QuantumProgramResultModel_1_1) -> QuantumProgramResult:
     """Convert a V1.1 model to a :class:`QuantumProgramResult`."""
     metadata = Metadata(
         chunk_timing=[
@@ -173,7 +188,7 @@ def quantum_program_result_from_1_1(model: QuantumProgramResultModel) -> Quantum
     return result
 
 
-def quantum_program_result_from_2_0(model: QuantumProgramResultModel) -> QuantumProgramResult:
+def quantum_program_result_from_2_0(model: QuantumProgramResultModel_2_0) -> QuantumProgramResult:
     """Convert a V2.0 model to a :class:`QuantumProgramResult`."""
     metadata = Metadata(
         chunk_timing=[

--- a/qiskit_ibm_runtime/executor_estimator/utils.py
+++ b/qiskit_ibm_runtime/executor_estimator/utils.py
@@ -28,7 +28,8 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     from qiskit import QuantumCircuit
     from qiskit.circuit import BoxOp, CircuitInstruction
-    from qiskit.primitives import EstimatorPub, SamplerPub
+    from qiskit.primitives.containers.estimator_pub import EstimatorPub
+    from qiskit.primitives.containers.sampler_pub import SamplerPub
     from samplomatic.samplex import Samplex
 
     from ..options_models.measure_noise_learning import MeasureNoiseLearningOptions

--- a/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
+++ b/qiskit_ibm_runtime/noise_learner_v3/params_converters.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from ibm_quantum_schemas.noise_learner_v3.version_0_1 import ParamsModel as ParamsModel_0_1
 from ibm_quantum_schemas.noise_learner_v3.version_0_2 import ParamsModel as ParamsModel_0_2
@@ -38,16 +39,20 @@ if TYPE_CHECKING:
     from ..options_models import NoiseLearnerV3Options
 
 
-class ParamsConverter(NamedTuple):
+ModelT = TypeVar("ModelT", bound="BaseParamsModel")
+
+
+@dataclass(frozen=True)
+class ParamsConverter(Generic[ModelT]):
     """A helper to store params models and converters."""
 
-    model: type[BaseParamsModel]
+    model: type[ModelT]
     """The model describing the NLV3 inputs, or 'params'."""
 
-    decoder: Callable[[BaseParamsModel], tuple[list[CircuitInstruction], NoiseLearnerV3Options]]
+    decoder: Callable[[ModelT], tuple[list[CircuitInstruction], NoiseLearnerV3Options]]
     """A function to decode the inputs of NLV3."""
 
-    encoder: Callable[[Iterable[CircuitInstruction], NoiseLearnerV3Options], BaseParamsModel]
+    encoder: Callable[[Iterable[CircuitInstruction], NoiseLearnerV3Options], ModelT]
     """A function to encode the inputs of NLV3."""
 
 

--- a/qiskit_ibm_runtime/quantum_program/params_converters.py
+++ b/qiskit_ibm_runtime/quantum_program/params_converters.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from ibm_quantum_schemas.executor.version_0_1 import ParamsModel as ParamsModel_0_1
 from ibm_quantum_schemas.executor.version_0_2 import ParamsModel as ParamsModel_0_2
@@ -44,16 +45,20 @@ if TYPE_CHECKING:
     from .quantum_program import QuantumProgram
 
 
-class ParamsConverter(NamedTuple):
+ModelT = TypeVar("ModelT", bound="BaseParamsModel")
+
+
+@dataclass(frozen=True)
+class ParamsConverter(Generic[ModelT]):
     """A helper to store params models and converters."""
 
-    model: type[BaseParamsModel]
+    model: type[ModelT]
     """The model describing the executor inputs, or 'params'."""
 
-    decoder: Callable[[BaseParamsModel], tuple[QuantumProgram, ExecutorOptions]]
+    decoder: Callable[[ModelT], tuple[QuantumProgram, ExecutorOptions]]
     """A function to decode the inputs of executor."""
 
-    encoder: Callable[[QuantumProgram, ExecutorOptions], BaseParamsModel]
+    encoder: Callable[[QuantumProgram, ExecutorOptions], ModelT]
     """A function to encode the inputs of executor."""
 
 

--- a/qiskit_ibm_runtime/results/quantum_program.py
+++ b/qiskit_ibm_runtime/results/quantum_program.py
@@ -204,15 +204,12 @@ class QuantumProgramResult(BaseQuantumProgramResult):
     def __getitem__(self, idx: slice) -> list[QuantumProgramItemResult]: ...
 
     def __getitem__(
-        self, index: int | slice
+        self, idx: int | slice
     ) -> QuantumProgramItemResult | list[QuantumProgramItemResult]:
-        get_item = super().__getitem__
-        if isinstance(index, int):
-            return cast("QuantumProgramItemResult", get_item(index))
-        return [
-            cast("QuantumProgramItemResult", get_item(idx))
-            for idx in range(*index.indices(len(self)))
-        ]
+        return cast(
+            "QuantumProgramItemResult | list[QuantumProgramItemResult]",
+            super().__getitem__(idx),
+        )
 
     def __iter__(self) -> Iterator[QuantumProgramItemResult]:
         return cast("Iterator[QuantumProgramItemResult]", super().__iter__())


### PR DESCRIPTION
### Summary

Revise some of the typing hints related to the `QuantumProgram` move in #3206 (only one notable item, see comments), and take the chance to revise other Pyright warnings (not emitted by `mypy`).

### Details and comments

Fixes #3279

### AI/LLM disclosure

- [x] I used the following tool to generate or modify code: Claude Opus 4.8 (for the registries)
