### PR TITLE
Update registries focused on usage, add new endpoint

### DIFF
--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from ...json import RuntimeEncoder
 from ...utils import local_to_utc
@@ -38,6 +38,7 @@ class Runtime(RestAdapterBase):
         "jobs": "/jobs",
         "backends": "/backends",
         "cloud_usage": "/instances/usage",
+        "workloads": "/workloads",
     }
 
     def program_job(self, job_id: str) -> ProgramJob:
@@ -228,3 +229,67 @@ class Runtime(RestAdapterBase):
         """
         url = self.get_url("cloud_usage")
         return self.session.get(url, headers=self._HEADER_JSON_ACCEPT).json()
+
+    def workloads_get(
+        self,
+        user: str | None = None,
+        sort: Literal["createdAt", "-createdAt"] | None = None,
+        limit: int | None = None,
+        previous: str | None = None,
+        next: str | None = None,
+        backend: str | None = None,
+        search: str | None = None,
+        status: list[str] | None = [],
+        mode: Literal["job", "session", "batch"] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+        tags: list[str] | None = None,
+    ) -> dict:
+        """Get a list of user instance workloads.
+
+        Args:
+            user: User identifier.
+            sort: Field to sort the workloads.
+            limit: Number of workloads to return at a time.
+            previous: Cursor to previous workloads results page.
+            next: Cursor to next workloads results page.
+            backend: Backend name.
+            search: Search string, used to filter workloads by id or tags.
+            status: status type to filter workloads by.
+            mode: Workload mode.
+            created_after: Initial date of workloads to be included.
+            created_before: Last date of workloads to be included.
+            tags: List of tags for the worload.
+
+        Returns:
+            JSON response.
+        """
+        url = self.get_url("workloads")
+        payload: dict[str, int | str | list[str]] = {}
+
+        if user:
+            payload["user"] = user
+        if sort:
+            payload["sort"] = sort
+        if limit:
+            payload["limit"] = limit
+        if previous:
+            payload["previous"] = previous
+        if next:
+            payload["next"] = next
+        if backend:
+            payload["backend"] = backend
+        if search:
+            payload["search"] = search
+        if status:
+            payload["status"] = status
+        if mode:
+            payload["mode"] = mode
+        if created_before:
+            payload["created_before"] = local_to_utc(created_before).isoformat()
+        if created_after:
+            payload["created_after"] = local_to_utc(created_after).isoformat()
+        if tags:
+            payload["tags"] = tags
+
+        return self.session.get(url, params=payload, headers=self._HEADER_JSON_ACCEPT).json()

--- a/qiskit_ibm_runtime/api/rest/runtime.py
+++ b/qiskit_ibm_runtime/api/rest/runtime.py
@@ -265,31 +265,22 @@ class Runtime(RestAdapterBase):
             JSON response.
         """
         url = self.get_url("workloads")
