### PR TITLE
Tone down debug output in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
             python-version: '3.10'
     env:
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "--durations=10 --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "--durations=10"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -119,7 +120,8 @@ jobs:
         os: [ "ubuntu-latest" ]
     env:
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "--durations=10 --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "--durations=10"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -159,7 +161,8 @@ jobs:
       QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
       QISKIT_IBM_QPU: ${{ secrets.QISKIT_IBM_QPU }}
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "-v -s --durations=0 --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "-v -s --durations=0"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/integration-tests-qiskit-main.yml
+++ b/.github/workflows/integration-tests-qiskit-main.yml
@@ -35,7 +35,8 @@ jobs:
       QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
       QISKIT_IBM_QPU: ${{ secrets.QISKIT_IBM_QPU }}
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "-v -s --durations=0 --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "-v -s --durations=0"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,7 +35,8 @@ jobs:
       QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
       QISKIT_IBM_QPU: ${{ secrets.QISKIT_IBM_QPU }}
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "-v -s --durations=0 --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "-v -s --durations=0"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -68,7 +69,8 @@ jobs:
       QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
       QISKIT_IBM_QPU: ${{ secrets.QISKIT_IBM_QPU }}
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "--benchmark-time-unit s --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "--benchmark-time-unit s"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -101,7 +103,8 @@ jobs:
             python-version: '3.13'
     env:
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "--durations=10 --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "--durations=10"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -32,7 +32,8 @@ jobs:
       QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
       QISKIT_IBM_QPU: ${{ secrets.QISKIT_IBM_QPU }}
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "-v -s --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "-v -s"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/unit-tests-terra-main.yml
+++ b/.github/workflows/unit-tests-terra-main.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: "ubuntu-latest"
     env:
       QISKIT_IN_PARALLEL: True
-      PYTEST_ADDOPTS: "-v -s --log-level=DEBUG"
+      QISKIT_IBM_RUNTIME_LOG_LEVEL: DEBUG
+      PYTEST_ADDOPTS: "-v -s"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/test/unit/test_logger.py
+++ b/test/unit/test_logger.py
@@ -59,7 +59,7 @@ class TestLogger(IBMTestCase):
         logger = logging.getLogger(self.id())
         default_level_not_set = logging.NOTSET
 
-        with custom_envs({}):
+        with custom_envs({QISKIT_IBM_RUNTIME_LOG_LEVEL: ""}):
             setup_logger(logger)
             self.assertEqual(
                 logger.level,


### PR DESCRIPTION
### Summary

The workflows that are executed in verbose mode can get quite verbose when a test fails, producing a large output with no significant gain. This PR changes the verbosity in such occasions, ensuring that the `debug` level applies only to `qiskit_ibm_runtime` and not to the rest of the python libraries.

### Details and comments

Fixes N/A

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
