### PR TITLE
Avoid using FakeRuntimeService in tests directly

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -428,7 +428,7 @@ class QiskitRuntimeService:
             account = AccountManager.get(filename=filename, name=name)
         elif channel:
             if channel and channel not in ["ibm_cloud", "ibm_quantum_platform"]:
-                raise ValueError("'channel' can only be 'ibm_cloud', or 'ibm_quantum_platform")
+                raise ValueError("'channel' can only be 'ibm_cloud', or 'ibm_quantum_platform'")
             if token:
                 account = Account.create_account(
                     channel=channel,

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -48,8 +48,9 @@ def mock_responses(
 
     When decorating a test, this decorator:
     * intercepts HTTP requests and returns mocked HTTP responses, based on a ``Registry``, which
-      is added as an argument to the test.
+      is added as an ``registry`` argument to the test.
     * patches low-level method related to IAM authentication, to simplify the authentication flow.
+    * optionally exposes the responses mock as ``responses`` argument to the test.
 
     This decorator is meant to be used with the items in the ``registries`` module:
     * ``DefaultRegistry`` and its subclasses.
@@ -71,7 +72,7 @@ def mock_responses(
     Args:
         func_or_registry: the ``Registry`` to use. If the decorator is used without parenthesis
             (``@mock_responses``), contains the test to decorate.
-        expose_responses_mock: if ``True``, the ``response`` will be added to the list of arguments
+        expose_responses_mock: if ``True``, the ``responses`` will be added to the list of arguments
             of the decorated tests.
 
     Can be used bare (``@mock_authentication``, using the default registry) or
@@ -100,10 +101,15 @@ def mock_responses(
             ):
                 if expose_responses_mock:
                     return test_method(
-                        *args, responses_mock.get_registry(), responses_mock, **kwargs
+                        *args,
+                        # Pass the registry (and optionally the responses mock) as keyword arguments
+                        # to prevent colliding with other decorators (specially ``@combine``).
+                        registry=responses_mock.get_registry(),
+                        responses=responses_mock,
+                        **kwargs,
                     )
                 else:
-                    return test_method(*args, responses_mock.get_registry(), **kwargs)
+                    return test_method(*args, registry=responses_mock.get_registry(), **kwargs)
 
         return wrapper
 

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -48,9 +48,9 @@ def mock_responses(
 
     When decorating a test, this decorator:
     * intercepts HTTP requests and returns mocked HTTP responses, based on a ``Registry``, which
-      is added as an ``registry`` argument to the test.
+      is added as an ``registry`` argument to the wrapped test.
     * patches low-level method related to IAM authentication, to simplify the authentication flow.
-    * optionally exposes the responses mock as ``responses`` argument to the test.
+    * optionally exposes the responses mock as ``responses`` argument to the wrapped test.
 
     This decorator is meant to be used with the items in the ``registries`` module:
     * ``DefaultRegistry`` and its subclasses.
@@ -75,9 +75,8 @@ def mock_responses(
         expose_responses_mock: if ``True``, the ``responses`` will be added to the list of arguments
             of the decorated tests.
 
-    Can be used bare (``@mock_authentication``, using the default registry) or
-    called with a registry class (``@mock_authentication(SomeRegistry)``). The
-    instantiated registry is passed to the wrapped test as an extra argument.
+    Can be used bare (``@mock_authentication``, using the default registry) or called with a
+    registry class (``@mock_authentication(SomeRegistry)``).
     """
     # Bare use: the argument is the decorated test method, not a registry class.
     if not isinstance(func_or_registry, type):

--- a/test/registries.py
+++ b/test/registries.py
@@ -455,7 +455,6 @@ class BaseRegistry(FirstMatchRegistry):
                 for backend in self.backends[instance.name].values()
             ]
         }
-        print(response_body)
         return (200, {"Content-Type": "application/json"}, json.dumps(response_body))
 
     def callback_backends_configuration(self, request: PreparedRequest) -> CallbackResult:
@@ -504,7 +503,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_backends_status(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/backends/{id}/status`` endpoint.
 
-        Dynamically return the configuration of a backend, based on the contents of `self.backends`.
+        Dynamically return the status of a backend, based on the contents of `self.backends`.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/backends
@@ -527,7 +526,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_jobs_post(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/jobs`` endpoint.
 
-        Dynamically return a job, based on the contents of `self.backends`.
+        Dynamically return the result of creating a job.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/jobs
@@ -548,7 +547,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_jobs_get(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/jobs`` endpoint.
 
-        Dynamically return a list of job, based on the contents of `self.jobs`.
+        Dynamically return a list of jobs, based on the contents of `self.jobs`.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/jobs
@@ -613,7 +612,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_jobs_metrics(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/jobs/{}/metrics`` endpoint.
 
-        Dynamically return the metric of a job, based on the contents of `self.jobs`.
+        Dynamically return the metrics of a job, based on the contents of `self.jobs`.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/jobs
@@ -643,7 +642,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_jobs_results(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/jobs/{}/results`` endpoint.
 
-        Dynamically return a job results, based on the contents of `self.jobs`.
+        Dynamically return a job's results, based on the contents of `self.jobs`.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/jobs
@@ -665,7 +664,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_instances_usage(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/instances/usage`` endpoint.
 
-        Dynamically return a job results, based on the contents of `self.jobs`.
+        Dynamically return the usage of an instance, based on the contents of `self.instances`.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/instances
@@ -678,7 +677,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_sessions_post(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/sessions`` endpoint.
 
-        Dynamically return session information.
+        Dynamically return result of creating a session.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/sessions
@@ -696,7 +695,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_sessions_id(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/sessions`` endpoint.
 
-        Dynamically return a session's information, based on the contents of `self.session`.
+        Dynamically return a session's information, based on the contents of `self.sessions`.
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/sessions
@@ -714,7 +713,7 @@ class BaseRegistry(FirstMatchRegistry):
     def callback_sessions_patch(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/sessions`` endpoint.
 
-        Dynamically update a session.
+        Dynamically update a session (no-op).
 
         References:
             https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/sessions

--- a/test/registries.py
+++ b/test/registries.py
@@ -67,6 +67,9 @@ class Instance:
     usage: dict | None = None
     """Instance usage dictionary."""
 
+    tags: list = field(default_factory=list)
+    """Instance tags."""
+
     def __post_init__(self) -> None:
         if not self.crn:
             self.crn = f"crn:v1:bluemix:public:quantum-computing:my-region:{self.name}/...:...::"
@@ -219,14 +222,18 @@ class BaseRegistry(FirstMatchRegistry):
         self.add(
             CallbackResponse(
                 method=POST,
-                url="https://api.global-search-tagging.cloud.ibm.com/v3/resources/search",
+                url=re.compile(
+                    r"https://api.global-search-tagging.(?:([a-zA-Z0-9-]+)\.)?cloud.ibm.com/v3/resources/search"
+                ),
                 callback=self.callback_global_search,
             )
         )
         self.add(
             CallbackResponse(
                 method=GET,
-                url=re.compile(r"https://globalcatalog.cloud.ibm.com/api/v1/\w+"),
+                url=re.compile(
+                    r"https://globalcatalog.(?:([a-zA-Z0-9-]+)\.)?cloud.ibm.com/api/v1/\w+"
+                ),
                 callback=self.callback_catalog,
             )
         )
@@ -356,6 +363,7 @@ class BaseRegistry(FirstMatchRegistry):
                     "name": instance.name,
                     "doc": {"extensions": instance.allocations},
                     "service_plan_unique_id": instance.name,
+                    "tags": instance.tags,
                 }
                 for _, instance in self.instances.items()
             ]

--- a/test/registries.py
+++ b/test/registries.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, TypeAlias
 from urllib.parse import parse_qs, urlparse
 
-from responses import GET, POST, CallbackResponse
+from responses import GET, PATCH, POST, CallbackResponse
 from responses.registries import FirstMatchRegistry
 
 from qiskit_ibm_runtime.fake_provider import FakeLimaV2
@@ -181,6 +181,20 @@ class Job:
             }
 
 
+@dataclass
+class Session:
+    """Registry representation of a session."""
+
+    id: str
+    """Session id."""
+
+    backend_name: str
+    """Backend name."""
+
+    mode: Literal["batch", "dedicated"] = "dedicated"
+    """Session mode."""
+
+
 class BaseRegistry(FirstMatchRegistry):
     """Registry that dynamically serves IBM Quantum Compute responses.
 
@@ -211,12 +225,16 @@ class BaseRegistry(FirstMatchRegistry):
     jobs: dict[str, dict[str, Job]]
     """Jobs in this registry, keyed by instance name and job id."""
 
+    sessions: dict[str, dict[str, Session]]
+    """Sessions in this registry, keyed by instance id and session id."""
+
     def __init__(self) -> None:
         super().__init__()
 
         self.instances = {}
         self.backends = defaultdict(dict)
         self.jobs = defaultdict(dict)
+        self.sessions = defaultdict(dict)
 
         # Add callbacks for IBM Global Search and Global Catalog.
         self.add(
@@ -320,6 +338,29 @@ class BaseRegistry(FirstMatchRegistry):
             ),
         )
 
+        # Add callbacks for the IBM Quantum Compute `/sessions` endpoints.
+        self.add(
+            CallbackResponse(
+                method=POST,
+                url="https://my-region.quantum.cloud.ibm.com/api/v1/sessions",
+                callback=self.callback_sessions_post,
+            ),
+        )
+        self.add(
+            CallbackResponse(
+                method=GET,
+                url=re.compile(r"https://my-region.quantum.cloud.ibm.com/api/v1/sessions/\w+"),
+                callback=self.callback_sessions_id,
+            ),
+        )
+        self.add(
+            CallbackResponse(
+                method=PATCH,
+                url=re.compile(r"https://my-region.quantum.cloud.ibm.com/api/v1/sessions/\w+"),
+                callback=self.callback_sessions_patch,
+            ),
+        )
+
         # Add callbacks for the IBM Quantum Compute `/workloads` endpoints.
         self.add(
             CallbackResponse(
@@ -345,6 +386,10 @@ class BaseRegistry(FirstMatchRegistry):
     def add_job(self, job: Job, instance: str) -> None:
         """Add a new job to the registry."""
         self.jobs[instance][job.id] = job
+
+    def add_session(self, session: Session, instance: str) -> None:
+        """Add a new session to the registry."""
+        self.sessions[instance][session.id] = session
 
     def callback_global_search(self, _: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Cloud Global Search API.
@@ -410,6 +455,7 @@ class BaseRegistry(FirstMatchRegistry):
                 for backend in self.backends[instance.name].values()
             ]
         }
+        print(response_body)
         return (200, {"Content-Type": "application/json"}, json.dumps(response_body))
 
     def callback_backends_configuration(self, request: PreparedRequest) -> CallbackResult:
@@ -628,6 +674,58 @@ class BaseRegistry(FirstMatchRegistry):
         instance = self.get_crn_from_request(request)
 
         return (200, {"Content-Type": "application/json"}, json.dumps(instance.usage))
+
+    def callback_sessions_post(self, request: PreparedRequest) -> CallbackResult:
+        """Callback for the IBM Quantum Compute API ``/sessions`` endpoint.
+
+        Dynamically return session information.
+
+        References:
+            https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/sessions
+        """
+        # Validate the instance CRN and backend name.
+        instance = self.get_crn_from_request(request)
+        request_body = json.loads(request.body)
+        backend_name = request_body["backend"]
+        if instance.name not in self.backends or backend_name not in self.backends[instance.name]:
+            return (404, {"Content-Type": "application/json"}, "{}")
+
+        response_body = {"id": "12345", "backend_name": backend_name, "mode": request_body["mode"]}
+        return (200, {"Content-Type": "application/json"}, json.dumps(response_body))
+
+    def callback_sessions_id(self, request: PreparedRequest) -> CallbackResult:
+        """Callback for the IBM Quantum Compute API ``/sessions`` endpoint.
+
+        Dynamically return a session's information, based on the contents of `self.session`.
+
+        References:
+            https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/sessions
+        """
+        # Validate the instance CRN and session id.
+        instance = self.get_crn_from_request(request)
+        session_id = request.path_url.split("/")[-1].split("?")[0]
+        if instance.name not in self.backends or session_id not in self.sessions[instance.name]:
+            return (404, {"Content-Type": "application/json"}, "{}")
+        session = self.sessions[instance.name][session_id]
+
+        response_body = {"id": "12345", "backend_name": session.backend_name, "mode": session.mode}
+        return (200, {"Content-Type": "application/json"}, json.dumps(response_body))
+
+    def callback_sessions_patch(self, request: PreparedRequest) -> CallbackResult:
+        """Callback for the IBM Quantum Compute API ``/sessions`` endpoint.
+
+        Dynamically update a session.
+
+        References:
+            https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/sessions
+        """
+        # Validate the instance CRN and session id.
+        instance = self.get_crn_from_request(request)
+        session_id = request.path_url.split("/")[-1].split("?")[0]
+        if instance.name not in self.backends or session_id not in self.sessions[instance.name]:
+            return (404, {"Content-Type": "application/json"}, "{}")
+
+        return (204, {"Content-Type": "application/json"}, json.dumps({}))
 
     def callback_workloads_get(self, request: PreparedRequest) -> CallbackResult:
         """Callback for the IBM Quantum Compute API ``/workloads`` endpoint.

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -19,7 +19,6 @@ import os
 import uuid
 from typing import Any
 from unittest import skipIf
-from unittest.mock import patch
 
 from ddt import data, ddt
 
@@ -37,6 +36,7 @@ from qiskit_ibm_runtime.accounts.management import (
     _DEFAULT_ACCOUNT_NAME_IBM_QUANTUM_PLATFORM,
 )
 from qiskit_ibm_runtime.proxies import ProxyConfiguration
+from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 
 from ..account import (
     custom_envs,
@@ -44,8 +44,9 @@ from ..account import (
     no_envs,
     temporary_account_config_file,
 )
+from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
-from .mock.fake_runtime_service import FakeRuntimeService
+from ..utils import combine
 
 _TEST_IBM_CLOUD_ACCOUNT = Account.create_account(
     channel="ibm_cloud",
@@ -407,13 +408,14 @@ class TestAccountManager(IBMTestCase):
         )
         self.assertEqual(account.token, dummy_token)
 
+    @mock_responses
     @temporary_account_config_file()
-    def test_default_env_channel(self):
+    def test_default_env_channel(self, registry):
         """Test that if QISKIT_IBM_CHANNEL is set in the environment, this channel will be used."""
         token = uuid.uuid4().hex
         # unset default_channel in the environment
         with temporary_account_config_file(token=token), no_envs("QISKIT_IBM_CHANNEL"):
-            service = FakeRuntimeService()
+            service = QiskitRuntimeService()
             self.assertEqual(service.channel, "ibm_quantum_platform")
 
         # set channel to default channel in the environment
@@ -424,7 +426,7 @@ class TestAccountManager(IBMTestCase):
                 temporary_account_config_file(channel=channel, token=token),
                 custom_envs(channel_env),
             ):
-                service = FakeRuntimeService()
+                service = QiskitRuntimeService()
                 self.assertEqual(service.channel, channel)
 
     def test_save_private_endpoint(self):
@@ -461,8 +463,9 @@ class TestAccountManager(IBMTestCase):
         self.assertEqual(account.channel, "ibm_quantum_platform")
         self.assertEqual(account.token, _TEST_IBM_CLOUD_ACCOUNT.token)
 
+    @mock_responses
     @temporary_account_config_file()
-    def test_set_channel_precedence(self):
+    def test_set_channel_precedence(self, registry):
         """Test the precedence of the various methods to set the account.
 
         account name > env_variables > channel parameter default account
@@ -500,7 +503,7 @@ class TestAccountManager(IBMTestCase):
             custom_envs(channel_env),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService(name="any-quantum")
+            service = QiskitRuntimeService(name="any-quantum")
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, any_token)
 
@@ -510,7 +513,7 @@ class TestAccountManager(IBMTestCase):
             no_envs("QISKIT_IBM_CHANNEL"),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService()
+            service = QiskitRuntimeService()
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, preferred_token)
 
@@ -521,7 +524,7 @@ class TestAccountManager(IBMTestCase):
             custom_envs(channel_env),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService(channel="ibm_quantum_platform")
+            service = QiskitRuntimeService(channel="ibm_quantum_platform")
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, preferred_token)
 
@@ -532,7 +535,7 @@ class TestAccountManager(IBMTestCase):
             custom_envs(channel_env),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService(channel="ibm_quantum_platform")
+            service = QiskitRuntimeService(channel="ibm_quantum_platform")
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, cloud_token)
 
@@ -542,7 +545,7 @@ class TestAccountManager(IBMTestCase):
             custom_envs(channel_env),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService(channel="ibm_quantum_platform")
+            service = QiskitRuntimeService(channel="ibm_quantum_platform")
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, cloud_token)
 