-        payload: dict[str, int | str | list[str]] = {}
-
-        if user:
-            payload["user"] = user
-        if sort:
-            payload["sort"] = sort
-        if limit:
-            payload["limit"] = limit
-        if previous:
-            payload["previous"] = previous
-        if next:
-            payload["next"] = next
-        if backend:
-            payload["backend"] = backend
-        if search:
-            payload["search"] = search
-        if status:
-            payload["status"] = status
-        if mode:
-            payload["mode"] = mode
-        if created_before:
-            payload["created_before"] = local_to_utc(created_before).isoformat()
-        if created_after:
-            payload["created_after"] = local_to_utc(created_after).isoformat()
-        if tags:
-            payload["tags"] = tags
+        payload = {
+            "user": user,
+            "sort": sort,
+            "limit": limit,
+            "previous": previous,
+            "next": next,
+            "backend": backend,
+            "search": search,
+            "status": status,
+            "mode": mode,
+            "created_before": (
+                local_to_utc(created_before).isoformat() if created_before else None
+            ),
+            "created_after": (local_to_utc(created_after).isoformat() if created_after else None),
+            "tags": tags,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
 
         return self.session.get(url, params=payload, headers=self._HEADER_JSON_ACCEPT).json()

--- a/qiskit_ibm_runtime/base_runtime_job.py
+++ b/qiskit_ibm_runtime/base_runtime_job.py
@@ -226,7 +226,6 @@ class BaseRuntimeJob(ABC):
         """Fetch and set status and error message."""
         if self._status not in self.JOB_FINAL_STATES:
             response = self._api_client.job_get(job_id=self.job_id())
-            print(response)
             self._set_status(response)
             self._set_error_message(response)
 

--- a/qiskit_ibm_runtime/base_runtime_job.py
+++ b/qiskit_ibm_runtime/base_runtime_job.py
@@ -226,6 +226,7 @@ class BaseRuntimeJob(ABC):
         """Fetch and set status and error message."""
         if self._status not in self.JOB_FINAL_STATES:
             response = self._api_client.job_get(job_id=self.job_id())
+            print(response)
             self._set_status(response)
             self._set_error_message(response)
 

--- a/test/registries.py
+++ b/test/registries.py
@@ -141,6 +141,9 @@ class Job:
     raw_results: str | None = None
     """Response for the job results."""
 
+    raw_metrics: str | None = None
+    """Response for the job metrics."""
+
 
 class BaseRegistry(FirstMatchRegistry):
     """Registry that dynamically serves IBM Quantum Compute responses.
@@ -260,6 +263,13 @@ class BaseRegistry(FirstMatchRegistry):
                 method=GET,
                 url=re.compile(r"https://my-region.quantum.cloud.ibm.com/api/v1/jobs/\w+"),
                 callback=self.callback_jobs_id,
+            ),
+        )
+        self.add(
+            CallbackResponse(
+                method=GET,
+                url=re.compile(r"https://my-region.quantum.cloud.ibm.com/api/v1/jobs/\w+/metrics"),
+                callback=self.callback_jobs_metrics,
             ),
         )
         self.add(
@@ -478,7 +488,7 @@ class BaseRegistry(FirstMatchRegistry):
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/jobs
         """
-        # Validate the instance CRN and backend name.
+        # Validate the instance CRN and job id.
         instance = self.get_crn_from_request(request)
         job_id = request.path_url.split("/")[-1].split("?")[0]
 
@@ -500,6 +510,39 @@ class BaseRegistry(FirstMatchRegistry):
             )
         return (200, {"Content-Type": "application/json"}, response_body)
 
