### PR TITLE
Attempt direct backend creation in service.backend()

### DIFF
--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -968,7 +968,7 @@ class QiskitRuntimeService:
             from qiskit_ibm_runtime import QiskitRuntimeService
 
             service = QiskitRuntimeService()
-            backend = service.backend()
+            backend = service.backend("ibm_kingston")
 
             status = backend.status()
             assert status.operational and status.status_msg == "active"
@@ -996,6 +996,34 @@ class QiskitRuntimeService:
             use_fractional_gates=use_fractional_gates,
             calibration_id=calibration_id,
         )
+
+        # `self.backends()` might not include all the backends by default. If no backend was
+        # returned, make a one-time uncached attempt to retrieve the backend based on its name.
+        if not backends:
+            # Use the specified instance crns, or traverse instances in sensible order.
+            instances = [data[0] for data in self._resolve_cloud_instances(instance)]
+
+            for instance_ in instances:
+                try:
+                    self._get_or_create_cloud_client(instance_)
+                    backends = [
+                        self._create_backend_obj(
+                            name, instance_, use_fractional_gates, calibration_id, cache=False
+                        )
+                    ]
+                    # Show a warning only if the instance is guessed.
+                    if not instance and not self._instance_auto:
+                        for inst_details in self._backend_instance_groups:
+                            if instance_ == inst_details["crn"]:
+                                logger.warning(
+                                    "Loading instance: %s, plan: %s",
+                                    inst_details["name"],
+                                    inst_details["plan"],
+                                )
+                    break
+                except QiskitBackendNotFoundError:
+                    pass
+
         if not backends:
             cloud_msg_url = ""
             if self._channel in ["ibm_cloud", "ibm_quantum_platform"]:

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -331,8 +331,7 @@ class QiskitRuntimeService:
             self._backends_info_per_instance[instance] = self._active_api_client.list_backends()
             return [backend["name"] for backend in self._backends_info_per_instance[instance]]
         # On staging there some invalid instances returned that 403 when retrieving backends
-        except Exception as ex:
-            print(ex)
+        except Exception:
             logger.warning("Invalid instance %s", instance)
             return []
 

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -726,6 +726,7 @@ class QiskitRuntimeService:
         instance: str,
         use_fractional_gates: bool | None,
         calibration_id: str | None = None,