@@ -554,7 +557,7 @@ class TestAccountManager(IBMTestCase):
             custom_envs(channel_env),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService()
+            service = QiskitRuntimeService()
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, preferred_token)
 
@@ -570,7 +573,7 @@ class TestAccountManager(IBMTestCase):
             custom_envs(channel_env),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService()
+            service = QiskitRuntimeService()
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, cloud_token)
 
@@ -581,12 +584,12 @@ class TestAccountManager(IBMTestCase):
             custom_envs(channel_env),
             no_envs("QISKIT_IBM_TOKEN"),
         ):
-            service = FakeRuntimeService()
+            service = QiskitRuntimeService()
             self.assertEqual(service.channel, "ibm_quantum_platform")
             self.assertEqual(service._account.token, cloud_token)
         # default channel
         with temporary_account_config_file(contents=contents), no_envs("QISKIT_IBM_CHANNEL"):
-            service = FakeRuntimeService()
+            service = QiskitRuntimeService()
             self.assertEqual(service.channel, "ibm_quantum_platform")
 
     def tearDown(self) -> None:
@@ -601,119 +604,113 @@ MOCK_PROXY_CONFIG_DICT = {"urls": {"https": "127.0.0.1", "username_ntlm": "", "p
 
 # NamedTemporaryFiles not supported in Windows
 @skipIf(os.name == "nt", "Test not supported in Windows")
+@ddt
 class TestEnableAccount(IBMTestCase):
     """Tests for QiskitRuntimeService enable account."""
 
-    def test_enable_account_by_name(self):
+    @mock_responses
+    def test_enable_account_by_name(self, registry):
         """Test initializing account by name."""
         name = "foo"
         token = uuid.uuid4().hex
         with temporary_account_config_file(name=name, token=token):
-            service = FakeRuntimeService(name=name)
+            service = QiskitRuntimeService(name=name)
 
         self.assertTrue(service._account)
         self.assertEqual(service._account.token, token)
 
-    def test_enable_account_by_channel(self):
+    @mock_responses
+    @data("ibm_quantum_platform", "ibm_cloud")
+    def test_enable_account_by_channel(self, channel, registry):
         """Test initializing account by channel."""
-        for channel in ["ibm_quantum_platform"]:
-            with self.subTest(channel=channel), no_envs(["QISKIT_IBM_TOKEN"]):
-                token = uuid.uuid4().hex
-                with temporary_account_config_file(channel=channel, token=token):
-                    service = FakeRuntimeService(channel=channel)
-                self.assertTrue(service._account)
-                self.assertEqual(service._account.token, token)
+        with no_envs(["QISKIT_IBM_TOKEN"]):
+            token = uuid.uuid4().hex
+            with temporary_account_config_file(channel=channel, token=token):
+                service = QiskitRuntimeService(channel=channel)
+            self.assertTrue(service._account)
+            self.assertEqual(service._account.token, token)
 
-    def test_enable_account_by_token_url(self):
+    @mock_responses
+    @data(
+        {"token": uuid.uuid4().hex}, {"token": uuid.uuid4().hex, "url": "https://foo.cloud.ibm.com"}
+    )
+    def test_enable_account_by_token_url(self, params, registry):
         """Test initializing account by token."""
-        token = uuid.uuid4().hex
-        subtests = [
-            {"token": token},
-            {"token": token, "url": "some_url"},
-        ]
-        for param in subtests:
-            with self.subTest(param=param):
-                with temporary_account_config_file(channel="ibm_quantum_platform", token=token):
-                    service = FakeRuntimeService(**param)
-                    self.assertTrue(service._account)
+        with temporary_account_config_file(channel="ibm_quantum_platform", token=params["token"]):
+            service = QiskitRuntimeService(**params)
+            self.assertTrue(service._account)
 
     def test_enable_account_by_url_error(self):
         """Test initializing account by url gives an error."""
         token = uuid.uuid4().hex
         with temporary_account_config_file(channel="ibm_quantum_platform", token=token):
-            with self.assertRaises(ValueError):
-                _ = FakeRuntimeService(url="some_url")
+            with self.assertRaisesRegex(ValueError, "not valid as a standalone parameter"):
+                QiskitRuntimeService(url="some_url")
 
-    def test_enable_account_by_name_and_other(self):
+    @mock_responses
+    @data(
+        {"channel": "ibm_cloud"},
+        {"token": "some_token"},
+        {"url": "some_url"},
+        {"channel": "ibm_cloud", "token": "some_token", "url": "some_url"},
+    )
+    def test_enable_account_by_name_and_other(self, params, registry):
         """Test initializing account by name and other."""
-        subtests = [
-            {"channel": "ibm_cloud"},
-            {"token": "some_token"},
-            {"url": "some_url"},
-            {"channel": "ibm_cloud", "token": "some_token", "url": "some_url"},
-        ]
-
         name = "foo"
         token = uuid.uuid4().hex
-        for param in subtests:
-            with self.subTest(param=param), temporary_account_config_file(name=name, token=token):
-                with self.assertLogs("qiskit_ibm_runtime", logging.WARNING) as logged:
-                    service = FakeRuntimeService(name=name, **param)
+        with temporary_account_config_file(name=name, token=token):
+            with self.assertLogs("qiskit_ibm_runtime", logging.WARNING) as logged:
+                service = QiskitRuntimeService(name=name, **params)
 
-                self.assertTrue(service._account)
-                self.assertEqual(service._account.token, token)
-                self.assertIn("are ignored", logged.output[0])
+            self.assertTrue(service._account)
+            self.assertEqual(service._account.token, token)
+            self.assertIn("are ignored", logged.output[0])
 
-    def test_enable_cloud_account_by_channel_token_url(self):
+    @mock_responses
+    @data(None, "https://foo.cloud.ibm.com")
+    def test_enable_cloud_account_by_channel_token_url(self, url, registry):
         """Test initializing cloud account by channel, token, url."""
-        # Enable account will fail due to missing CRN.
-        urls = [None, "some_url"]
-        for url in urls:
-            with self.subTest(url=url), no_envs(["QISKIT_IBM_TOKEN"]):
-                token = uuid.uuid4().hex
-                with patch.object(FakeRuntimeService, "_resolve_cloud_instances", return_value=[]):
-                    service = FakeRuntimeService(
-                        channel="ibm_quantum_platform", token=token, url=url
-                    )
-                self.assertTrue(service)
+        with no_envs(["QISKIT_IBM_TOKEN"]):
+            token = uuid.uuid4().hex
+            service = QiskitRuntimeService(channel="ibm_quantum_platform", token=token, url=url)
+            self.assertTrue(service)
 
-    def test_enable_account_by_channel_url(self):
+    @mock_responses
+    @data("ibm_quantum_platform", "ibm_cloud")
+    def test_enable_account_by_channel_url(self, channel, registry):
         """Test initializing account by channel, token, url."""
-        subtests = ["ibm_quantum_platform"]
-        for channel in subtests:
-            with self.subTest(channel=channel):
-                token = uuid.uuid4().hex
-                with (
-                    temporary_account_config_file(channel=channel, token=token),
-                    no_envs(["QISKIT_IBM_TOKEN"]),
-                ):
-                    with self.assertLogs("qiskit_ibm_runtime", logging.WARNING) as logged:
-                        service = FakeRuntimeService(channel=channel, url="some_url")
+        token = uuid.uuid4().hex
+        with (
+            temporary_account_config_file(channel=channel, token=token),
+            no_envs(["QISKIT_IBM_TOKEN"]),
+        ):
+            with self.assertLogs("qiskit_ibm_runtime", logging.WARNING) as logged:
+                service = QiskitRuntimeService(channel=channel, url="some_url")
 
-                self.assertTrue(service._account)
-                self.assertEqual(service._account.token, token)
-                expected = IBM_QUANTUM_PLATFORM_API_URL
-                self.assertEqual(service._account.url, expected)
-                self.assertIn("url", logged.output[0])
+        self.assertTrue(service._account)
+        self.assertEqual(service._account.token, token)
+        expected = IBM_QUANTUM_PLATFORM_API_URL
+        self.assertEqual(service._account.url, expected)
+        self.assertIn("url", logged.output[0])
 
-    def test_enable_account_by_only_channel(self):
+    @mock_responses
+    @data("ibm_quantum_platform", "ibm_cloud")
+    def test_enable_account_by_only_channel(self, channel, registry):
         """Test initializing account with single saved account."""
-        subtests = ["ibm_quantum_platform"]
-        for channel in subtests:
-            with self.subTest(channel=channel):
-                token = uuid.uuid4().hex
-                with (
-                    temporary_account_config_file(channel=channel, token=token),
-                    no_envs(["QISKIT_IBM_TOKEN"]),
-                ):
-                    service = FakeRuntimeService()
-                self.assertTrue(service._account)
-                self.assertEqual(service._account.token, token)
-                expected = IBM_QUANTUM_PLATFORM_API_URL
-                self.assertEqual(service._account.url, expected)
-                self.assertEqual(service._account.channel, channel)
+        token = uuid.uuid4().hex
+        with (
+            temporary_account_config_file(channel=channel, token=token),
+            no_envs(["QISKIT_IBM_TOKEN"]),
+        ):
+            service = QiskitRuntimeService()
+        self.assertTrue(service._account)
+        self.assertEqual(service._account.token, token)
+        expected = IBM_QUANTUM_PLATFORM_API_URL
+        self.assertEqual(service._account.url, expected)
+        self.assertEqual(service._account.channel, channel)
 
-    def test_enable_account_both_channel(self):
+    @mock_responses
+    def test_enable_account_both_channel(self, registry):
         """Test initializing account with both saved types."""
         token = uuid.uuid4().hex
         contents = get_account_config_contents(channel="ibm_quantum_platform", token=token)
@@ -722,214 +719,224 @@ class TestEnableAccount(IBMTestCase):
             temporary_account_config_file(contents=contents),
             no_envs(["QISKIT_IBM_TOKEN", "QISKIT_IBM_CHANNEL"]),
         ):
-            service = FakeRuntimeService()
+            service = QiskitRuntimeService()
         self.assertTrue(service._account)
         self.assertEqual(service._account.token, token)
         self.assertEqual(service._account.url, IBM_QUANTUM_PLATFORM_API_URL)
         self.assertEqual(service._account.channel, "ibm_quantum_platform")
 
-    def test_enable_account_by_env_channel(self):
+    @mock_responses
+    @data("ibm_quantum_platform", "ibm_cloud", None)
+    def test_enable_account_by_env_channel(self, channel, registry):
         """Test initializing account by environment variable and channel."""
-        subtests = ["ibm_quantum_platform", "ibm_cloud", None]
-        for channel in subtests:
-            with self.subTest(channel=channel):
-                token = uuid.uuid4().hex
-                url = uuid.uuid4().hex
-                envs = {
-                    "QISKIT_IBM_TOKEN": token,
-                    "QISKIT_IBM_URL": url,
-                    "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
-                }
-                with custom_envs(envs), no_envs("QISKIT_IBM_CHANNEL"):
-                    service = FakeRuntimeService(channel=channel)
-
-                self.assertTrue(service._account)
-                self.assertEqual(service._account.token, token)
-                self.assertEqual(service._account.url, url)
-                channel = channel or "ibm_quantum_platform"
-                self.assertEqual(service._account.channel, channel)
-
-    def test_enable_account_only_env_variables(self):
-        """Test initializing account with only environment variables."""
-        subtests = ["ibm_quantum_platform"]
         token = uuid.uuid4().hex
-        url = uuid.uuid4().hex
-        for channel in subtests:
-            envs = {
-                "QISKIT_IBM_TOKEN": token,
-                "QISKIT_IBM_URL": url,
-                "QISKIT_IBM_CHANNEL": channel,
-                "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
-            }
-            with custom_envs(envs):
-                service = FakeRuntimeService()
-            self.assertEqual(service._account.channel, channel)
-            self.assertEqual(service._account.url, url)
-
-    def test_enable_account_by_env_token_url(self):
-        """Test initializing account by environment variable and extra."""
-        token = uuid.uuid4().hex
-        url = uuid.uuid4().hex
+        url = "https://foo.cloud.ibm.com"
         envs = {
             "QISKIT_IBM_TOKEN": token,
             "QISKIT_IBM_URL": url,
             "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
         }
-        subtests = [{"token": token}, {"token": token, "url": url}]
-        for extra in subtests:
-            with self.subTest(extra=extra):
-                with custom_envs(envs) as _:
-                    service = FakeRuntimeService(**extra)
-                    self.assertTrue(service._account)
+        with custom_envs(envs), no_envs("QISKIT_IBM_CHANNEL"):
+            service = QiskitRuntimeService(channel=channel)
+
+        self.assertTrue(service._account)
+        self.assertEqual(service._account.token, token)
+        self.assertEqual(service._account.url, url)
+        channel = channel or "ibm_quantum_platform"
+        self.assertEqual(service._account.channel, channel)
+
+    @mock_responses
+    @data("ibm_quantum_platform", "ibm_cloud", None)
+    def test_enable_account_only_env_variables(self, channel, registry):
+        """Test initializing account with only environment variables."""
+        token = uuid.uuid4().hex
+        url = "https://foo.cloud.ibm.com"
+        envs = {
+            "QISKIT_IBM_TOKEN": token,
+            "QISKIT_IBM_URL": url,
+            "QISKIT_IBM_CHANNEL": channel,
+            "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
+        }
+        with custom_envs(envs):
+            service = QiskitRuntimeService()
+        self.assertEqual(service._account.channel, channel or "ibm_quantum_platform")
+        self.assertEqual(service._account.url, url)
+
+    @mock_responses
+    @data(
+        {"token": uuid.uuid4().hex}, {"token": uuid.uuid4().hex, "url": "https://foo.cloud.ibm.com"}
+    )
+    def test_enable_account_by_env_token_url(self, params, registry):
+        """Test initializing account by environment variable and extra."""
+        token = params["token"]
+        url = "https://foo.cloud.ibm.com"
+        envs = {
+            "QISKIT_IBM_TOKEN": token,
+            "QISKIT_IBM_URL": url,
+            "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
+        }
+        with custom_envs(envs) as _:
+            service = QiskitRuntimeService(**params)
+            self.assertTrue(service._account)
 
     def test_enable_account_bad_name(self):
         """Test initializing account by bad name."""
         name = "phantom"
-        with temporary_account_config_file() as _, self.assertRaises(AccountNotFoundError) as err:
-            _ = FakeRuntimeService(name=name)
-        self.assertIn(name, str(err.exception))
+        with temporary_account_config_file():
+            with self.assertRaisesRegex(AccountNotFoundError, f"Account with the name {name}"):
+                _ = QiskitRuntimeService(name=name)
 
     def test_enable_account_bad_channel(self):
         """Test initializing account by bad name."""
         channel = "phantom"
-        with temporary_account_config_file() as _, self.assertRaises(ValueError) as err:
-            _ = FakeRuntimeService(channel=channel)
-        self.assertIn("channel", str(err.exception))
+        with temporary_account_config_file():
+            with self.assertRaisesRegex(ValueError, "'channel' can only be"):
+                QiskitRuntimeService(channel=channel)
 
-    def test_enable_account_by_name_pref(self):
+    @mock_responses
+    @data(
+        {"proxies": MOCK_PROXY_CONFIG_DICT},
+        {"verify": False},
+        {"instance": _DEFAULT_CRN},
+        {"proxies": MOCK_PROXY_CONFIG_DICT, "verify": False, "instance": _DEFAULT_CRN},
+    )
+    def test_enable_account_by_name_pref(self, params, registry):
         """Test initializing account by name and preferences."""
         name = "foo"
-        subtests = [
+        with temporary_account_config_file(name=name, verify=True, proxies={}):
+            service = QiskitRuntimeService(name=name, **params)
+        self.assertTrue(service._account)
+        self._verify_prefs(params, service._account)
+
+    @mock_responses
+    @combine(
+        channel=["ibm_quantum_platform", "ibm_cloud"],
+        params=[
             {"proxies": MOCK_PROXY_CONFIG_DICT},
             {"verify": False},
             {"instance": _DEFAULT_CRN},
             {"proxies": MOCK_PROXY_CONFIG_DICT, "verify": False, "instance": _DEFAULT_CRN},
-        ]
-        for extra in subtests:
-            with self.subTest(extra=extra):
-                with temporary_account_config_file(name=name, verify=True, proxies={}):
-                    service = FakeRuntimeService(name=name, **extra)
-                self.assertTrue(service._account)
-                self._verify_prefs(extra, service._account)
-
-    def test_enable_account_by_channel_pref(self):
+        ],
+    )
+    def test_enable_account_by_channel_pref(self, channel, params, registry):
         """Test initializing account by channel and preferences."""
-        subtests = [
-            {"proxies": MOCK_PROXY_CONFIG_DICT},
-            {"verify": False},
-            {"instance": _DEFAULT_CRN},
-            {"proxies": MOCK_PROXY_CONFIG_DICT, "verify": False, "instance": _DEFAULT_CRN},
-        ]
-        for channel in ["ibm_quantum_platform"]:
-            for extra in subtests:
-                with (
-                    self.subTest(channel=channel, extra=extra),
-                    temporary_account_config_file(channel=channel, verify=True, proxies={}),
-                    no_envs(["QISKIT_IBM_TOKEN"]),
-                ):
-                    service = FakeRuntimeService(channel=channel, **extra)
-                    self.assertTrue(service._account)
-                    self._verify_prefs(extra, service._account)
+        with (
+            temporary_account_config_file(channel=channel, verify=True, proxies={}),
+            no_envs(["QISKIT_IBM_TOKEN"]),
+        ):
+            service = QiskitRuntimeService(channel=channel, **params)
+            self.assertTrue(service._account)
+            self._verify_prefs(params, service._account)
 
-    def test_enable_account_by_env_pref(self):
+    @mock_responses
+    @data(
+        {"proxies": MOCK_PROXY_CONFIG_DICT},
+        {"verify": False},
+        {"instance": _DEFAULT_CRN},
+        {"proxies": MOCK_PROXY_CONFIG_DICT, "verify": False, "instance": _DEFAULT_CRN},
+    )
+    def test_enable_account_by_env_pref(self, params, registry):
         """Test initializing account by environment variable and preferences."""
-        subtests = [
-            {"proxies": MOCK_PROXY_CONFIG_DICT},
-            {"verify": False},
-            {"instance": _DEFAULT_CRN},
-            {"proxies": MOCK_PROXY_CONFIG_DICT, "verify": False, "instance": _DEFAULT_CRN},
-        ]
-        for extra in subtests:
-            with self.subTest(extra=extra):
-                token = uuid.uuid4().hex
-                url = uuid.uuid4().hex
-                envs = {
-                    "QISKIT_IBM_TOKEN": token,
-                    "QISKIT_IBM_URL": url,
-                    "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
-                }
-                with custom_envs(envs), no_envs("QISKIT_IBM_CHANNEL"):
-                    service = FakeRuntimeService(**extra)
+        token = uuid.uuid4().hex
+        url = "https://foo.cloud.ibm.com"
+        envs = {
+            "QISKIT_IBM_TOKEN": token,
+            "QISKIT_IBM_URL": url,
+            "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
+        }
+        with custom_envs(envs), no_envs("QISKIT_IBM_CHANNEL"):
+            service = QiskitRuntimeService(**params)
 
-                self.assertTrue(service._account)
-                self._verify_prefs(extra, service._account)
+        self.assertTrue(service._account)
+        self._verify_prefs(params, service._account)
 
-    def test_enable_account_by_name_input_instance(self):
+    @mock_responses
+    def test_enable_account_by_name_input_instance(self, registry):
         """Test initializing account by name and input instance."""
         name = "foo"
         instance = _DEFAULT_CRN
         with temporary_account_config_file(name=name, instance="stored-instance"):
-            service = FakeRuntimeService(name=name, instance=instance)
+            service = QiskitRuntimeService(name=name, instance=instance)
         self.assertTrue(service._account)
         self.assertEqual(service._account.instance, instance)
 
-    def test_enable_account_by_channel_input_instance(self):
+    @mock_responses
+    def test_enable_account_by_channel_input_instance(self, registry):
         """Test initializing account by channel and input instance."""
         instance = _DEFAULT_CRN
         with temporary_account_config_file(channel="ibm_quantum_platform", instance="bla"):
-            service = FakeRuntimeService(channel="ibm_quantum_platform", instance=instance)
+            service = QiskitRuntimeService(channel="ibm_quantum_platform", instance=instance)
         self.assertTrue(service._account)
         self.assertEqual(service._account.instance, instance)
 
-    def test_enable_account_by_env_input_instance(self):
+    @mock_responses
+    def test_enable_account_by_env_input_instance(self, registry):
         """Test initializing account by env and input instance."""
         instance = _DEFAULT_CRN
         envs = {
             "QISKIT_IBM_TOKEN": "some_token",
-            "QISKIT_IBM_URL": "some_url",
+            "QISKIT_IBM_URL": "https://foo.cloud.ibm.com",
             "QISKIT_IBM_INSTANCE": _DEFAULT_CRN,
         }
         with custom_envs(envs):
-            service = FakeRuntimeService(channel="ibm_cloud", instance=instance)
+            service = QiskitRuntimeService(channel="ibm_cloud", instance=instance)
         self.assertTrue(service._account)
         self.assertEqual(service._account.instance, instance)
 
-    def test_instance_filter_tags(self):
+    @mock_responses
+    def test_instance_filter_tags(self, registry):
         """Test initializing account by channel and input instance."""
+        registry.instances["a"].tags = ["services"]
+
         tags = ["services"]
         with temporary_account_config_file(channel="ibm_quantum_platform"):
-            service = FakeRuntimeService(channel="ibm_quantum_platform", tags=tags)
+            service = QiskitRuntimeService(channel="ibm_quantum_platform", tags=tags)
             self.assertTrue(service._account)
             for inst in service._backend_instance_groups:
                 self.assertEqual(inst["tags"], tags)
 
-            with self.assertRaises(IBMInputValueError):
-                service = FakeRuntimeService(channel="ibm_quantum_platform", tags=["invalid_tags"])
+            with self.assertRaisesRegex(IBMInputValueError, "No matching instances"):
+                service = QiskitRuntimeService(
+                    channel="ibm_quantum_platform", tags=["invalid_tags"]
+                )
 
-    def test_wrong_instance(self):
+    @mock_responses
+    def test_wrong_instance(self, registry):
         """Test an instance from a different account."""
         instance = "wrong_instance"
         with temporary_account_config_file(channel="ibm_quantum_platform"):
-            with self.assertRaises(IBMInputValueError):
-                _ = FakeRuntimeService(channel="ibm_quantum_platform", instance=instance)
+            with self.assertRaisesRegex(IBMInputValueError, "not a valid instance name"):
+                QiskitRuntimeService(channel="ibm_quantum_platform", instance=instance)
 
-    def test_instance_auto_flag_set(self):
+    @mock_responses
+    def test_instance_auto_flag_set(self, registry):
         """instance='auto' sets _instance_auto and leaves account.instance as None."""
-        service = FakeRuntimeService(
+        service = QiskitRuntimeService(
             channel="ibm_quantum_platform", token="my_token", instance="auto"
         )
         self.assertTrue(service._instance_auto)
         self.assertIsNone(service._account.instance)
 
-    def test_instance_auto_suppresses_init_warning(self):
+    @mock_responses
+    def test_instance_auto_suppresses_init_warning(self, registry):
         """instance='auto' must not trigger the 'instance was not set' warning during init."""
         # "Loading account with the given token" warning fires regardless; check only for
         # the absence of the specific instance warning. Contrast with no-instance service.
         with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
-            FakeRuntimeService(channel="ibm_quantum_platform", token="my_token")
+            QiskitRuntimeService(channel="ibm_quantum_platform", token="my_token")
         self.assertTrue(any("Instance was not set" in msg for msg in logs.output))
 
         with self.assertLogs("qiskit_ibm_runtime", level="WARNING") as logs:
-            FakeRuntimeService(channel="ibm_quantum_platform", token="my_token", instance="auto")
+            QiskitRuntimeService(channel="ibm_quantum_platform", token="my_token", instance="auto")
         self.assertFalse(any("Instance was not set" in msg for msg in logs.output))
 
-    def test_saved_account_instance_auto_sets_flag(self):
+    @mock_responses
+    def test_saved_account_instance_auto_sets_flag(self, registry):
         """A saved account with instance='auto' sets _instance_auto and clears the instance."""
-        saved_account = Account.create_account(
+        with temporary_account_config_file(
             channel="ibm_quantum_platform", token="my_token", instance="auto"
-        )
-        with patch.object(FakeRuntimeService, "_discover_account", return_value=saved_account):
-            service = FakeRuntimeService(channel="ibm_quantum_platform", token="my_token")
+        ):
+            service = QiskitRuntimeService()
         self.assertTrue(service._instance_auto)
         self.assertIsNone(service._account.instance)
 

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -59,6 +59,7 @@ from qiskit_ibm_runtime.fake_provider import FakeNairobiV2
 from qiskit_ibm_runtime.json import RuntimeDecoder, RuntimeEncoder
 from qiskit_ibm_runtime.noise_learner_v3.params_converters import NOISE_LEARNER_V3_PARAMS_CONVERTERS
 from qiskit_ibm_runtime.options_models import ExecutorOptions, NoiseLearnerV3Options
+from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 from qiskit_ibm_runtime.quantum_program import QuantumProgram
 from qiskit_ibm_runtime.quantum_program.params_converters import QUANTUM_PROGRAM_PARAMS_CONVERTERS
 from qiskit_ibm_runtime.results.estimator_pub import EstimatorPubResult
@@ -68,12 +69,11 @@ from qiskit_ibm_runtime.results.noise_learner import (
     PauliLindbladError,
 )
 
+from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
-from ..program import run_program
+from ..registries import Job
 from ..serialization import SerializableClass, SerializableClassDecoder, get_complex_types
-from ..utils import bell, mock_wait_for_final_state
-from .mock.fake_runtime_client import CustomResultRuntimeJob
-from .mock.fake_runtime_service import FakeRuntimeService
+from ..utils import bell
 
 if HAS_AER:
     from qiskit_aer.noise import NoiseModel
@@ -258,24 +258,22 @@ if __name__ == '__main__':
                 )
                 self.assertIn(operator.__class__.__name__, proc.stdout)
 
-    def test_result_decoder(self):
+    @mock_responses
+    def test_result_decoder(self, registry):
         """Test result decoder."""
-        custom_result = get_complex_types()
-        job_cls = CustomResultRuntimeJob
-        job_cls.custom_result = custom_result
-        ibm_quantum_service = FakeRuntimeService(channel="ibm_quantum_platform", token="some_token")
+        registry.add_job(
+            Job(
+                "my_job",
+                "common_backend",
+                raw_results=json.dumps(get_complex_types(), cls=RuntimeEncoder),
+            ),
+            instance="a",
+        )
+        service = QiskitRuntimeService(token="my_token")
 
-        sub_tests = [(SerializableClassDecoder, None), (None, SerializableClassDecoder)]
-        for result_decoder, decoder in sub_tests:
-            with self.subTest(decoder=decoder):
-                job = run_program(
-                    service=ibm_quantum_service,
-                    job_classes=job_cls,
-                    decoder=result_decoder,
-                )
-                with mock_wait_for_final_state(ibm_quantum_service, job):
-                    result = job.result(decoder=decoder)
-                self.assertIsInstance(result["serializable_class"], SerializableClass)
+        job = service.job("my_job")
+        result = job.result(decoder=SerializableClassDecoder)
+        self.assertIsInstance(result["serializable_class"], SerializableClass)
 
     def test_circuit_metadata(self):
         """Test serializing circuit metadata."""

--- a/test/unit/test_job_retrieval.py
+++ b/test/unit/test_job_retrieval.py
@@ -22,7 +22,6 @@ from ..ibm_test_case import IBMTestCase
 from ..program import run_program
 from ..registries import Backend, Job, OneInstanceNoBackendsRegistry
 from ..utils import mock_wait_for_final_state
-from .mock.fake_runtime_service import FakeRuntimeService
 
 
 class TestRetrieveJobs(IBMTestCase):
@@ -257,22 +256,18 @@ class TestRetrieveJobs(IBMTestCase):
         with self.assertRaises(Exception):
             _ = service.jobs(instance="foo")
 
-    def test_different_instance(self):
+    @mock_responses
+    def test_different_instance(self, registry):
         """Test retrieving job submitted with different instance."""
-        # Initialize with first instance
-        service = FakeRuntimeService(
-            channel="ibm_quantum_platform",
-            token="some_token",
-            instance=FakeRuntimeService.DEFAULT_CRNS[0],
-        )
-        program_id = "sampler"
+        registry.add_job(Job("my_job", "unique_backend_a"), "a")
+        service = QiskitRuntimeService(token="my_token")
 
-        # Run with different instance
-        backend_name = FakeRuntimeService.DEFAULT_UNIQUE_BACKEND_PREFIX + "1"
-        job = run_program(service, program_id=program_id, backend_name=backend_name)
+        # Ensure the active api client is the one for the instance that does _not_ contain the job.
+        self.assertEqual(service._active_api_client._instance, registry.instances["b"].crn)
 
-        rjob = service.job(job.job_id())
-        self.assertIsNotNone(rjob.backend())
+        # Retrieve a job from instance "a" when active instance is "b".
+        job = service.job("my_job")
+        self.assertIsNotNone(job.backend())
 
     def _populate_jobs_with_all_statuses(self, service, program_id):
         """Populate the database with jobs of all statuses."""

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -15,7 +15,7 @@
 from unittest.mock import MagicMock
 
 import numpy as np
-from ddt import data, ddt, named_data, unpack
+from ddt import data, ddt, unpack
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import real_amplitudes
@@ -27,11 +27,12 @@ from qiskit.transpiler import Target
 
 from qiskit_ibm_runtime import IBMInputValueError, SamplerOptions, SamplerV2, Session
 from qiskit_ibm_runtime.fake_provider import FakeCusco, FakeFractionalBackend, FakeSherbrooke
+from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 
+from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
+from ..registries import Backend
 from ..utils import get_mocked_backend, transpile_pubs
-from .mock.fake_api_backend import FakeApiBackendSpecs
-from .mock.fake_runtime_service import FakeRuntimeService
 
 
 class MockSession(Session):
@@ -176,13 +177,11 @@ class TestSamplerV2(IBMTestCase):
             ):
                 inst.run([(circ,)])
 