+    def callback_jobs_metrics(self, request: PreparedRequest) -> CallbackResult:
+        """Callback for the IBM Quantum Compute API ``/jobs/{}/metrics`` endpoint.
+
+        Dynamically return the metric of a job, based on the contents of `self.jobs`.
+
+        References:
+            https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/jobs
+        """
+        # Validate the instance CRN and job id.
+        instance = self.get_crn_from_request(request)
+        job_id = request.path_url.split("/")[-2].split("?")[0]
+        if instance.name not in self.backends or job_id not in self.jobs[instance.name]:
+            return (404, {"Content-Type": "application/json"}, "{}")
+
+        job = self.jobs[instance.name][job_id]
+
+        if job.raw_metrics:
+            response_body = job.raw_metrics
+        else:
+            response_body = json.dumps(
+                {
+                    "timestamps": {
+                        "created": "2026-03-06T14:02:11Z",
+                        "running": "2026-03-06T14:02:18Z",
+                        "finished": "2026-03-06T14:05:47Z",
+                    },
+                    "usage": {"qpu_charge_time_seconds": 20, "status": "complete"},
+                    "circuits_execution_time_ns": 20000000,
+                    "qiskit_version": "2.3.0",
+                }
+            )
+        return (200, {"Content-Type": "application/json"}, response_body)
+
     def callback_jobs_results(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/jobs/{}/results`` endpoint.
 
@@ -508,10 +551,9 @@ class BaseRegistry(FirstMatchRegistry):
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/jobs
         """
-        # Validate the instance CRN and backend name.
+        # Validate the instance CRN and job id.
         instance = self.get_crn_from_request(request)
         job_id = request.path_url.split("/")[-2].split("?")[0]
-
         if instance.name not in self.backends or job_id not in self.jobs[instance.name]:
             return (404, {"Content-Type": "application/json"}, "{}")
 

--- a/test/registries.py
+++ b/test/registries.py
@@ -474,6 +474,7 @@ class BaseRegistry(FirstMatchRegistry):
                 "id": job.id,
                 "backend": job.backend_name,
                 "status": job.status.capitalize(),
+                "state": {"status": job.status.capitalize()},
                 "program": {"id": job.program},
                 "usage": job.usage,
             }
@@ -513,6 +514,7 @@ class BaseRegistry(FirstMatchRegistry):
                     "id": job.id,
                     "backend": job.backend_name,
                     "status": job.status.capitalize(),
+                    "state": {"status": job.status.capitalize()},
                     "program": {"id": job.program},
                     "usage": job.usage,
                 }

--- a/test/registries.py
+++ b/test/registries.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, TypeAlias
 from urllib.parse import parse_qs, urlparse
 
-from responses import GET, POST, CallbackResponse, Response
+from responses import GET, POST, CallbackResponse
 from responses.registries import FirstMatchRegistry
 
 from qiskit_ibm_runtime.fake_provider import FakeLimaV2
@@ -59,9 +59,21 @@ class Instance:
     pricing_type: PricingType = "free"
     """Pricing type of the instance."""
 
+    usage: dict | None = None
+    """Instance usage dictionary that overrides the default `usage` in responses."""
+
     def __post_init__(self) -> None:
         if not self.crn:
             self.crn = f"crn:v1:bluemix:public:quantum-computing:my-region:{self.name}/...:...::"
+
+        if self.usage is None:
+            self.usage = {
+                "instance_id": self.crn,
+                "usage_consumed_seconds": 12,
+                "usage_limit_seconds": 60,
+                "usage_allocation_seconds": 120,
+                "usage_limit_reached": False,
+            }
 
 
 @dataclass
@@ -243,10 +255,10 @@ class BaseRegistry(FirstMatchRegistry):
 
         # Add responses for the IBM Quantum Compute `/instances` endpoints.
         self.add(
-            Response(
+            CallbackResponse(
                 method=GET,
                 url="https://my-region.quantum.cloud.ibm.com/api/v1/instances/usage",
-                json={},
+                callback=self.callback_instances_usage,
             )
         )
 
@@ -572,6 +584,19 @@ class BaseRegistry(FirstMatchRegistry):
         else:
             response_body = json.dumps({})
         return (200, {"Content-Type": "application/json"}, response_body)
+
+    def callback_instances_usage(self, request: PreparedRequest) -> CallbackResult:
+        """Callback for the IBM Quantum Compute API ``/instances/usage`` endpoint.
+
+        Dynamically return a job results, based on the contents of `self.jobs`.
+
+        References:
+            https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/instances
+        """
+        # Validate the instance CRN and job id.
+        instance = self.get_crn_from_request(request)
+
+        return (200, {"Content-Type": "application/json"}, json.dumps(instance.usage))
 
     def get_crn_from_request(self, request: PreparedRequest) -> Instance:
         """Retrieve the `Instance` from the request headers."""

--- a/test/registries.py
+++ b/test/registries.py
@@ -253,7 +253,7 @@ class BaseRegistry(FirstMatchRegistry):
             )
         )
 
-        # Add responses for the IBM Quantum Compute `/instances` endpoints.
+        # Add callbacks for the IBM Quantum Compute `/instances` endpoints.
         self.add(
             CallbackResponse(
                 method=GET,
@@ -296,6 +296,15 @@ class BaseRegistry(FirstMatchRegistry):
                 method=GET,
                 url=re.compile(r"https://my-region.quantum.cloud.ibm.com/api/v1/jobs/\w+/results"),
                 callback=self.callback_jobs_results,
+            ),
+        )
+
+        # Add callbacks for the IBM Quantum Compute `/workloads` endpoints.
+        self.add(
+            CallbackResponse(
+                method=GET,
+                url="https://my-region.quantum.cloud.ibm.com/api/v1/workloads",
+                callback=self.callback_workloads_get,
             ),
         )
 
@@ -597,6 +606,36 @@ class BaseRegistry(FirstMatchRegistry):
         instance = self.get_crn_from_request(request)
 
         return (200, {"Content-Type": "application/json"}, json.dumps(instance.usage))
+
+    def callback_workloads_get(self, request: PreparedRequest) -> CallbackResult:
+        """Callback for the IBM Quantum Compute API ``/workloads`` endpoint.
+
+        Dynamically return a list of workloads, based on the contents of `self.jobs`.
+
+        References:
+            https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/workloads
+        """
+        workloads = [
+            {
+                "id": job.id,
+                "backend": job.backend_name,
+                "status": job.status.capitalize(),
+                "state": {"status": job.status.capitalize()},
+                "program": {"id": job.program},
+                "usage": job.usage,
+                "mode": "job",
+                "instance": instance.crn,
+            }
+            for instance in self.instances.values()
+            for job in self.jobs[instance.name].values()
+        ]
+
+        response_body = {
+            "workloads": workloads,
+            "total_count": len(workloads),
+            "limit": 20,
+        }
+        return (200, {"Content-Type": "application/json"}, json.dumps(response_body))
 
     def get_crn_from_request(self, request: PreparedRequest) -> Instance:
         """Retrieve the `Instance` from the request headers."""

--- a/test/registries.py
+++ b/test/registries.py
@@ -141,8 +141,15 @@ class Job:
     raw_results: str | None = None
     """Response for the job results."""
 
-    raw_metrics: str | None = None
-    """Response for the job metrics."""
+    usage: dict | None = None
+    """Job usage dictionary that overrides the default `usage` field in responses."""
+
+    def __post_init__(self) -> None:
+        if self.usage is None:
+            self.usage = {
+                "qpu_charge_time_seconds": 0 if self.status != "completed" else 20,
+                "status": "pending" if self.status in ("queued", "running") else "completed",
+            }
 
 
 class BaseRegistry(FirstMatchRegistry):
@@ -468,6 +475,7 @@ class BaseRegistry(FirstMatchRegistry):
                 "backend": job.backend_name,
                 "status": job.status.capitalize(),
                 "program": {"id": job.program},
+                "usage": job.usage,
             }
             for job in self.jobs[instance.name].values()
         ]
@@ -506,6 +514,7 @@ class BaseRegistry(FirstMatchRegistry):
                     "backend": job.backend_name,
                     "status": job.status.capitalize(),
                     "program": {"id": job.program},
+                    "usage": job.usage,
                 }
             )
         return (200, {"Content-Type": "application/json"}, response_body)
@@ -526,21 +535,18 @@ class BaseRegistry(FirstMatchRegistry):
 
         job = self.jobs[instance.name][job_id]
 
-        if job.raw_metrics:
-            response_body = job.raw_metrics
-        else:
-            response_body = json.dumps(
-                {
-                    "timestamps": {
-                        "created": "2026-03-06T14:02:11Z",
-                        "running": "2026-03-06T14:02:18Z",
-                        "finished": "2026-03-06T14:05:47Z",
-                    },
-                    "usage": {"qpu_charge_time_seconds": 20, "status": "complete"},
-                    "circuits_execution_time_ns": 20000000,
-                    "qiskit_version": "2.3.0",
-                }
-            )
+        response_body = json.dumps(
+            {
+                "timestamps": {
+                    "created": "2026-03-06T14:02:11Z",
+                    "running": "2026-03-06T14:02:18Z",
+                    "finished": "2026-03-06T14:05:47Z",
+                },
+                "usage": job.usage,
+                "circuits_execution_time_ns": 20000000,
+                "qiskit_version": "2.3.0",
+            }
+        )
         return (200, {"Content-Type": "application/json"}, response_body)
 
     def callback_jobs_results(self, request: PreparedRequest) -> CallbackResult:

--- a/test/registries.py
+++ b/test/registries.py
@@ -45,7 +45,12 @@ DEFAULT_BACKED_PROPERTIES = FakeLimaV2()._load_json(FakeLimaV2.props_filename)
 
 @dataclass
 class Instance:
-    """Registry representation of an instance."""
+    """Registry representation of an instance.
+
+    The following fields will be initialized if set to their default value:
+    * `crn`
+    * `usage`
+    """
 
     name: str
     """Name of the instance."""
@@ -60,7 +65,7 @@ class Instance:
     """Pricing type of the instance."""
 
     usage: dict | None = None
-    """Instance usage dictionary that overrides the default `usage` in responses."""
+    """Instance usage dictionary."""
 
     def __post_init__(self) -> None:
         if not self.crn:
@@ -78,16 +83,21 @@ class Instance:
 
 @dataclass
 class Backend:
-    """Registry representation of a backend."""
+    """Registry representation of a backend.
+
+    The following fields will be initialized if set to their default value:
+    * `configuration`: set based on `FakeLimaV2`.
+    * `properties`: set based on `FakeLimaV2`.
+    """
 
     name: str
     """Name of the backend."""
 
     configuration: dict = field(default_factory=dict)
-    """Configuration of the backend. If not set, it will be set based on ``FakeLimaV2``."""
+    """Configuration of the backend."""
 
     properties: dict = field(default_factory=dict)
-    """Properties of the backend. If not set, it will be set based on ``FakeLimaV2``."""
+    """Properties of the backend."""
 
     status: Literal["online", "paused", "offline"] = "online"
     """Status of the backend."""
@@ -134,7 +144,11 @@ class Backend:
 
 @dataclass
 class Job:
-    """Registry representation of a job."""
+    """Registry representation of a job.
+
+    The following fields will be initialized if set to their default value:
+    * `usage`
+    """
 
     id: str
     """Job id."""
@@ -154,7 +168,7 @@ class Job:
     """Response for the job results."""
 
     usage: dict | None = None
-    """Job usage dictionary that overrides the default `usage` field in responses."""
+    """Job usage dictionary."""
 
     def __post_init__(self) -> None:
         if self.usage is None:

--- a/test/unit/test_jobs.py
+++ b/test/unit/test_jobs.py
@@ -12,6 +12,7 @@
 
 """Tests for job related runtime functions."""
 
+import json
 import warnings
 from unittest.mock import patch
 
@@ -285,12 +286,14 @@ class TestRuntimeJob(IBMTestCase):
 
         self.assertIsInstance(job._result_decoders, list)
 
-    @run_cloud_fake
-    def test_result_chains_decoders(self, service):
+    @mock_responses
+    def test_result_chains_decoders(self, registry):
         """When passing a list of decoders to `result()`, they are chained."""
-        job = run_program(service)
-        job._status = "DONE"
+        results = json.dumps({"some": "response"})
+        registry.add_job(Job("my_job", "common_backend", raw_results=results), "a")
+        service = QiskitRuntimeService(token="my_token")
 
-        with patch.object(BaseFakeRuntimeClient, "job_results", return_value={"some": "response"}):
-            self.assertEqual(job.result(decoder=ToIntDecoder), 2)
-            self.assertEqual(job.result(decoder=[ToIntDecoder, MultiplierDecoder]), 2 * 3)
+        job = service.job("my_job")
+
+        self.assertEqual(job.result(decoder=ToIntDecoder), 2)
+        self.assertEqual(job.result(decoder=[ToIntDecoder, MultiplierDecoder]), 2 * 3)

--- a/test/unit/test_jobs.py
+++ b/test/unit/test_jobs.py
@@ -12,6 +12,7 @@
 
 """Tests for job related runtime functions."""
 
+import json
 import warnings
 from unittest.mock import patch
 
@@ -27,10 +28,12 @@ from qiskit_ibm_runtime.exceptions import (
     RuntimeJobMaxTimeoutError,
     RuntimeJobNotFound,
 )
+from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 
-from ..decorators import run_cloud_fake
+from ..decorators import mock_responses, run_cloud_fake
 from ..ibm_test_case import IBMTestCase
 from ..program import run_program
+from ..registries import Job
 from ..utils import mock_wait_for_final_state
 from .mock.fake_runtime_client import (
     BaseFakeRuntimeClient,
@@ -244,27 +247,29 @@ class TestRuntimeJob(IBMTestCase):
 
                     patched_sleep.assert_called_with(expected_interval)
 
-    @run_cloud_fake
-    @data("pending", "completed")
-    def test_usage_no_partial(self, status, service):
+    @mock_responses
+    @data("pending", "complete")
+    def test_usage_no_partial(self, status, registry):
         """usage() should return 0 if the status is not `completed`."""
-        job = run_program(service)
-        api_response = {"usage": {"qpu_charge_time_seconds": 123, "status": status}}
+        raw_metrics = json.dumps({"usage": {"qpu_charge_time_seconds": 123, "status": status}})
+        registry.add_job(Job("my_job", "common_backend", raw_metrics=raw_metrics), "a")
+        service = QiskitRuntimeService(token="my_token")
 
-        with patch.object(BaseFakeRuntimeClient, "job_metadata", return_value=api_response):
-            usage = job.usage()
-            self.assertEqual(usage, 0 if status != "completed" else 123)
+        job = service.job("my_job")
+        usage = job.usage()
+        self.assertEqual(usage, 0 if status == "pending" else 123)
 
-    @run_cloud_fake
-    @data("pending", "completed")
-    def test_usage_partial(self, status, service):
+    @mock_responses
+    @data("pending", "complete")
+    def test_usage_partial(self, status, registry):
         """usage() should always return `qpu_charge_time_seconds` regardless of status."""
-        job = run_program(service)
-        api_response = {"usage": {"qpu_charge_time_seconds": 123, "status": status}}
+        raw_metrics = json.dumps({"usage": {"qpu_charge_time_seconds": 123, "status": status}})
+        registry.add_job(Job("my_job", "common_backend", raw_metrics=raw_metrics), "a")
+        service = QiskitRuntimeService(token="my_token")
 
-        with patch.object(BaseFakeRuntimeClient, "job_metadata", return_value=api_response):
-            usage = job.usage(partial=True)
-            self.assertEqual(usage, 123)
+        job = service.job("my_job")
+        usage = job.usage(partial=True)
+        self.assertEqual(usage, 123)
 
     @run_cloud_fake
     @data(None, ToIntDecoder, [ToIntDecoder, MultiplierDecoder])

--- a/test/unit/test_jobs.py
+++ b/test/unit/test_jobs.py
@@ -36,7 +36,6 @@ from ..program import run_program
 from ..registries import Job
 from ..utils import mock_wait_for_final_state
 from .mock.fake_runtime_client import (
-    BaseFakeRuntimeClient,
     CancelableRuntimeJob,
     FailedRanTooLongRuntimeJob,
     FailedRuntimeJob,
@@ -180,38 +179,36 @@ class TestRuntimeJob(IBMTestCase):
         with self.assertRaises(RuntimeJobNotFound):
             service.job(job.job_id())
 
-    @run_cloud_fake
-    def test_instance_limit_warning(self, service):
+    @mock_responses
+    def test_instance_limit_warning(self, registry):
         """Test emitting a warning if instance usage has been reached."""
+        service = QiskitRuntimeService(token="my_token")
+
         # All relevant fields present, account limit reached.
-        instance_usage_msg_1 = {
+        registry.instances["a"].usage = {
             "usage_consumed_seconds": 1,
             "usage_limit_seconds": 2,
             "usage_limit_reached": True,
         }
+        with self.assertWarnsRegex(UserWarning, r"There is currently no more time available"):
+            service._run(program_id="sampler", options={"backend": "common_backend"}, inputs={})
+
         # All relevant fields present, instance limit reached.
-        instance_usage_msg_2 = {
+        registry.instances["a"].usage = {
             "usage_consumed_seconds": 3,
             "usage_limit_seconds": 2,
             "usage_limit_reached": True,
         }
+        with self.assertWarnsRegex(UserWarning, r"This instance has met its usage limit"):
+            service._run(program_id="sampler", options={"backend": "common_backend"}, inputs={})
+
         # Missing `usage_limit_seconds`, account limit reached.
-        instance_usage_msg_3 = {
+        registry.instances["a"].usage = {
             "usage_consumed_seconds": 1,
             "usage_limit_reached": True,
         }
-
-        with patch.object(BaseFakeRuntimeClient, "cloud_usage", return_value=instance_usage_msg_1):
-            with self.assertWarnsRegex(UserWarning, r"There is currently no more time available"):
-                run_program(service=service)
-
-        with patch.object(BaseFakeRuntimeClient, "cloud_usage", return_value=instance_usage_msg_2):
-            with self.assertWarnsRegex(UserWarning, r"This instance has met its usage limit"):
-                run_program(service=service)
-
-        with patch.object(BaseFakeRuntimeClient, "cloud_usage", return_value=instance_usage_msg_3):
-            with self.assertWarnsRegex(UserWarning, r"There is currently no more time available"):
-                run_program(service=service)
+        with self.assertWarnsRegex(UserWarning, r"There is currently no more time available"):
+            service._run(program_id="sampler", options={"backend": "common_backend"}, inputs={})
 
     @run_cloud_fake
     @data((None, 0.5), ("some_session_id", 0.1))

--- a/test/unit/test_jobs.py
+++ b/test/unit/test_jobs.py
@@ -12,7 +12,6 @@
 
 """Tests for job related runtime functions."""
 
-import json
 import warnings
 from unittest.mock import patch
 
@@ -251,8 +250,8 @@ class TestRuntimeJob(IBMTestCase):
     @data("pending", "complete")
     def test_usage_no_partial(self, status, registry):
         """usage() should return 0 if the status is not `completed`."""
-        raw_metrics = json.dumps({"usage": {"qpu_charge_time_seconds": 123, "status": status}})
-        registry.add_job(Job("my_job", "common_backend", raw_metrics=raw_metrics), "a")
+        usage = {"qpu_charge_time_seconds": 123, "status": status}
+        registry.add_job(Job("my_job", "common_backend", usage=usage), "a")
         service = QiskitRuntimeService(token="my_token")
 
         job = service.job("my_job")
@@ -263,8 +262,8 @@ class TestRuntimeJob(IBMTestCase):
     @data("pending", "complete")
     def test_usage_partial(self, status, registry):
         """usage() should always return `qpu_charge_time_seconds` regardless of status."""
-        raw_metrics = json.dumps({"usage": {"qpu_charge_time_seconds": 123, "status": status}})
-        registry.add_job(Job("my_job", "common_backend", raw_metrics=raw_metrics), "a")
+        usage = {"qpu_charge_time_seconds": 123, "status": status}
+        registry.add_job(Job("my_job", "common_backend", usage=usage), "a")
         service = QiskitRuntimeService(token="my_token")
 
         job = service.job("my_job")

--- a/test/unit/test_qiskit_runtime_service.py
+++ b/test/unit/test_qiskit_runtime_service.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from ddt import data, ddt
 from qiskit import QuantumCircuit
@@ -27,11 +27,11 @@ from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 from ..account import custom_envs
 from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
-from ..registries import Backend, DefaultRegistry, Instance, OneInstanceNoBackendsRegistry
+from ..registries import Backend, Instance, Job, OneInstanceNoBackendsRegistry
 from ..utils import transpile_pubs
 
 if TYPE_CHECKING:
-    from ..registries import DefaultRegistry
+    from ..registries import BaseRegistry
 
 
 @ddt
@@ -39,7 +39,7 @@ class TestQiskitRuntimeService(IBMTestCase):
     """Class for testing the `QiskitRuntimeService` class."""
 
     @mock_responses(OneInstanceNoBackendsRegistry)
-    def test_run_active_client(self, registry):
+    def test_run_active_client(self, registry: BaseRegistry) -> None:
         """`_run()` should use the backend/instance api client rather than the active client."""
         # Create several instances, with one instance per backend, so they use different clients.
         registry.add_instance(Instance("b"))
@@ -55,42 +55,49 @@ class TestQiskitRuntimeService(IBMTestCase):
         backend_c._instance = "invalid"
 
         # Add mocks in order to ensure which clients are used.
-        backend_a._api_client.program_run = MagicMock(wraps=backend_a._api_client.program_run)
-        backend_b._api_client.program_run = MagicMock(wraps=backend_b._api_client.program_run)
-        backend_c._api_client.program_run = MagicMock(wraps=backend_c._api_client.program_run)
-
-        # Run a job with the client and instance active in the service.
-        pubs = transpile_pubs([(QuantumCircuit(1),)], backend_a, "sampler")
-        sampler = SamplerV2(mode=backend_a)
-        _ = sampler.run(pubs)
-        backend_a._api_client.program_run.assert_called()
-        backend_b._api_client.program_run.assert_not_called()
-        backend_c._api_client.program_run.assert_not_called()
-        self.assertEqual(service._active_api_client, backend_a._api_client)
-        backend_a._api_client.program_run.reset_mock()
-
-        # Run a job with the client and instance not active in the service.
-        sampler = SamplerV2(mode=backend_b)
-        _ = sampler.run(pubs)
-        backend_a._api_client.program_run.assert_not_called()
-        backend_b._api_client.program_run.assert_called()
-        backend_c._api_client.program_run.assert_not_called()
-        self.assertEqual(service._active_api_client, backend_b._api_client)
-        backend_b._api_client.program_run.reset_mock()
-
-        # Run a job with the client and instance not active in the service.
-        sampler = SamplerV2(mode=backend_c)
-        with self.assertRaises(IBMRuntimeError) as ex:
+        with (
+            patch.object(
+                backend_a._api_client, "program_run", wraps=backend_a._api_client.program_run
+            ) as api_client_a_run,
+            patch.object(
+                backend_b._api_client, "program_run", wraps=backend_b._api_client.program_run
+            ) as api_client_b_run,
+            patch.object(
+                backend_c._api_client, "program_run", wraps=backend_c._api_client.program_run
+            ) as api_client_c_run,
+        ):
+            # Run a job with the client and instance active in the service.
+            pubs = transpile_pubs([(QuantumCircuit(1),)], backend_a, "sampler")
+            sampler = SamplerV2(mode=backend_a)
             _ = sampler.run(pubs)
-            self.assertIn("not among", str(ex.msg))
+            api_client_a_run.assert_called()
+            api_client_b_run.assert_not_called()
+            api_client_c_run.assert_not_called()
+            self.assertEqual(service._active_api_client, backend_a._api_client)
+            api_client_a_run.reset_mock()
 
-        backend_a._api_client.program_run.assert_not_called()
-        backend_b._api_client.program_run.assert_not_called()
-        backend_c._api_client.program_run.assert_not_called()
-        self.assertEqual(service._active_api_client, backend_b._api_client)
+            # Run a job with the client and instance not active in the service.
+            sampler = SamplerV2(mode=backend_b)
+            _ = sampler.run(pubs)
+            api_client_a_run.assert_not_called()
+            api_client_b_run.assert_called()
+            api_client_c_run.assert_not_called()
+            self.assertEqual(service._active_api_client, backend_b._api_client)
+            api_client_b_run.reset_mock()
+
+            # Run a job with the client and instance not active in the service.
+            sampler = SamplerV2(mode=backend_c)
+            with self.assertRaises(IBMRuntimeError) as ex:
+                _ = sampler.run(pubs)
+                self.assertIn("not among", str(ex.msg))
+
+            api_client_a_run.assert_not_called()
+            api_client_b_run.assert_not_called()
+            api_client_c_run.assert_not_called()
+            self.assertEqual(service._active_api_client, backend_b._api_client)
 
     @mock_responses
-    def test_initialization_state(self, registry: DefaultRegistry) -> None:
+    def test_initialization_state(self, registry: BaseRegistry) -> None:
         """Test `__init__` state variables, with default arguments."""
         crns_in_registry = {instance.crn for instance in registry.instances.values()}
         backends_in_registry = {
@@ -124,7 +131,7 @@ class TestQiskitRuntimeService(IBMTestCase):
     @mock_responses(OneInstanceNoBackendsRegistry)
     @data(True, False)
     def test_initialization_state_passing_instance(
-        self, with_env_var: bool, registry: OneInstanceNoBackendsRegistry
+        self, with_env_var: bool, registry: BaseRegistry
     ) -> None:
         """Test `__init__` state variables, passing the `instance` argument."""
         chosen_crn = registry.instances["a"].crn
@@ -149,3 +156,23 @@ class TestQiskitRuntimeService(IBMTestCase):
         self.assertEqual(service._backends_info_per_instance, {})
         # `_backend_instance_groups` is empty.
         self.assertEqual(service._backend_instance_groups, [])
+
+    @mock_responses
+    def test_experimental_workload_endpoint(self, registry: BaseRegistry) -> None:
+        """Test the experimental usage of the `/workloads` endpoint.
+
+        The endpoint is only supported at the `api/rest` level. This tests provide some assurances
+        about the endpoint while it is still not used by `QiskitRuntimeService`.
+        """
+        registry.add_job(Job("my_job_instance_a", "unique_backend_a"), "a")
+        registry.add_job(Job("my_job_instance_b", "unique_backend_b"), "b")
+
+        service = QiskitRuntimeService(token="my_token")
+        workloads_response = service._active_api_client._api.workloads_get()
+
+        # Jobs from all instances should be included.
+        self.assertEqual(len(workloads_response["workloads"]), 2)
+        # All workloads should be jobs currently.
+        self.assertTrue(
+            all(workload["mode"] == "job" for workload in workloads_response["workloads"])
+        )


### PR DESCRIPTION
### Summary

Groundwork for making it easier to iterate on usage-related features, as such work is expected in the upcoming weeks. It is centered in preparing the `registries` for easier customizing of the responses related to those endpoints - moving some tests to using the `@mock_responses` decorator (as this way we do get guarantees we are exercising the real `QiskitRuntimeService`, and having the callbacks take into account new information.

The second part is adding "experimental" (as in, still not used by `QiskitRuntimeService`) supports to the `/workloads` endpoint. While it might not end up being used by the upcoming changes, it is a versatile endpoint that could simplify and unify several parts of the service in the future, and having this minimal support available allows for exploring it already.

### Details and comments

Fixes #3296

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