+        cache: bool = True,
     ) -> IBMBackend:
         """Given a backend configuration return the backend object.
 
@@ -738,6 +739,7 @@ class QiskitRuntimeService:
                 operations.  See :meth:`~.QiskitRuntimeService.backends` for
                 further details.
             calibration_id: The calibration id to use for the IBM backend.
+            cache: If ``False``, do not cache the backend in `self._backend_configs`.
 
         Returns:
             A backend object.
@@ -774,7 +776,8 @@ class QiskitRuntimeService:
                         instance=instance,
                         use_fractional_gates=use_fractional_gates,
                     )
-                    self._backend_configs[backend_name] = config
+                    if cache:
+                        self._backend_configs[backend_name] = config
 
             else:
                 config = configuration_from_server_data(
@@ -787,7 +790,8 @@ class QiskitRuntimeService:
                 # I know we have a configuration_registry in the api client
                 # but that doesn't work with new IQP since we different api clients are being used
 
-                self._backend_configs[backend_name] = config
+                if cache:
+                    self._backend_configs[backend_name] = config
         except Exception as ex:
             logger.warning("Unable to create configuration for %s. %s ", backend_name, ex)
             raise QiskitBackendNotFoundError(

--- a/qiskit_ibm_runtime/qiskit_runtime_service.py
+++ b/qiskit_ibm_runtime/qiskit_runtime_service.py
@@ -331,7 +331,8 @@ class QiskitRuntimeService:
             self._backends_info_per_instance[instance] = self._active_api_client.list_backends()
             return [backend["name"] for backend in self._backends_info_per_instance[instance]]
         # On staging there some invalid instances returned that 403 when retrieving backends
-        except Exception:
+        except Exception as ex:
+            print(ex)
             logger.warning("Invalid instance %s", instance)
             return []
 
@@ -1016,7 +1017,7 @@ class QiskitRuntimeService:
                         for inst_details in self._backend_instance_groups:
                             if instance_ == inst_details["crn"]:
                                 logger.warning(
-                                    "Loading instance: %s, plan: %s",
+                                    "Using instance: %s, plan: %s",
                                     inst_details["name"],
                                     inst_details["plan"],
                                 )

--- a/test/unit/test_backend_retrieval.py
+++ b/test/unit/test_backend_retrieval.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import json
+from typing import TYPE_CHECKING
 from unittest import mock
 
 from ddt import ddt, named_data
@@ -25,7 +27,12 @@ from qiskit_ibm_runtime.qiskit_runtime_service import QiskitRuntimeService
 
 from ..decorators import mock_responses
 from ..ibm_test_case import IBMTestCase
-from ..registries import Backend, OneInstanceNoBackendsRegistry
+from ..registries import Backend, DefaultRegistry, OneInstanceNoBackendsRegistry
+
+if TYPE_CHECKING:
+    from requests import PreparedRequest
+
+    from test.registries import CallbackResult
 
 
 class TestBackendFilters(IBMTestCase):
@@ -222,6 +229,14 @@ class TestBackendFilters(IBMTestCase):
             self.assertGreaterEqual(backend.configuration().n_qubits, n_qubits)
 
 
+class EmptyBackendListRegistry(DefaultRegistry):
+    """Registry that returns an empty list for the `/backends` endpoint."""
+
+    def callback_backends(self, request: PreparedRequest) -> CallbackResult:
+        """Callback for the IBM Quantum Compute API ``/backends`` endpoint."""
+        return (200, {"Content-Type": "application/json"}, json.dumps({"devices": []}))
+
+
 @ddt
 class TestGetBackend(IBMTestCase):
     """Test getting a backend."""
@@ -333,3 +348,62 @@ class TestGetBackend(IBMTestCase):
 
         with self.assertRaises(QiskitBackendNotFoundError):
             service.backend("ibm_torino", calibration_id="invalid")
+
+    @mock_responses(EmptyBackendListRegistry)
+    def test_backend_not_in_backends_list(self, registry):
+        """Test retrieving a backend that is not in the list of backends.
+
+        This test exercises the case where a backend is retrieved via `backend()`, and that backend
+        is not returned in the `backends()` method.
+        """
+        instance_a = registry.instances["a"]
+        instance_b = registry.instances["b"]
+
+        service = QiskitRuntimeService(token="my_token")
+        # Ensure that no backend appears in the backends list.
+        self.assertEqual(service.backends(), [])
+
+        # Retrieve an existing backend (available in several instances).
+        backend = service.backend("common_backend")
+        self.assertEqual(backend.name, "common_backend")
+        self.assertEqual(backend._instance, instance_a.crn)
+
+        # Retrieve an existing backend (available in several instances), passing instance.
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            backend = service.backend("common_backend", instance="b")
+        self.assertEqual(backend.name, "common_backend")
+        self.assertEqual(backend._instance, instance_b.crn)
+
+        # Retrieve an existing backend (available in one instance).
+        backend = service.backend("unique_backend_a")
+        self.assertEqual(backend.name, "unique_backend_a")
+        self.assertEqual(backend._instance, instance_a.crn)
+
+        # Retrieve an existing backend (available in one instance), with wrong instance.
+        with (
+            self.assertRaises(QiskitBackendNotFoundError),
+            self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"),
+        ):
+            backend = service.backend("unique_backend_a", instance="b")
+
+    @mock_responses(EmptyBackendListRegistry)
+    def test_backend_not_in_backends_list_instance_auto(self, registry):
+        """Test retrieving a backend not in the list of backends, with service instance `auto`.
+
+        This test exercises the case where a backend is retrieved via `backend()`, and that backend
+        is not returned in the `backends()` method.
+
+        When passing `instance=auto` to `QiskitRuntimeService()`, warnings should not be emitted
+        when guessing instances.
+        """
+        instance_a = registry.instances["a"]
+
+        service = QiskitRuntimeService(token="my_token", instance="auto")
+        # Ensure that no backend appears in the backends list.
+        self.assertEqual(service.backends(), [])
+
+        # Retrieve an existing backend (available in one instance).
+        with self.assertNoLogs("qiskit_ibm_runtime", level="WARNING"):
+            backend = service.backend("unique_backend_a")
+        self.assertEqual(backend.name, "unique_backend_a")
+        self.assertEqual(backend._instance, instance_a.crn)


### PR DESCRIPTION
### Summary

Allow `service.backend()` to attempt to create a backend directly (as in, constructing the `backend` object from its properties and configuration) even if it is not returned in the list of `service.backends()`.

### Details and comments

This prepares for an upcoming API change where the defaults for the backends endpoint might filter out some devices. 

Fixes #3306

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.