-    def test_run_dynamic_circuit_with_fractional_opted(self):
+    @mock_responses
+    def test_run_dynamic_circuit_with_fractional_opted(self, registry):
         """Fractional opted backend can run dynamic circuits."""
-        service = FakeRuntimeService(
-            channel="ibm_quantum_platform",
-            token="my_token",
-            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
-        )
+        registry.add_backend(Backend.from_(FakeFractionalBackend), "a")
+        service = QiskitRuntimeService(token="my_token")
         backend = service.backends("fake_fractional", use_fractional_gates=True)[0]
 
         dynamic_circuit = QuantumCircuit(3, 1)
@@ -191,37 +190,30 @@ class TestSamplerV2(IBMTestCase):
             (0, True), QuantumCircuit(3, 1), QuantumCircuit(3, 1), [0, 1, 2], [0]
         )
 
-        inst = SamplerV2(mode=backend)
-        inst.run([dynamic_circuit])
+        sampler = SamplerV2(mode=backend)
+        sampler.run([dynamic_circuit])
 
-    def test_run_fractional_circuit_without_fractional_opted(self):
+    @mock_responses
+    def test_run_fractional_circuit_without_fractional_opted(self, registry):
         """Fractional non-opted backend cannot run fractional circuits."""
-        service = FakeRuntimeService(
-            channel="ibm_quantum_platform",
-            token="my_token",
-            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
-        )
+        registry.add_backend(Backend.from_(FakeFractionalBackend), "a")
+        service = QiskitRuntimeService(token="my_token")
         backend = service.backends("fake_fractional", use_fractional_gates=False)[0]
 
         fractional_circuit = QuantumCircuit(1, 1)
         fractional_circuit.rx(1.23, 0)
         fractional_circuit.measure(0, 0)
 
-        inst = SamplerV2(mode=backend)
+        sampler = SamplerV2(mode=backend)
         with self.assertRaises(IBMInputValueError):
-            inst.run([fractional_circuit])
+            sampler.run([fractional_circuit])
 
-    @named_data(
-        ("without_fractional", False),
-    )
-    def test_run_fractional_dynamic_mix(self, use_fractional):
+    @mock_responses
+    def test_run_fractional_dynamic_mix(self, registry):
         """Any backend cannot run mixture of fractional and dynamic circuits."""
-        service = FakeRuntimeService(
-            channel="ibm_quantum_platform",
-            token="my_token",
-            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
-        )
-        backend = service.backends("fake_fractional", use_fractional_gates=use_fractional)[0]
+        registry.add_backend(Backend.from_(FakeFractionalBackend), "a")
+        service = QiskitRuntimeService(token="my_token")
+        backend = service.backends("fake_fractional", use_fractional_gates=False)[0]
 
         dynamic_circuit = QuantumCircuit(3, 1)
         dynamic_circuit.measure(0, 0)

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -18,14 +18,16 @@ from ddt import data, ddt
 
 from qiskit_ibm_runtime import SamplerV2, Session
 from qiskit_ibm_runtime.exceptions import IBMRuntimeError
-from qiskit_ibm_runtime.fake_provider import FakeManilaV2
+from qiskit_ibm_runtime.fake_provider import FakeFractionalBackend, FakeManilaV2
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
+from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 from qiskit_ibm_runtime.utils.default_session import _DEFAULT_SESSION
 
+from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
+from ..registries import Backend
+from ..registries import Session as RegistrySession
 from ..utils import get_mocked_backend
-from .mock.fake_api_backend import FakeApiBackendSpecs
-from .mock.fake_runtime_service import FakeRuntimeService
 
 
 @ddt
@@ -108,33 +110,38 @@ class TestSession(IBMTestCase):
             session.cancel()
         self.assertFalse(session._active)
 
-    @data([None, "my_id"])
-    def test_session_from_id(self, calibration_id):
+    @data(None, "my_id")
+    @mock_responses
+    def test_session_from_id(self, calibration_id, registry):
         """Create session with given session_id."""
-        service = FakeRuntimeService(channel="ibm_quantum_platform", token="abc")
         session_id = "123"
+        registry.add_session(RegistrySession(session_id, "common_backend"), "a")
+        if calibration_id:
+            registry.backends["a"]["common_backend"].calibrations[calibration_id] = {}
+        service = QiskitRuntimeService(token="my_token")
+
         session = Session.from_id(
             session_id=session_id, service=service, calibration_id=calibration_id
         )
         session._run(program_id="foo", inputs={})
-        session._create_session = MagicMock()
-        self.assertTrue(session._create_session.assert_not_called)
         self.assertEqual(session.session_id, session_id)
 
-    def test_correct_execution_mode(self):
+    @mock_responses
+    def test_correct_execution_mode(self, registry):
         """Test that the execution mode is correctly set."""
-        _ = FakeRuntimeService(channel="ibm_quantum_platform", token="abc")
-        backend = get_mocked_backend("ibm_gotham")
+        service = QiskitRuntimeService(token="my_token")
+        backend = service.backend("common_backend")
         session = Session(backend=backend)
+
+        registry.add_session(RegistrySession(session.session_id, "common_backend"), "a")
         self.assertEqual(session.details()["mode"], "dedicated")
 
-    def test_cm_session_fractional(self):
-        """Test instantiating primitive inside session context manager with the fractional optin."""
-        service = FakeRuntimeService(
-            channel="ibm_quantum_platform",
-            token="abc",
-            backend_specs=[FakeApiBackendSpecs(backend_name="FakeFractionalBackend")],
-        )
+    @mock_responses
+    def test_cm_session_fractional(self, registry):
+        """Test instantiating primitive inside session context manager with fractional option."""
+        registry.add_backend(Backend.from_(FakeFractionalBackend), "a")
+        service = QiskitRuntimeService(token="my_token")
+
         backend = service.backend("fake_fractional", use_fractional_gates=True)
         with Session(backend=backend) as _:
             primitive = SamplerV2()


### PR DESCRIPTION
### Summary

Avoid using `FakeRuntimeService` (direct usage - importing an instantiating) in the unit tests, by converting these tests to a registry-based approach:
* registries gain the ability of using `Session`s (superficially, same "add just what is needed for the tests" philosophy)
* some tweaks to the decorator (for playing nicely with `combine()` and smaller improvements (instance tags, better handling of catalog URLs)
* convert tests to `@mock_requests` and to use `@ddt`. Some tests had some stronger or less evident tweaks, spirit should stay the same in all of them

This gets us closer to avoid `FakeRuntimeService` - the remaining usage is through the `@run_cloud_fake` decorator.

### Details and comments

Related to #3296 (continuing the approach, strictly not needed for new features though)

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
